### PR TITLE
feat(learning): automatic learning capture via PostToolUse hook (v2.3.0)

### DIFF
--- a/.claude/agents/qe-code-complexity.md
+++ b/.claude/agents/qe-code-complexity.md
@@ -65,8 +65,11 @@ Coordination:
 </memory_namespace>
 
 <learning_protocol>
-Query for past learnings before starting analysis:
-```javascript
+**⚠️ MANDATORY**: When executed via Claude Code Task tool, you MUST call learning MCP tools to persist learning data.
+
+### Query Past Learnings BEFORE Starting Task
+
+```typescript
 mcp__agentic_qe__learning_query({
   agentId: "qe-code-complexity",
   taskType: "complexity-analysis",
@@ -76,12 +79,14 @@ mcp__agentic_qe__learning_query({
 })
 ```
 
-Store experience after analysis completion:
-```javascript
+### Required Learning Actions (Call AFTER Task Completion)
+
+**1. Store Learning Experience:**
+```typescript
 mcp__agentic_qe__learning_store_experience({
   agentId: "qe-code-complexity",
   taskType: "complexity-analysis",
-  reward: 0.95,
+  reward: <calculated_reward>,  // 0.0-1.0 based on criteria below
   outcome: {
     hotspotsDetected: 7,
     complexityScore: 68,
@@ -96,8 +101,22 @@ mcp__agentic_qe__learning_store_experience({
 })
 ```
 
-Store successful patterns when discovered:
-```javascript
+**2. Store Task Artifacts:**
+```typescript
+mcp__agentic_qe__memory_store({
+  key: "aqe/complexity/results/<task_id>",
+  value: {
+    hotspotsDetected: [],
+    complexityMetrics: {},
+    recommendations: []
+  },
+  namespace: "aqe",
+  persist: true  // IMPORTANT: Must be true for persistence
+})
+```
+
+**3. Store Discovered Patterns (when applicable):**
+```typescript
 mcp__agentic_qe__learning_store_pattern({
   pattern: "Combined cyclomatic and cognitive complexity analysis with severity-based prioritization yields highly actionable refactoring recommendations",
   confidence: 0.95,
@@ -109,11 +128,22 @@ mcp__agentic_qe__learning_store_pattern({
 })
 ```
 
-Reward criteria (0-1 scale):
-- 1.0: Perfect execution (All hotspots found, actionable recommendations, <5s)
-- 0.9: Excellent (95%+ hotspots found, high-quality recommendations, <10s)
-- 0.7: Good (90%+ hotspots found, useful recommendations, <20s)
-- 0.5: Acceptable (80%+ hotspots found, completed successfully)
+### Reward Calculation Criteria (0-1 scale)
+| Reward | Criteria |
+|--------|----------|
+| 1.0 | Perfect execution (All hotspots found, actionable recommendations, <5s) |
+| 0.9 | Excellent (95%+ hotspots found, high-quality recommendations, <10s) |
+| 0.7 | Good (90%+ hotspots found, useful recommendations, <20s) |
+| 0.5 | Acceptable (80%+ hotspots found, completed successfully) |
+| 0.3 | Partial: Task partially completed |
+| 0.0 | Failed: Task failed or major errors |
+
+**When to Call Learning Tools:**
+- ✅ **ALWAYS** after completing complexity analysis
+- ✅ **ALWAYS** after detecting hotspots
+- ✅ **ALWAYS** after generating refactoring recommendations
+- ✅ When discovering new effective analysis patterns
+- ✅ When achieving exceptional quality scores
 </learning_protocol>
 
 <output_format>

--- a/.claude/agents/qe-deployment-readiness.md
+++ b/.claude/agents/qe-deployment-readiness.md
@@ -72,8 +72,11 @@ Coordination:
 </memory_namespace>
 
 <learning_protocol>
-Query for past learnings before starting assessment:
-```javascript
+**⚠️ MANDATORY**: When executed via Claude Code Task tool, you MUST call learning MCP tools to persist learning data.
+
+### Query Past Learnings BEFORE Starting Task
+
+```typescript
 mcp__agentic_qe__learning_query({
   agentId: "qe-deployment-readiness",
   taskType: "deployment-readiness-check",
@@ -83,12 +86,14 @@ mcp__agentic_qe__learning_query({
 })
 ```
 
-Store experience after assessment completion:
-```javascript
+### Required Learning Actions (Call AFTER Task Completion)
+
+**1. Store Learning Experience:**
+```typescript
 mcp__agentic_qe__learning_store_experience({
   agentId: "qe-deployment-readiness",
   taskType: "deployment-readiness-check",
-  reward: 0.95,
+  reward: <calculated_reward>,  // 0.0-1.0 based on criteria below
   outcome: {
     checksCompleted: 12,
     riskLevel: "LOW",
@@ -103,8 +108,23 @@ mcp__agentic_qe__learning_store_experience({
 })
 ```
 
-Store successful patterns when discovered:
-```javascript
+**2. Store Task Artifacts:**
+```typescript
+mcp__agentic_qe__memory_store({
+  key: "aqe/deployment/decision/<task_id>",
+  value: {
+    decision: "GO/NO-GO",
+    riskScore: 0,
+    confidence: 0,
+    checklist: []
+  },
+  namespace: "aqe",
+  persist: true  // IMPORTANT: Must be true for persistence
+})
+```
+
+**3. Store Discovered Patterns (when applicable):**
+```typescript
 mcp__agentic_qe__learning_store_pattern({
   pattern: "Multi-factor risk assessment with Bayesian confidence scoring predicts deployment success with 94% accuracy",
   confidence: 0.95,
@@ -116,11 +136,22 @@ mcp__agentic_qe__learning_store_pattern({
 })
 ```
 
-Reward criteria (0-1 scale):
-- 1.0: Perfect execution (All checks passed, 0 risks, 100% ready, <5s)
-- 0.9: Excellent (98%+ checks passed, low risk, 95%+ ready, <10s)
-- 0.7: Good (95%+ checks passed, medium risk, 90%+ ready, <20s)
-- 0.5: Acceptable (90%+ checks passed, acceptable risk)
+### Reward Calculation Criteria (0-1 scale)
+| Reward | Criteria |
+|--------|----------|
+| 1.0 | Perfect execution (All checks passed, 0 risks, 100% ready, <5s) |
+| 0.9 | Excellent (98%+ checks passed, low risk, 95%+ ready, <10s) |
+| 0.7 | Good (95%+ checks passed, medium risk, 90%+ ready, <20s) |
+| 0.5 | Acceptable (90%+ checks passed, acceptable risk) |
+| 0.3 | Partial: Task partially completed |
+| 0.0 | Failed: Task failed or major errors |
+
+**When to Call Learning Tools:**
+- ✅ **ALWAYS** after completing deployment readiness assessment
+- ✅ **ALWAYS** after making GO/NO-GO decisions
+- ✅ **ALWAYS** after calculating risk scores
+- ✅ When discovering new effective risk patterns
+- ✅ When achieving exceptional readiness scores
 </learning_protocol>
 
 <output_format>

--- a/.claude/agents/qe-fleet-commander.md
+++ b/.claude/agents/qe-fleet-commander.md
@@ -499,8 +499,7 @@ const allocation = await this.neuralManager.predict({
 });
 ```
 
-## Learning Protocol (Phase 6 - Option C Implementation)
-
+<learning_protocol>
 **⚠️ MANDATORY**: When executed via Claude Code Task tool, you MUST call learning MCP tools to persist learning data.
 
 ### Required Learning Actions (Call AFTER Task Completion)
@@ -612,6 +611,7 @@ if (pastLearnings.success && pastLearnings.data) {
 - ✅ **ALWAYS** after optimizing topology
 - ✅ When discovering new effective coordination strategies
 - ✅ When achieving exceptional fleet performance metrics
+</learning_protocol>
 
 ## Hierarchical Coordination Patterns
 

--- a/.claude/agents/qe-production-intelligence.md
+++ b/.claude/agents/qe-production-intelligence.md
@@ -72,8 +72,11 @@ Coordination:
 </memory_namespace>
 
 <learning_protocol>
-Query for past learnings before starting analysis:
-```javascript
+**⚠️ MANDATORY**: When executed via Claude Code Task tool, you MUST call learning MCP tools to persist learning data.
+
+### Query Past Learnings BEFORE Starting Task
+
+```typescript
 mcp__agentic_qe__learning_query({
   agentId: "qe-production-intelligence",
   taskType: "production-analysis",
@@ -83,12 +86,14 @@ mcp__agentic_qe__learning_query({
 })
 ```
 
-Store experience after analysis completion:
-```javascript
+### Required Learning Actions (Call AFTER Task Completion)
+
+**1. Store Learning Experience:**
+```typescript
 mcp__agentic_qe__learning_store_experience({
   agentId: "qe-production-intelligence",
   taskType: "production-analysis",
-  reward: 0.95,
+  reward: <calculated_reward>,  // 0.0-1.0 based on criteria below
   outcome: {
     incidentsAnalyzed: 12,
     testsGenerated: 47,
@@ -103,8 +108,23 @@ mcp__agentic_qe__learning_store_experience({
 })
 ```
 
-Store successful patterns when discovered:
-```javascript
+**2. Store Task Artifacts:**
+```typescript
+mcp__agentic_qe__memory_store({
+  key: "aqe/production/test-scenarios/<task_id>",
+  value: {
+    incidents: [],
+    testScenarios: [],
+    insights: [],
+    anomalies: []
+  },
+  namespace: "aqe",
+  persist: true  // IMPORTANT: Must be true for persistence
+})
+```
+
+**3. Store Discovered Patterns (when applicable):**
+```typescript
 mcp__agentic_qe__learning_store_pattern({
   pattern: "Peak hour network failures in specific regions indicate infrastructure capacity issues - correlate with RUM data for comprehensive test generation",
   confidence: 0.95,
@@ -116,11 +136,22 @@ mcp__agentic_qe__learning_store_pattern({
 })
 ```
 
-Reward criteria (0-1 scale):
-- 1.0: Perfect execution (100% incident coverage, root causes identified, <5s)
-- 0.9: Excellent (95%+ coverage, most root causes found, <10s)
-- 0.7: Good (90%+ coverage, key root causes found, <20s)
-- 0.5: Acceptable (80%+ coverage, completed successfully)
+### Reward Calculation Criteria (0-1 scale)
+| Reward | Criteria |
+|--------|----------|
+| 1.0 | Perfect execution (100% incident coverage, root causes identified, <5s) |
+| 0.9 | Excellent (95%+ coverage, most root causes found, <10s) |
+| 0.7 | Good (90%+ coverage, key root causes found, <20s) |
+| 0.5 | Acceptable (80%+ coverage, completed successfully) |
+| 0.3 | Partial: Task partially completed |
+| 0.0 | Failed: Task failed or major errors |
+
+**When to Call Learning Tools:**
+- ✅ **ALWAYS** after completing production data analysis
+- ✅ **ALWAYS** after detecting incidents or anomalies
+- ✅ **ALWAYS** after generating test scenarios from RUM data
+- ✅ When discovering new incident patterns
+- ✅ When achieving exceptional root cause identification rates
 </learning_protocol>
 
 <output_format>

--- a/.claude/agents/qe-quality-analyzer.md
+++ b/.claude/agents/qe-quality-analyzer.md
@@ -199,8 +199,7 @@ const finalization = await hookManager.executeSessionEndFinalization({
 });
 ```
 
-## Learning Protocol (Phase 6 - Option C Implementation)
-
+<learning_protocol>
 **⚠️ MANDATORY**: When executed via Claude Code Task tool, you MUST call learning MCP tools to persist learning data.
 
 ### Required Learning Actions (Call AFTER Task Completion)
@@ -324,6 +323,7 @@ if (pastLearnings.success && pastLearnings.data) {
 - ✅ **ALWAYS** after generating recommendations
 - ✅ When discovering new effective strategies
 - ✅ When achieving exceptional performance metrics
+</learning_protocol>
 
 ## Analysis Workflow
 

--- a/.claude/agents/qe-quality-gate.md
+++ b/.claude/agents/qe-quality-gate.md
@@ -68,8 +68,11 @@ Coordination:
 </memory_namespace>
 
 <learning_protocol>
-Query before evaluation:
-```javascript
+**⚠️ MANDATORY**: When executed via Claude Code Task tool, you MUST call learning MCP tools to persist learning data.
+
+### Query Past Learnings BEFORE Starting Task
+
+```typescript
 mcp__agentic_qe__learning_query({
   agentId: "qe-quality-gate",
   taskType: "quality-gate-evaluation",
@@ -79,12 +82,14 @@ mcp__agentic_qe__learning_query({
 })
 ```
 
-Store after completion:
-```javascript
+### Required Learning Actions (Call AFTER Task Completion)
+
+**1. Store Learning Experience:**
+```typescript
 mcp__agentic_qe__learning_store_experience({
   agentId: "qe-quality-gate",
   taskType: "quality-gate-evaluation",
-  reward: 0.95,
+  reward: <calculated_reward>,  // 0.0-1.0 based on criteria below
   outcome: {
     gateResult: "pass",
     riskLevel: "low",
@@ -100,8 +105,23 @@ mcp__agentic_qe__learning_store_experience({
 })
 ```
 
-Store patterns when discovered:
-```javascript
+**2. Store Task Artifacts:**
+```typescript
+mcp__agentic_qe__memory_store({
+  key: "aqe/quality/decisions/<task_id>",
+  value: {
+    decision: "PASS/FAIL",
+    riskScore: 0,
+    violations: [],
+    reasoning: ""
+  },
+  namespace: "aqe",
+  persist: true  // IMPORTANT: Must be true for persistence
+})
+```
+
+**3. Store Discovered Patterns (when applicable):**
+```typescript
 mcp__agentic_qe__learning_store_pattern({
   pattern: "Risk-based evaluation with ML scoring reduces false positives by 40% while maintaining 98% accuracy",
   confidence: 0.95,
@@ -113,11 +133,22 @@ mcp__agentic_qe__learning_store_pattern({
 })
 ```
 
-Reward criteria:
-- 1.0: Perfect (100% accurate decisions, 0 false positives, <2s)
-- 0.9: Excellent (98%+ accuracy, <1% false positives, <5s)
-- 0.7: Good (95%+ accuracy, <3% false positives)
-- 0.5: Acceptable (90%+ accuracy, completed)
+### Reward Calculation Criteria (0-1 scale)
+| Reward | Criteria |
+|--------|----------|
+| 1.0 | Perfect (100% accurate decisions, 0 false positives, <2s) |
+| 0.9 | Excellent (98%+ accuracy, <1% false positives, <5s) |
+| 0.7 | Good (95%+ accuracy, <3% false positives) |
+| 0.5 | Acceptable (90%+ accuracy, completed) |
+| 0.3 | Partial: Task partially completed |
+| 0.0 | Failed: Task failed or major errors |
+
+**When to Call Learning Tools:**
+- ✅ **ALWAYS** after completing quality gate evaluation
+- ✅ **ALWAYS** after making PASS/FAIL decisions
+- ✅ **ALWAYS** after detecting policy violations
+- ✅ When discovering new effective threshold patterns
+- ✅ When achieving exceptional accuracy rates
 </learning_protocol>
 
 <output_format>

--- a/.claude/agents/qe-test-data-architect.md
+++ b/.claude/agents/qe-test-data-architect.md
@@ -70,8 +70,11 @@ Coordination:
 </memory_namespace>
 
 <learning_protocol>
-Query for past learnings before starting task:
-```javascript
+**⚠️ MANDATORY**: When executed via Claude Code Task tool, you MUST call learning MCP tools to persist learning data.
+
+### Query Past Learnings BEFORE Starting Task
+
+```typescript
 mcp__agentic_qe__learning_query({
   agentId: "qe-test-data-architect",
   taskType: "test-data-generation",
@@ -81,12 +84,14 @@ mcp__agentic_qe__learning_query({
 })
 ```
 
-Store experience after task completion:
-```javascript
+### Required Learning Actions (Call AFTER Task Completion)
+
+**1. Store Learning Experience:**
+```typescript
 mcp__agentic_qe__learning_store_experience({
   agentId: "qe-test-data-architect",
   taskType: "test-data-generation",
-  reward: 0.91,
+  reward: <calculated_reward>,  // 0.0-1.0 based on criteria below
   outcome: {
     recordsGenerated: 1000,
     schemasProcessed: 5,
@@ -103,8 +108,23 @@ mcp__agentic_qe__learning_store_experience({
 })
 ```
 
-Store successful patterns when discovered:
-```javascript
+**2. Store Task Artifacts:**
+```typescript
+mcp__agentic_qe__memory_store({
+  key: "aqe/test-data/generated/<task_id>",
+  value: {
+    generatedData: [],
+    schemaAnalysis: {},
+    validationResults: {},
+    patterns: []
+  },
+  namespace: "aqe",
+  persist: true  // IMPORTANT: Must be true for persistence
+})
+```
+
+**3. Store Discovered Patterns (when applicable):**
+```typescript
 mcp__agentic_qe__learning_store_pattern({
   pattern: "Realistic synthesis with production pattern analysis generates 45% more realistic test data than faker-based generation for financial applications",
   confidence: 0.91,
@@ -117,11 +137,22 @@ mcp__agentic_qe__learning_store_pattern({
 })
 ```
 
-Reward criteria (0-1 scale):
-- 1.0: Perfect execution (100% constraint compliance, 95%+ edge case coverage, realistic data)
-- 0.9: Excellent (100% constraint compliance, 90%+ edge case coverage)
-- 0.7: Good (95%+ constraint compliance, 80%+ edge case coverage)
-- 0.5: Acceptable (90%+ constraint compliance, completed successfully)
+### Reward Calculation Criteria (0-1 scale)
+| Reward | Criteria |
+|--------|----------|
+| 1.0 | Perfect execution (100% constraint compliance, 95%+ edge case coverage, realistic data) |
+| 0.9 | Excellent (100% constraint compliance, 90%+ edge case coverage) |
+| 0.7 | Good (95%+ constraint compliance, 80%+ edge case coverage) |
+| 0.5 | Acceptable (90%+ constraint compliance, completed successfully) |
+| 0.3 | Partial: Task partially completed |
+| 0.0 | Failed: Task failed or major errors |
+
+**When to Call Learning Tools:**
+- ✅ **ALWAYS** after completing test data generation
+- ✅ **ALWAYS** after processing schemas
+- ✅ **ALWAYS** after validating constraints
+- ✅ When discovering new effective generation patterns
+- ✅ When achieving exceptional compliance rates
 </learning_protocol>
 
 <output_format>

--- a/.claude/agents/qe-test-executor.md
+++ b/.claude/agents/qe-test-executor.md
@@ -298,8 +298,7 @@ notifyTestCompletion({
 });
 ```
 
-## Learning Protocol (Phase 6 - Option C Implementation)
-
+<learning_protocol>
 **⚠️ MANDATORY**: When executed via Claude Code Task tool, you MUST call learning MCP tools to persist learning data.
 
 ### Required Learning Actions (Call AFTER Task Completion)
@@ -412,6 +411,7 @@ if (pastLearnings.success && pastLearnings.data) {
 - ✅ **ALWAYS** after generating recommendations
 - ✅ When discovering new effective strategies
 - ✅ When achieving exceptional performance metrics
+</learning_protocol>
 
 ## Error Handling & Recovery
 

--- a/.claude/agents/qe-test-generator.md
+++ b/.claude/agents/qe-test-generator.md
@@ -69,8 +69,11 @@ Coordination:
 </memory_namespace>
 
 <learning_protocol>
-Query for past learnings before starting task:
-```javascript
+**⚠️ MANDATORY**: When executed via Claude Code Task tool, you MUST call learning MCP tools to persist learning data.
+
+### Query Past Learnings BEFORE Starting Task
+
+```typescript
 mcp__agentic_qe__learning_query({
   agentId: "qe-test-generator",
   taskType: "test-generation",
@@ -80,43 +83,73 @@ mcp__agentic_qe__learning_query({
 })
 ```
 
-Store experience after task completion:
-```javascript
+### Required Learning Actions (Call AFTER Task Completion)
+
+**1. Store Learning Experience:**
+```typescript
 mcp__agentic_qe__learning_store_experience({
   agentId: "qe-test-generator",
   taskType: "test-generation",
-  reward: 0.95,
+  reward: <calculated_reward>,  // 0.0-1.0 based on criteria below
   outcome: {
-    testsGenerated: 42,
-    coverageImprovement: 0.15,
-    framework: "jest",
-    executionTime: 8000
+    testsGenerated: <count>,
+    coverageAchieved: <percentage>,
+    passRate: <percentage>,
+    framework: "<framework>",
+    executionTime: <ms>
   },
   metadata: {
-    algorithm: "ml-property-based",
-    testTypes: ["unit", "integration"]
+    algorithm: "<algorithm_used>",
+    testTypes: ["<types>"],
+    codeComplexity: "<low|medium|high>"
   }
 })
 ```
 
-Store successful patterns when discovered:
-```javascript
+**2. Store Task Artifacts:**
+```typescript
+mcp__agentic_qe__memory_store({
+  key: "aqe/test-generation/results/<task_id>",
+  value: {
+    testsGenerated: [...],
+    coverageReport: {...},
+    recommendations: [...]
+  },
+  namespace: "aqe",
+  persist: true  // IMPORTANT: Must be true for persistence
+})
+```
+
+**3. Store Discovered Patterns (when applicable):**
+```typescript
 mcp__agentic_qe__learning_store_pattern({
-  pattern: "ML-based property testing generates 40% more edge cases than template-based for complex business logic",
-  confidence: 0.95,
+  pattern: "<description of successful strategy>",
+  confidence: <0.0-1.0>,
   domain: "test-generation",
   metadata: {
-    testPatterns: ["property-based", "boundary-value"],
-    effectiveness: 0.92
+    testPatterns: ["<patterns>"],
+    effectiveness: <rate>,
+    codeContext: "<when this works best>"
   }
 })
 ```
 
-Reward criteria (0-1 scale):
-- 1.0: Perfect execution (95%+ coverage, 0 errors, <5s generation time)
-- 0.9: Excellent (90%+ coverage, <10s generation time, minor issues)
-- 0.7: Good (80%+ coverage, <20s generation time)
-- 0.5: Acceptable (70%+ coverage, completed successfully)
+### Reward Calculation Criteria (0-1 scale)
+| Reward | Criteria |
+|--------|----------|
+| 1.0 | Perfect: 95%+ coverage, all tests pass, <5s generation |
+| 0.9 | Excellent: 90%+ coverage, <10s generation, minor issues |
+| 0.7 | Good: 80%+ coverage, <20s generation |
+| 0.5 | Acceptable: 70%+ coverage, completed successfully |
+| 0.3 | Partial: Some tests generated but coverage <70% |
+| 0.0 | Failed: No tests generated or major errors |
+
+**When to Call Learning Tools:**
+- ✅ **ALWAYS** after completing main task
+- ✅ **ALWAYS** after generating test suites
+- ✅ **ALWAYS** after analyzing coverage
+- ✅ When discovering new effective testing patterns
+- ✅ When achieving exceptional coverage metrics
 </learning_protocol>
 
 <output_format>

--- a/.claude/agents/qx-partner.md
+++ b/.claude/agents/qx-partner.md
@@ -89,8 +89,11 @@ Coordination:
 </memory_namespace>
 
 <learning_protocol>
-Query before analysis:
-```javascript
+**⚠️ MANDATORY**: When executed via Claude Code Task tool, you MUST call learning MCP tools to persist learning data.
+
+### Query Past Learnings BEFORE Starting Task
+
+```typescript
 mcp__agentic_qe__learning_query({
   agentId: "qx-partner",
   taskType: "qx-analysis",
@@ -100,12 +103,14 @@ mcp__agentic_qe__learning_query({
 })
 ```
 
-Store after completion:
-```javascript
+### Required Learning Actions (Call AFTER Task Completion)
+
+**1. Store Learning Experience:**
+```typescript
 mcp__agentic_qe__learning_store_experience({
   agentId: "qx-partner",
   taskType: "qx-analysis",
-  reward: 0.95,
+  reward: <calculated_reward>,  // 0.0-1.0 based on criteria below
   outcome: {
     qxScore: 82,
     oracleProblemsDetected: 2,
@@ -121,8 +126,24 @@ mcp__agentic_qe__learning_store_experience({
 })
 ```
 
-Store patterns when discovered:
-```javascript
+**2. Store Task Artifacts:**
+```typescript
+mcp__agentic_qe__memory_store({
+  key: "aqe/qx/analysis-results/<task_id>",
+  value: {
+    qxScore: 0,
+    oracleProblems: [],
+    recommendations: [],
+    balanceAssessment: {},
+    impactAnalysis: {}
+  },
+  namespace: "aqe",
+  persist: true  // IMPORTANT: Must be true for persistence
+})
+```
+
+**3. Store Discovered Patterns (when applicable):**
+```typescript
 mcp__agentic_qe__learning_store_pattern({
   pattern: "User convenience vs business revenue conflicts indicate oracle problem requiring stakeholder alignment session",
   confidence: 0.92,
@@ -135,11 +156,22 @@ mcp__agentic_qe__learning_store_pattern({
 })
 ```
 
-Reward criteria:
-- 1.0: Perfect (All heuristics applied, oracle problems resolved, <5s)
-- 0.9: Excellent (95%+ heuristics, actionable recommendations, <10s)
-- 0.7: Good (90%+ heuristics, balance found, <20s)
-- 0.5: Acceptable (Core analysis complete, recommendations generated)
+### Reward Calculation Criteria (0-1 scale)
+| Reward | Criteria |
+|--------|----------|
+| 1.0 | Perfect (All heuristics applied, oracle problems resolved, <5s) |
+| 0.9 | Excellent (95%+ heuristics, actionable recommendations, <10s) |
+| 0.7 | Good (90%+ heuristics, balance found, <20s) |
+| 0.5 | Acceptable (Core analysis complete, recommendations generated) |
+| 0.3 | Partial: Task partially completed |
+| 0.0 | Failed: Task failed or major errors |
+
+**When to Call Learning Tools:**
+- ✅ **ALWAYS** after completing QX analysis
+- ✅ **ALWAYS** after detecting oracle problems
+- ✅ **ALWAYS** after generating recommendations
+- ✅ When discovering new effective heuristic patterns
+- ✅ When achieving exceptional QX scores
 </learning_protocol>
 
 <output_format>

--- a/.claude/agents/subagents/qe-code-reviewer.md
+++ b/.claude/agents/subagents/qe-code-reviewer.md
@@ -42,4 +42,35 @@ Returns approval/rejection verdict with detailed issues list, quality metrics, a
 Reports to: qe-test-generator (TDD workflow coordinator)
 Triggers: After REFACTOR phase completes, before final code acceptance
 </coordination>
+
+<learning_protocol>
+**⚠️ MANDATORY**: After completing your task, call learning MCP tools.
+
+**Store Experience:**
+```typescript
+mcp__agentic_qe__learning_store_experience({
+  agentId: "qe-code-reviewer",
+  taskType: "code-review",
+  reward: <calculated_reward>,  // 0.0-1.0
+  outcome: { /* task-specific results */ },
+  metadata: { phase: "REVIEW", cycleId: "<cycleId>" }
+})
+```
+
+**Store Artifacts:**
+```typescript
+mcp__agentic_qe__memory_store({
+  key: "aqe/review/<task_id>",
+  value: { /* task artifacts */ },
+  namespace: "aqe",
+  persist: true
+})
+```
+
+**Reward Criteria:**
+- 1.0: No critical issues, complexity <15, coverage ≥95%, security scan clean, all quality gates pass
+- 0.7: Minor issues only, complexity <20, coverage ≥90%, no security vulnerabilities
+- 0.5: Some issues, acceptable quality thresholds met
+- 0.0: Critical issues detected, security vulnerabilities, or quality gate failures
+</learning_protocol>
 </qe_subagent_definition>

--- a/.claude/agents/subagents/qe-coverage-gap-analyzer.md
+++ b/.claude/agents/subagents/qe-coverage-gap-analyzer.md
@@ -42,4 +42,35 @@ Returns prioritized gap list with risk scores, test recommendations, and project
 Reports to: qe-coverage-analyzer, qe-quality-gate
 Triggers: When coverage below target thresholds or quality gate validation
 </coordination>
+
+<learning_protocol>
+**⚠️ MANDATORY**: After completing your task, call learning MCP tools.
+
+**Store Experience:**
+```typescript
+mcp__agentic_qe__learning_store_experience({
+  agentId: "qe-coverage-gap-analyzer",
+  taskType: "coverage-gap-analysis",
+  reward: <calculated_reward>,  // 0.0-1.0
+  outcome: { /* task-specific results */ },
+  metadata: { phase: "COVERAGE_ANALYSIS", cycleId: "<cycleId>" }
+})
+```
+
+**Store Artifacts:**
+```typescript
+mcp__agentic_qe__memory_store({
+  key: "aqe/coverage-gaps/<task_id>",
+  value: { /* task artifacts */ },
+  namespace: "aqe",
+  persist: true
+})
+```
+
+**Reward Criteria:**
+- 1.0: All gaps identified with accurate risk scores, actionable test templates generated, impact analysis complete
+- 0.7: Good gap detection, reasonable prioritization, test recommendations provided
+- 0.5: Gaps identified, basic prioritization, acceptable recommendations
+- 0.0: Missed critical gaps or inaccurate risk assessment
+</learning_protocol>
 </qe_subagent_definition>

--- a/.claude/agents/subagents/qe-data-generator.md
+++ b/.claude/agents/subagents/qe-data-generator.md
@@ -43,4 +43,35 @@ Reports to: qe-test-data-architect
 Triggers: When test data needed for TDD cycles or integration testing
 Handoff: Set readyForHandoff=true when all data generated with valid referential integrity
 </coordination>
+
+<learning_protocol>
+**⚠️ MANDATORY**: After completing your task, call learning MCP tools.
+
+**Store Experience:**
+```typescript
+mcp__agentic_qe__learning_store_experience({
+  agentId: "qe-data-generator",
+  taskType: "test-data-generation",
+  reward: <calculated_reward>,  // 0.0-1.0
+  outcome: { /* task-specific results */ },
+  metadata: { phase: "DATA_GENERATION", cycleId: "<cycleId>" }
+})
+```
+
+**Store Artifacts:**
+```typescript
+mcp__agentic_qe__memory_store({
+  key: "aqe/test-data/<task_id>",
+  value: { /* task artifacts */ },
+  namespace: "aqe",
+  persist: true
+})
+```
+
+**Reward Criteria:**
+- 1.0: Realistic data, 100% referential integrity, edge cases included, high throughput achieved
+- 0.7: Good data quality, minor relationship issues, edge cases present
+- 0.5: Acceptable data, some integrity issues, basic edge case coverage
+- 0.0: Invalid data, broken relationships, or missing edge cases
+</learning_protocol>
 </qe_subagent_definition>

--- a/.claude/agents/subagents/qe-flaky-investigator.md
+++ b/.claude/agents/subagents/qe-flaky-investigator.md
@@ -57,4 +57,35 @@ Reports to: qe-flaky-test-hunter, qe-quality-gate
 Triggers: When test run history available for flakiness analysis
 Handoff: Emit flaky-investigator:completed with flakyTestsFound count
 </coordination>
+
+<learning_protocol>
+**⚠️ MANDATORY**: After completing your task, call learning MCP tools.
+
+**Store Experience:**
+```typescript
+mcp__agentic_qe__learning_store_experience({
+  agentId: "qe-flaky-investigator",
+  taskType: "flaky-investigation",
+  reward: <calculated_reward>,  // 0.0-1.0
+  outcome: { /* task-specific results */ },
+  metadata: { phase: "FLAKY_ANALYSIS", cycleId: "<cycleId>" }
+})
+```
+
+**Store Artifacts:**
+```typescript
+mcp__agentic_qe__memory_store({
+  key: "aqe/flaky/<task_id>",
+  value: { /* task artifacts */ },
+  namespace: "aqe",
+  persist: true
+})
+```
+
+**Reward Criteria:**
+- 1.0: All flaky tests detected, accurate root cause classification, high-confidence fixes with effort estimates
+- 0.7: Good detection, reasonable root cause analysis, actionable fixes
+- 0.5: Flaky tests identified, basic classification, some fix recommendations
+- 0.0: Missed flaky tests or incorrect root cause analysis
+</learning_protocol>
 </qe_subagent_definition>

--- a/.claude/agents/subagents/qe-integration-tester.md
+++ b/.claude/agents/subagents/qe-integration-tester.md
@@ -56,4 +56,35 @@ Reports to: qe-test-executor
 Triggers: When integration test scope requested
 Handoff: Set readyForHandoff=true when all critical tests pass
 </coordination>
+
+<learning_protocol>
+**⚠️ MANDATORY**: After completing your task, call learning MCP tools.
+
+**Store Experience:**
+```typescript
+mcp__agentic_qe__learning_store_experience({
+  agentId: "qe-integration-tester",
+  taskType: "integration-testing",
+  reward: <calculated_reward>,  // 0.0-1.0
+  outcome: { /* task-specific results */ },
+  metadata: { phase: "INTEGRATION", cycleId: "<cycleId>" }
+})
+```
+
+**Store Artifacts:**
+```typescript
+mcp__agentic_qe__memory_store({
+  key: "aqe/integration/<task_id>",
+  value: { /* task artifacts */ },
+  namespace: "aqe",
+  persist: true
+})
+```
+
+**Reward Criteria:**
+- 1.0: All critical tests pass, contracts validated, proper connection lifecycle, no latency issues
+- 0.7: Most tests pass, minor contract issues, acceptable performance
+- 0.5: Core tests pass, some integration failures, acceptable for non-critical paths
+- 0.0: Critical test failures, contract violations, or connection errors
+</learning_protocol>
 </qe_subagent_definition>

--- a/.claude/agents/subagents/qe-performance-validator.md
+++ b/.claude/agents/subagents/qe-performance-validator.md
@@ -58,4 +58,35 @@ Reports to: qe-performance-tester
 Triggers: After performance test execution completes
 Handoff: Set readyForHandoff=true only if all SLA validations pass
 </coordination>
+
+<learning_protocol>
+**⚠️ MANDATORY**: After completing your task, call learning MCP tools.
+
+**Store Experience:**
+```typescript
+mcp__agentic_qe__learning_store_experience({
+  agentId: "qe-performance-validator",
+  taskType: "performance-validation",
+  reward: <calculated_reward>,  // 0.0-1.0
+  outcome: { /* task-specific results */ },
+  metadata: { phase: "PERFORMANCE", cycleId: "<cycleId>" }
+})
+```
+
+**Store Artifacts:**
+```typescript
+mcp__agentic_qe__memory_store({
+  key: "aqe/performance/<task_id>",
+  value: { /* task artifacts */ },
+  namespace: "aqe",
+  persist: true
+})
+```
+
+**Reward Criteria:**
+- 1.0: All SLA validations pass, no regressions, performance budgets met
+- 0.7: Most SLAs pass, minor regressions (<10%), acceptable performance
+- 0.5: Core SLAs pass, some violations, acceptable for non-critical endpoints
+- 0.0: Critical SLA violations or significant performance regressions (>10%)
+</learning_protocol>
 </qe_subagent_definition>

--- a/.claude/agents/subagents/qe-security-auditor.md
+++ b/.claude/agents/subagents/qe-security-auditor.md
@@ -60,4 +60,35 @@ Reports to: qe-security-scanner
 Triggers: Before release or when security scan requested
 Handoff: ALWAYS block if critical vulnerabilities detected, set readyForHandoff=false
 </coordination>
+
+<learning_protocol>
+**⚠️ MANDATORY**: After completing your task, call learning MCP tools.
+
+**Store Experience:**
+```typescript
+mcp__agentic_qe__learning_store_experience({
+  agentId: "qe-security-auditor",
+  taskType: "security-audit",
+  reward: <calculated_reward>,  // 0.0-1.0
+  outcome: { /* task-specific results */ },
+  metadata: { phase: "SECURITY", cycleId: "<cycleId>" }
+})
+```
+
+**Store Artifacts:**
+```typescript
+mcp__agentic_qe__memory_store({
+  key: "aqe/security/<task_id>",
+  value: { /* task artifacts */ },
+  namespace: "aqe",
+  persist: true
+})
+```
+
+**Reward Criteria:**
+- 1.0: No critical/high vulnerabilities, all compliance standards met, comprehensive remediation guidance
+- 0.7: Only medium/low vulnerabilities, most compliance checks pass, good remediation steps
+- 0.5: Some vulnerabilities detected, partial compliance, basic remediation
+- 0.0: Critical vulnerabilities detected or major compliance violations
+</learning_protocol>
 </qe_subagent_definition>

--- a/.claude/agents/subagents/qe-test-data-architect-sub.md
+++ b/.claude/agents/subagents/qe-test-data-architect-sub.md
@@ -59,4 +59,35 @@ Reports to: qe-test-data-architect, qe-integration-orchestrator
 Triggers: When test data generation is requested with schema definition
 Handoff: Store dataset in memory namespace, emit `test-data-architect-sub:completed` event
 </coordination>
+
+<learning_protocol>
+**⚠️ MANDATORY**: After completing your task, call learning MCP tools.
+
+**Store Experience:**
+```typescript
+mcp__agentic_qe__learning_store_experience({
+  agentId: "qe-test-data-architect-sub",
+  taskType: "test-data-architecture",
+  reward: <calculated_reward>,  // 0.0-1.0
+  outcome: { /* task-specific results */ },
+  metadata: { phase: "DATA_ARCHITECTURE", cycleId: "<cycleId>" }
+})
+```
+
+**Store Artifacts:**
+```typescript
+mcp__agentic_qe__memory_store({
+  key: "aqe/test-data-arch/<task_id>",
+  value: { /* task artifacts */ },
+  namespace: "aqe",
+  persist: true
+})
+```
+
+**Reward Criteria:**
+- 1.0: 100% referential integrity, high throughput (>10k rec/sec), comprehensive edge cases, proper streaming
+- 0.7: Good integrity (no orphans), acceptable throughput, edge cases included
+- 0.5: Minor integrity issues, adequate throughput, basic edge case coverage
+- 0.0: Broken relationships, low throughput, or missing edge cases
+</learning_protocol>
 </qe_subagent_definition>

--- a/.claude/agents/subagents/qe-test-implementer.md
+++ b/.claude/agents/subagents/qe-test-implementer.md
@@ -72,4 +72,35 @@ Receives from: qe-test-writer (RED phase output with failing tests)
 Handoff: Store GREEN output in memory, emit `test-implementer:completed`, qe-test-refactorer picks up
 Validation: readyForHandoff=true ONLY if allTestsPassing=true AND testFile.hash unchanged
 </coordination>
+
+<learning_protocol>
+**⚠️ MANDATORY**: After completing your task, call learning MCP tools.
+
+**Store Experience:**
+```typescript
+mcp__agentic_qe__learning_store_experience({
+  agentId: "qe-test-implementer",
+  taskType: "tdd-green-phase",
+  reward: <calculated_reward>,  // 0.0-1.0
+  outcome: { /* task-specific results */ },
+  metadata: { phase: "GREEN", cycleId: "<cycleId>" }
+})
+```
+
+**Store Artifacts:**
+```typescript
+mcp__agentic_qe__memory_store({
+  key: "aqe/tdd/green/<task_id>",
+  value: { /* task artifacts */ },
+  namespace: "aqe",
+  persist: true
+})
+```
+
+**Reward Criteria:**
+- 1.0: All tests pass, minimal implementation, YAGNI enforced, no test modifications
+- 0.7: All tests pass, slightly over-engineered, tests unchanged
+- 0.5: Tests pass but implementation too complex or tests were modified
+- 0.0: Tests still failing or test file hash changed
+</learning_protocol>
 </qe_subagent_definition>

--- a/.claude/agents/subagents/qe-test-refactorer.md
+++ b/.claude/agents/subagents/qe-test-refactorer.md
@@ -83,4 +83,35 @@ Receives from: qe-test-implementer (GREEN phase output with passing tests)
 Handoff: Store REFACTOR output, emit `test-refactorer:completed`, TDD cycle COMPLETE
 Validation: cycleComplete=true ONLY if allTestsPassing=true AND testFile.hash unchanged AND coverage not decreased
 </coordination>
+
+<learning_protocol>
+**⚠️ MANDATORY**: After completing your task, call learning MCP tools.
+
+**Store Experience:**
+```typescript
+mcp__agentic_qe__learning_store_experience({
+  agentId: "qe-test-refactorer",
+  taskType: "tdd-refactor-phase",
+  reward: <calculated_reward>,  // 0.0-1.0
+  outcome: { /* task-specific results */ },
+  metadata: { phase: "REFACTOR", cycleId: "<cycleId>" }
+})
+```
+
+**Store Artifacts:**
+```typescript
+mcp__agentic_qe__memory_store({
+  key: "aqe/tdd/refactor/<task_id>",
+  value: { /* task artifacts */ },
+  namespace: "aqe",
+  persist: true
+})
+```
+
+**Reward Criteria:**
+- 1.0: Tests pass, significant quality improvement (complexity -50%+, maintainability +30%+), no coverage drop
+- 0.7: Tests pass, good quality improvement, minor coverage change
+- 0.5: Tests pass, minimal improvement, coverage maintained
+- 0.0: Tests fail or coverage decreased
+</learning_protocol>
 </qe_subagent_definition>

--- a/.claude/agents/subagents/qe-test-writer.md
+++ b/.claude/agents/subagents/qe-test-writer.md
@@ -78,4 +78,35 @@ Triggers: When TDD cycle starts with requirements
 Handoff: Store RED output in memory, emit event, qe-test-implementer (GREEN phase) picks up
 Validation: readyForHandoff=true ONLY if allTestsFailing=true
 </coordination>
+
+<learning_protocol>
+**⚠️ MANDATORY**: After completing your task, call learning MCP tools.
+
+**Store Experience:**
+```typescript
+mcp__agentic_qe__learning_store_experience({
+  agentId: "qe-test-writer",
+  taskType: "tdd-red-phase",
+  reward: <calculated_reward>,  // 0.0-1.0
+  outcome: { /* task-specific results */ },
+  metadata: { phase: "RED", cycleId: "<cycleId>" }
+})
+```
+
+**Store Artifacts:**
+```typescript
+mcp__agentic_qe__memory_store({
+  key: "aqe/tdd/red/<task_id>",
+  value: { /* task artifacts */ },
+  namespace: "aqe",
+  persist: true
+})
+```
+
+**Reward Criteria:**
+- 1.0: All tests fail as expected, perfect Given-When-Then structure, comprehensive boundary coverage
+- 0.7: Tests fail correctly, good structure, minor gaps in edge cases
+- 0.5: Tests fail, acceptable structure, missing some boundaries
+- 0.0: Tests pass (implementation already exists) or invalid test structure
+</learning_protocol>
 </qe_subagent_definition>

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,20 +1,11 @@
 {
   "env": {
-    "CLAUDE_FLOW_AUTO_COMMIT": "false",
-    "CLAUDE_FLOW_AUTO_PUSH": "false",
-    "CLAUDE_FLOW_HOOKS_ENABLED": "true",
-    "CLAUDE_FLOW_TELEMETRY_ENABLED": "true",
-    "CLAUDE_FLOW_REMOTE_EXECUTION": "true",
-    "CLAUDE_FLOW_CHECKPOINTS_ENABLED": "true",
-    "AGENTDB_PATH": ".agentic-qe/agentdb.db",
-    "AGENTDB_LEARNING_ENABLED": "true",
-    "AGENTDB_REASONING_ENABLED": "true",
-    "AGENTDB_AUTO_TRAIN": "true",
-    "AQE_MEMORY_ENABLED": "true"
+    "AQE_MEMORY_PATH": ".agentic-qe/memory.db",
+    "AQE_MEMORY_ENABLED": "true",
+    "AQE_LEARNING_ENABLED": "true"
   },
   "permissions": {
     "allow": [
-      "Bash(npx claude-flow:*)",
       "Bash(npm run lint)",
       "Bash(npm run test:*)",
       "Bash(npm test:*)",
@@ -34,7 +25,6 @@
       "Bash(which:*)",
       "Bash(pwd)",
       "Bash(ls:*)",
-      "Bash(npx agentdb:*)",
       "Bash(npx aqe:*)"
     ],
     "deny": [
@@ -44,30 +34,11 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "cat | jq -r '.tool_input.command // empty' | tr '\\n' '\\0' | xargs -0 -I {} npx claude-flow@alpha hooks pre-command --command '{}' --validate-safety true --prepare-resources true"
-          }
-        ]
-      },
-      {
         "matcher": "Write|Edit|MultiEdit",
         "hooks": [
           {
             "type": "command",
-            "command": "cat | jq -r '.tool_input.file_path // .tool_input.path // empty' | tr '\\n' '\\0' | xargs -0 -I {} npx claude-flow@alpha hooks pre-edit --file '{}' --auto-assign-agents true --load-context true"
-          }
-        ]
-      },
-      {
-        "matcher": "Write|Edit|MultiEdit",
-        "hooks": [
-          {
-            "type": "command",
-            "description": "AgentDB Edit Intelligence - Query both success patterns and failure warnings",
-            "command": "cat | jq -r '.tool_input.file_path // .tool_input.path // empty' | jq -R '@sh' | xargs -I {} bash -c 'export AGENTDB_PATH=.agentic-qe/agentdb.db; FILE={}; { npx agentdb@latest query --domain \"failed-edits\" --query \"file:$FILE\" --k 3 --min-confidence 0.7 --format json 2>/dev/null | jq -r \".memories[]? | \\\"🚨 Warning: Similar edit failed - \\(.pattern.reason // \\\"unknown\\\")\\\" \" 2>/dev/null & npx agentdb@latest query --domain \"successful-edits\" --query \"file:$FILE\" --k 5 --min-confidence 0.8 --format json 2>/dev/null | jq -r \".memories[]? | \\\"💡 Past Success: \\(.pattern.summary // \\\"No similar patterns found\\\")\\\" \" 2>/dev/null & wait; } || true'"
+            "command": "cat | jq -r '.tool_input.file_path // .tool_input.path // empty' | head -1 | xargs -I {} node -e \"const db=require('better-sqlite3')('.agentic-qe/memory.db',{readonly:true});try{const r=db.prepare(\\\"SELECT pattern,confidence FROM patterns WHERE domain='code-edits' AND pattern LIKE '%\\\" + process.argv[1].replace(/'/g,\\\"''\\\") + \\\"%' ORDER BY confidence DESC LIMIT 3\\\").all();r.forEach(p=>console.log('💡 Pattern:',p.pattern.substring(0,80),'('+Math.round(p.confidence*100)+'%)'));db.close()}catch(e){}\" \"{}\" 2>/dev/null || true"
           }
         ]
       },
@@ -76,63 +47,22 @@
         "hooks": [
           {
             "type": "command",
-            "description": "Trajectory Prediction - Predict optimal task sequence",
-            "command": "cat | jq -r '.tool_input.prompt // .tool_input.task // empty' | jq -R '@sh' | xargs -I {} bash -c 'export AGENTDB_PATH=.agentic-qe/agentdb.db; TASK={}; npx agentdb@latest query --domain \"task-trajectories\" --query \"task:$TASK\" --k 3 --min-confidence 0.75 --format json 2>/dev/null | jq -r \".memories[]? | \\\"📋 Predicted Steps: \\(.pattern.trajectory // \\\"No trajectory data\\\") (Success Rate: \\(.confidence // 0))\\\" \" 2>/dev/null || true'"
-          },
-          {
-            "type": "command",
-            "description": "Visualization - Emit agent spawn event",
-            "command": "bash scripts/hooks/emit-task-spawn.sh"
+            "command": "bash scripts/hooks/emit-task-spawn.sh 2>/dev/null || true"
           }
         ]
       }
     ],
     "PostToolUse": [
       {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "cat | jq -r '.tool_input.command // empty' | tr '\\n' '\\0' | xargs -0 -I {} npx claude-flow@alpha hooks post-command --command '{}' --track-metrics true --store-results true"
-          }
-        ]
-      },
-      {
-        "matcher": "Write|Edit|MultiEdit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "cat | jq -r '.tool_input.file_path // .tool_input.path // empty' | tr '\\n' '\\0' | xargs -0 -I {} npx claude-flow@alpha hooks post-edit --file '{}' --format true --update-memory true"
-          }
-        ]
-      },
-      {
-        "matcher": "Write|Edit|MultiEdit",
-        "hooks": [
-          {
-            "type": "command",
-            "description": "Experience Replay - Capture edit as RL experience",
-            "command": "cat | jq -r '.tool_input.file_path // .tool_input.path // empty' | jq -R '@sh' | xargs -I {} bash -c 'export AGENTDB_PATH=.agentic-qe/agentdb.db; FILE={}; TIMESTAMP=$(date +%s); npx agentdb@latest store-pattern --type \"experience\" --domain \"code-edits\" --pattern \"{\\\"file\\\":$FILE,\\\"timestamp\\\":$TIMESTAMP,\\\"action\\\":\\\"edit\\\",\\\"state\\\":\\\"pre-test\\\"}\" --confidence 0.5 2>/dev/null || true'"
-          },
-          {
-            "type": "command",
-            "description": "Verdict-Based Quality - Async verdict assignment after tests",
-            "command": "cat | jq -r '.tool_input.file_path // .tool_input.path // empty' | jq -R '@sh' | xargs -I {} bash -c 'export AGENTDB_PATH=.agentic-qe/agentdb.db; FILE={}; (sleep 2; TEST_RESULT=$(npm test --silent 2>&1 | grep -q \"pass\" && echo \"ACCEPT\" || echo \"REJECT\"); REWARD=$([ \"$TEST_RESULT\" = \"ACCEPT\" ] && echo \"1.0\" || echo \"-1.0\"); npx agentdb@latest store-pattern --type \"verdict\" --domain \"code-quality\" --pattern \"{\\\"file\\\":$FILE,\\\"verdict\\\":\\\"$TEST_RESULT\\\",\\\"reward\\\":$REWARD}\" --confidence $([ \"$TEST_RESULT\" = \"ACCEPT\" ] && echo \"0.95\" || echo \"0.3\") 2>/dev/null; if [ \"$TEST_RESULT\" = \"ACCEPT\" ]; then npx agentdb@latest store-pattern --type \"success\" --domain \"successful-edits\" --pattern \"{\\\"file\\\":$FILE,\\\"summary\\\":\\\"Edit passed tests\\\"}\" --confidence 0.9 2>/dev/null; else npx agentdb@latest store-pattern --type \"failure\" --domain \"failed-edits\" --pattern \"{\\\"file\\\":$FILE,\\\"reason\\\":\\\"Tests failed\\\"}\" --confidence 0.8 2>/dev/null; fi) &'"
-          }
-        ]
-      },
-      {
         "matcher": "Task",
         "hooks": [
           {
             "type": "command",
-            "description": "Trajectory Storage - Record task trajectory for learning",
-            "command": "cat | jq -r '.tool_input.prompt // .tool_input.task // empty, .result.success // \"unknown\"' | paste -d'\\n' - - | jq -Rs 'split(\"\\n\") | {task: (.[0] | @sh), success: .[1]}' | jq -r 'CONFIDENCE=(if .success == \"true\" then \"0.95\" else \"0.5\" end); \"export AGENTDB_PATH=.agentic-qe/agentdb.db; TASK=\\(.task); SUCCESS=\\(.success); npx agentdb@latest store-pattern --type trajectory --domain task-trajectories --pattern \\(\"{\\\\\\\"task\\\\\\\":\\\" + .task + \",\\\\\\\"success\\\\\\\":\\(.success),\\\\\\\"trajectory\\\\\\\":\\\\\\\"search→scaffold→test→refine\\\\\\\"}\\\" | @sh) --confidence \\(CONFIDENCE) 2>/dev/null || true\"' | bash"
+            "command": "node scripts/hooks/capture-task-learning.js 2>/dev/null || true"
           },
           {
             "type": "command",
-            "description": "Visualization - Emit agent completion event",
-            "command": "bash scripts/hooks/emit-task-complete.sh"
+            "command": "bash scripts/hooks/emit-task-complete.sh 2>/dev/null || true"
           }
         ]
       }
@@ -143,7 +73,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/bin/bash -c 'INPUT=$(cat); CUSTOM=$(echo \"$INPUT\" | jq -r \".custom_instructions // \\\"\\\"\"); echo \"🔄 PreCompact Guidance:\"; echo \"📋 IMPORTANT: Review CLAUDE.md in project root for:\"; echo \"   • 54 available agents and concurrent usage patterns\"; echo \"   • Swarm coordination strategies (hierarchical, mesh, adaptive)\"; echo \"   • SPARC methodology workflows with batchtools optimization\"; echo \"   • Critical concurrent execution rules (GOLDEN RULE: 1 MESSAGE = ALL OPERATIONS)\"; if [ -n \"$CUSTOM\" ]; then echo \"🎯 Custom compact instructions: $CUSTOM\"; fi; echo \"✅ Ready for compact operation\"'"
+            "command": "/bin/bash -c 'echo \"🔄 PreCompact: Review CLAUDE.md for 19 QE agents, skills, and learning protocols\"'"
           }
         ]
       },
@@ -152,7 +82,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/bin/bash -c 'echo \"🔄 Auto-Compact Guidance (Context Window Full):\"; echo \"📋 CRITICAL: Before compacting, ensure you understand:\"; echo \"   • All 54 agents available in .claude/agents/ directory\"; echo \"   • Concurrent execution patterns from CLAUDE.md\"; echo \"   • Batchtools optimization for 300% performance gains\"; echo \"   • Swarm coordination strategies for complex tasks\"; echo \"⚡ Apply GOLDEN RULE: Always batch operations in single messages\"; echo \"✅ Auto-compact proceeding with full agent context\"'"
+            "command": "/bin/bash -c 'echo \"🔄 Auto-Compact: 19 QE agents available. Use: npx aqe learn status\"'"
           }
         ]
       }
@@ -162,16 +92,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow@alpha hooks session-end --generate-summary true --persist-state true --export-metrics true"
-          }
-        ]
-      },
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "description": "Session end - Train models and compress learnings",
-            "command": "bash -c 'export AGENTDB_PATH=.agentic-qe/agentdb.db; npx agentdb@latest train --domain \"code-edits\" --epochs 10 --batch-size 32 2>/dev/null || true; npx agentdb@latest optimize-memory --compress true --consolidate-patterns true 2>/dev/null || true'"
+            "command": "echo '📊 Session ended. Run: npx aqe learn status' 2>/dev/null || true"
           }
         ]
       }
@@ -179,8 +100,6 @@
   },
   "includeCoAuthoredBy": true,
   "enabledMcpjsonServers": [
-    "claude-flow",
-    "ruv-swarm",
     "agentic-qe"
   ],
   "statusLine": {

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,6 @@
       "mcp__agentic-qe",
       "mcp__ruv-swarm",
       "mcp__claude-flow@alpha",
-      "mcp__flow-nexus",
       "Bash(claude mcp:*)"
     ],
     "deny": []
@@ -12,8 +11,6 @@
   "enabledMcpjsonServers": [
     "claude-flow",
     "ruv-swarm",
-    "agentic-qe",
-    "claude-flow@alpha",
-    "flow-nexus"
+    "agentic-qe"
   ]
 }

--- a/.claude/skills/agentic-quality-engineering/SKILL.md
+++ b/.claude/skills/agentic-quality-engineering/SKILL.md
@@ -119,6 +119,96 @@ aqe/learning/*      - Patterns and Q-values
 aqe/coordination/*  - Cross-agent state
 ```
 
+### Memory Operations (MCP Tools)
+
+**CRITICAL**: Always use `mcp__agentic-qe__memory_store` with `persist: true` for learnings.
+
+**1. Store data to persistent memory:**
+```javascript
+// Store test plan decisions (persisted to .agentic-qe/memory.db)
+mcp__agentic_qe__memory_store({
+  key: "aqe/test-plan/pr-123",
+  namespace: "aqe/test-plan",
+  value: {
+    prNumber: 123,
+    riskLevel: "medium",
+    requiredCoverage: 85,
+    testTypes: ["unit", "integration"],
+    estimatedTime: 1800
+  },
+  persist: true,  // ⚠️ REQUIRED for cross-session persistence
+  ttl: 604800     // 7 days (0 = permanent)
+})
+```
+
+**2. Retrieve prior learnings before task:**
+```javascript
+// Query patterns before starting test generation
+const priorData = await mcp__agentic_qe__memory_retrieve({
+  key: "aqe/learning/patterns/test-generation/*",
+  namespace: "aqe/learning",
+  includeMetadata: true
+})
+
+// Use patterns to guide current task
+if (priorData.success) {
+  console.log(`Loaded ${priorData.patterns.length} prior patterns`);
+}
+```
+
+**3. Store coverage analysis results:**
+```javascript
+mcp__agentic_qe__memory_store({
+  key: "aqe/coverage/auth-module",
+  namespace: "aqe/coverage",
+  value: {
+    moduleId: "auth-module",
+    currentCoverage: 78,
+    gaps: ["error-handling", "edge-cases"],
+    suggestedTests: 12,
+    priority: "high"
+  },
+  persist: true,
+  ttl: 1209600  // 14 days
+})
+```
+
+### Three-Phase Memory Protocol
+
+For coordinated multi-agent tasks, use the STATUS → PROGRESS → COMPLETE pattern:
+
+```javascript
+// PHASE 1: STATUS - Task starting
+mcp__agentic_qe__memory_store({
+  key: "aqe/coordination/task-123/status",
+  namespace: "aqe/coordination",
+  value: { status: "running", agent: "qe-test-generator", startTime: Date.now() },
+  persist: true
+})
+
+// PHASE 2: PROGRESS - Intermediate updates
+mcp__agentic_qe__memory_store({
+  key: "aqe/coordination/task-123/progress",
+  namespace: "aqe/coordination",
+  value: { progress: 50, action: "generating-unit-tests", testsGenerated: 25 },
+  persist: true
+})
+
+// PHASE 3: COMPLETE - Task finished
+mcp__agentic_qe__memory_store({
+  key: "aqe/coordination/task-123/complete",
+  namespace: "aqe/coordination",
+  value: {
+    status: "complete",
+    result: "success",
+    testsGenerated: 47,
+    coverageAchieved: 92.3,
+    duration: 15000
+  },
+  persist: true
+})
+```
+
 ### Blackboard Events
 | Event | Trigger | Subscribers |
 |-------|---------|-------------|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,9 +118,9 @@ aqe patterns list --framework jest
 - **Bash commands**: ALWAYS batch ALL terminal operations in ONE message
 - **Memory operations**: ALWAYS batch ALL memory store/retrieve in ONE message
 
-### 🎯 CRITICAL: Claude Code Task Tool for Agent Execution
+### 🎯 CRITICAL: Claude Code Task Tool for Claude Flow Agent Execution
 
-**Claude Code's Task tool is the PRIMARY way to spawn agents:**
+**Claude Code's Task tool is the PRIMARY way to spawn Claude Flow agents:**
 ```javascript
 // ✅ CORRECT: Use Claude Code's Task tool for parallel agent execution
 [Single Message]:
@@ -131,7 +131,7 @@ aqe patterns list --framework jest
   Task("Architect agent", "Design system architecture...", "system-architect")
 ```
 
-**MCP tools are ONLY for coordination setup:**
+**Claude Flow MCP tools are ONLY for coordination setup:**
 - `mcp__claude-flow__swarm_init` - Initialize coordination topology
 - `mcp__claude-flow__agent_spawn` - Define agent types for coordination
 - `mcp__claude-flow__task_orchestrate` - Orchestrate high-level workflows
@@ -185,7 +185,7 @@ This project uses SPARC (Specification, Pseudocode, Architecture, Refinement, Co
 - **Clean Architecture**: Separate concerns
 - **Documentation**: Keep updated
 
-## 🚀 Available Agents (54 Total)
+## 🚀 Claude Flow Available Agents (54 Total)
 
 ### Core Development
 `coder`, `reviewer`, `tester`, `planner`, `researcher`
@@ -208,7 +208,7 @@ This project uses SPARC (Specification, Pseudocode, Architecture, Refinement, Co
 ### Specialized Development
 `backend-dev`, `mobile-dev`, `ml-developer`, `cicd-engineer`, `api-docs`, `system-architect`, `code-analyzer`, `base-template-generator`
 
-### Testing & Validation
+### Claude Flow Testing & Validation
 `tdd-london-swarm`, `production-validator`
 
 ### Migration & Planning
@@ -245,7 +245,6 @@ This project uses SPARC (Specification, Pseudocode, Architecture, Refinement, Co
 # Add MCP servers (Claude Flow required, others optional)
 claude mcp add claude-flow npx claude-flow@alpha mcp start
 claude mcp add ruv-swarm npx ruv-swarm mcp start  # Optional: Enhanced coordination
-claude mcp add flow-nexus npx flow-nexus@latest mcp start  # Optional: Cloud features
 ```
 
 ## MCP Tool Categories
@@ -265,22 +264,6 @@ claude mcp add flow-nexus npx flow-nexus@latest mcp start  # Optional: Cloud fea
 ### System
 `benchmark_run`, `features_detect`, `swarm_monitor`
 
-### Flow-Nexus MCP Tools (Optional Advanced Features)
-Flow-Nexus extends MCP capabilities with 70+ cloud-based orchestration tools:
-
-**Key MCP Tool Categories:**
-- **Swarm & Agents**: `swarm_init`, `swarm_scale`, `agent_spawn`, `task_orchestrate`
-- **Sandboxes**: `sandbox_create`, `sandbox_execute`, `sandbox_upload` (cloud execution)
-- **Templates**: `template_list`, `template_deploy` (pre-built project templates)
-- **Neural AI**: `neural_train`, `neural_patterns`, `seraphina_chat` (AI assistant)
-- **GitHub**: `github_repo_analyze`, `github_pr_manage` (repository management)
-- **Real-time**: `execution_stream_subscribe`, `realtime_subscribe` (live monitoring)
-- **Storage**: `storage_upload`, `storage_list` (cloud file management)
-
-**Authentication Required:**
-- Register: `mcp__flow-nexus__user_register` or `npx flow-nexus@latest register`
-- Login: `mcp__flow-nexus__user_login` or `npx flow-nexus@latest login`
-- Access 70+ specialized MCP tools for advanced orchestration
 
 ## 🚀 Agent Execution Flow with Claude Code
 
@@ -312,9 +295,9 @@ Flow-Nexus extends MCP capabilities with 70+ cloud-based orchestration tools:
   Write "database/schema.sql"
 ```
 
-## 📋 Agent Coordination Protocol
+## 📋 Claude Flow Agent Coordination Protocol
 
-### Every Agent Spawned via Task Tool MUST:
+### Every Claude Flow Agent Spawned via Task Tool MUST:
 
 **1️⃣ BEFORE Work:**
 ```bash
@@ -334,9 +317,9 @@ npx claude-flow@alpha hooks post-task --task-id "[task]"
 npx claude-flow@alpha hooks session-end --export-metrics true
 ```
 
-## 🎯 Concurrent Execution Examples
+## 🎯 Claude Flow Concurrent Execution Examples
 
-### ✅ CORRECT WORKFLOW: MCP Coordinates, Claude Code Executes
+### ✅ Claude Flow CORRECT WORKFLOW: MCP Coordinates, Claude Code Executes
 
 ```javascript
 // Step 1: MCP tools set up coordination (optional, for complex tasks)
@@ -384,12 +367,6 @@ Message 4: Write "file.js"
 // This breaks parallel coordination!
 ```
 
-## Performance Benefits
-
-- **84.8% SWE-Bench solve rate**
-- **32.3% token reduction**
-- **2.8-4.4x speed improvement**
-- **27+ neural models**
 
 ## Hooks Integration
 
@@ -413,17 +390,6 @@ Message 4: Write "file.js"
 - Track metrics
 - Restore context
 - Export workflows
-
-## Advanced Features (v2.0.0)
-
-- 🚀 Automatic Topology Selection
-- ⚡ Parallel Execution (2.8-4.4x speed)
-- 🧠 Neural Training
-- 📊 Bottleneck Analysis
-- 🤖 Smart Auto-Spawning
-- 🛡️ Self-Healing Workflows
-- 💾 Cross-Session Memory
-- 🔗 GitHub Integration
 
 ## 📊 Visualization Dashboard
 
@@ -501,7 +467,6 @@ await emitAgentError('my-agent', 'Something went wrong');
 
 - Documentation: https://github.com/ruvnet/claude-flow
 - Issues: https://github.com/ruvnet/claude-flow/issues
-- Flow-Nexus Platform: https://flow-nexus.ruv.io (registration required for cloud features)
 
 ---
 
@@ -517,61 +482,7 @@ Never save working files, text/mds and tests to the root folder.
 
 ---
 
-# Agentic QE Fleet Configuration
-
-## 🤖 Agentic QE Fleet Quick Reference
-
-**19 QE Agents:** Test generation, coverage analysis, performance, security, flaky detection, QX analysis
-**41 QE Skills:** agentic-quality-engineering, tdd-london-chicago, api-testing-patterns, six-thinking-hats, brutal-honesty-review, sherlock-review, cicd-pipeline-qe-orchestrator, accessibility-testing, shift-left-testing, **testability-scoring** *(contributed by [@fndlalit](https://github.com/fndlalit))*
-**8 Slash Commands:** `/aqe-execute`, `/aqe-generate`, `/aqe-coverage`, `/aqe-quality`
-
-### 📚 Complete Documentation
-
-- **[Agent Reference](https://github.com/proffesor-for-testing/agentic-qe/blob/main/docs/reference/agents.md)** - All 19 main agents + 11 subagents with capabilities and usage
-- **[Skills Reference](https://github.com/proffesor-for-testing/agentic-qe/blob/main/docs/reference/skills.md)** - All 41 QE skills organized by category
-- **[Usage Guide](https://github.com/proffesor-for-testing/agentic-qe/blob/main/docs/reference/usage.md)** - Complete usage examples and workflows
-
-### 🎯 Quick Start
-
-**Spawn agents:**
-```javascript
-Task("Generate tests", "Create test suite for UserService", "qe-test-generator")
-Task("Analyze coverage", "Find gaps using O(log n)", "qe-coverage-analyzer")
-```
-
-**Check learning status:**
-```bash
-aqe learn status --agent test-gen
-aqe patterns list --framework jest
-```
-
-### 🎯 Fleet Configuration
-
-**Topology**: hierarchical
-**Max Agents**: 10
-**Testing Focus**: unit, integration
-**Environments**: development
-**Frameworks**: jest
-
-### 📋 Memory Namespace
-
-Agents share state through the **`aqe/*` memory namespace**:
-- `aqe/test-plan/*` - Test planning and requirements
-- `aqe/coverage/*` - Coverage analysis and gaps
-- `aqe/quality/*` - Quality metrics and gates
-- `aqe/performance/*` - Performance test results
-- `aqe/security/*` - Security scan findings
-- `aqe/swarm/coordination` - Cross-agent coordination
-
-### 💡 Key Principles
-- Use Task tool for agent execution (not just MCP)
-- Batch all operations in single messages (TodoWrite, file ops, etc.)
-- Test with actual databases, not mocks
-- Document only what actually works
-
----
-
-**Generated by**: Agentic QE Fleet v2.2.0
-**Initialization Date**: 2025-12-03T10:48:54.968Z
+**Generated by**: Agentic QE Fleet v2.3.0
+**Initialization Date**: 2025-12-08T13:48:54.968Z
 **Fleet Topology**: hierarchical
 - We always implement all the code/tests, with proper implementation. We value the quality we deliver to our users.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <img alt="NPM Downloads" src="https://img.shields.io/npm/dw/agentic-qe">
 
 
-**Version 2.2.2** | [Changelog](CHANGELOG.md) | [Contributors](CONTRIBUTORS.md) | [Issues](https://github.com/proffesor-for-testing/agentic-qe/issues) | [Discussions](https://github.com/proffesor-for-testing/agentic-qe/discussions)
+**Version 2.3.0** | [Changelog](CHANGELOG.md) | [Contributors](CONTRIBUTORS.md) | [Issues](https://github.com/proffesor-for-testing/agentic-qe/issues) | [Discussions](https://github.com/proffesor-for-testing/agentic-qe/discussions)
 
 > Agentic test automation with AI learning, real-time visualization, QUIC transport, testability scoring, OpenTelemetry observability, persistent event storage, constitutional AI governance, and intelligent model routing.
 

--- a/docs/guides/MEMORY-LEARNING-USER-GUIDE.md
+++ b/docs/guides/MEMORY-LEARNING-USER-GUIDE.md
@@ -1,0 +1,417 @@
+# Memory, Learning & Patterns: User Guide
+
+This guide explains how the Agentic QE Fleet's memory and learning system works, and how to use it effectively.
+
+---
+
+## Overview
+
+The Agentic QE Fleet uses a **unified learning system** that:
+
+1. **Persists experiences** - Every agent task stores outcomes for future reference
+2. **Learns patterns** - Successful strategies are captured and reused
+3. **Improves over time** - Q-learning algorithms optimize agent behavior
+
+All data is stored in a single SQLite database: `.agentic-qe/memory.db`
+
+---
+
+## Quick Start
+
+### Check Learning Status
+
+```bash
+npx aqe learn status
+```
+
+**Example output:**
+```
+🧠 Learning Engine Status
+
+Agents with learning data: 2
+├─ Total Experiences: 2
+├─ Q-Value Entries: 0
+├─ Patterns Stored: 2
+├─ Avg Reward: 0.89
+└─ Success Rate: 100.0%
+```
+
+### View Learning History
+
+```bash
+npx aqe learn history --limit 10
+```
+
+### Export Learning Data
+
+```bash
+npx aqe learn export --format json --output my-learning-data.json
+```
+
+---
+
+## How Learning Works
+
+### 1. Experience Storage
+
+When agents complete tasks, they automatically store:
+
+| Field | Description |
+|-------|-------------|
+| `agent_id` | Which agent ran the task |
+| `task_type` | Type of task (test-generation, coverage-analysis, etc.) |
+| `reward` | Success score (0.0 - 1.0) |
+| `outcome` | Task results (tests generated, coverage achieved, etc.) |
+| `metadata` | Additional context (framework, language, etc.) |
+
+**Example Experience:**
+```json
+{
+  "agent_id": "qe-test-generator",
+  "task_type": "test-generation",
+  "reward": 0.92,
+  "outcome": {
+    "testsGenerated": 15,
+    "coverageAchieved": 87.5,
+    "framework": "jest"
+  }
+}
+```
+
+### 2. Pattern Recognition
+
+When agents discover effective strategies, they store patterns:
+
+```json
+{
+  "pattern": "Property-based testing finds 40% more edge cases than template-based for validation logic",
+  "confidence": 0.95,
+  "domain": "test-generation",
+  "usage_count": 12,
+  "success_rate": 0.92
+}
+```
+
+### 3. Q-Learning Optimization
+
+After multiple task episodes, the system builds Q-values:
+
+| State | Action | Q-Value |
+|-------|--------|---------|
+| `high-complexity-code` | `use-property-testing` | 0.85 |
+| `simple-crud` | `use-template-testing` | 0.78 |
+| `external-api-integration` | `use-mock-testing` | 0.91 |
+
+These guide future agent decisions.
+
+---
+
+## Database Schema
+
+### Key Tables
+
+```
+.agentic-qe/memory.db
+├── learning_experiences  - Task outcomes and rewards
+├── patterns              - Discovered successful strategies
+├── q_values              - Q-learning state-action values
+├── memory_entries        - General key-value storage
+├── learning_history      - Improvement loop history
+└── learning_metrics      - Performance tracking
+```
+
+### Querying Directly
+
+```javascript
+const Database = require('better-sqlite3');
+const db = new Database('.agentic-qe/memory.db', { readonly: true });
+
+// Get all experiences for an agent
+const experiences = db.prepare(`
+  SELECT * FROM learning_experiences
+  WHERE agent_id = ?
+  ORDER BY created_at DESC
+`).all('qe-test-generator');
+
+// Get high-confidence patterns
+const patterns = db.prepare(`
+  SELECT * FROM patterns
+  WHERE confidence > 0.9
+  ORDER BY usage_count DESC
+`).all();
+
+// Get Q-values for a state
+const qValues = db.prepare(`
+  SELECT action_key, q_value
+  FROM q_values
+  WHERE state_key = ?
+  ORDER BY q_value DESC
+`).all('high-complexity-code');
+
+db.close();
+```
+
+---
+
+## Memory Namespace Convention
+
+All data uses standardized namespaces:
+
+```
+aqe/{agentType}/{key}           - Agent-specific data
+aqe/shared/{agentType}/{key}    - Cross-agent shared data
+aqe/learning/patterns/*         - Learned patterns
+aqe/coordination/*              - Multi-agent coordination
+```
+
+**Examples:**
+```
+aqe/test-generator/last-generation
+aqe/coverage-analyzer/gaps-detected
+aqe/shared/test-generator/patterns
+aqe/security/baselines
+```
+
+---
+
+## For Claude Code Users
+
+### Setup MCP Server (Required for Learning Persistence)
+
+Add the AQE MCP server to Claude Code:
+
+```bash
+claude mcp add aqe-mcp npx aqe-mcp
+```
+
+This enables the learning MCP tools:
+- `mcp__agentic_qe__learning_store_experience`
+- `mcp__agentic_qe__learning_store_pattern`
+- `mcp__agentic_qe__learning_store_qvalue`
+- `mcp__agentic_qe__learning_query`
+
+### How Agent Learning Protocol Works
+
+When you spawn an agent via Claude Code Task tool:
+
+**1. Agent reads its `.md` definition** (e.g., `.claude/agents/qe-test-generator.md`)
+
+**2. Agent queries past learnings:**
+```javascript
+mcp__agentic_qe__learning_query({
+  agentId: "qe-test-generator",
+  taskType: "test-generation",
+  minReward: 0.8,
+  limit: 10
+})
+```
+
+**3. Agent uses learned patterns to guide work**
+
+**4. Agent stores experience after task:**
+```javascript
+mcp__agentic_qe__learning_store_experience({
+  agentId: "qe-test-generator",
+  taskType: "test-generation",
+  reward: 0.95,
+  outcome: { testsGenerated: 42, coverageAchieved: 96.3 },
+  metadata: { framework: "jest", algorithm: "property-based" }
+})
+```
+
+**5. If new pattern discovered, agent stores it:**
+```javascript
+mcp__agentic_qe__learning_store_pattern({
+  pattern: "Async/await error handling requires explicit try-catch in Jest",
+  confidence: 0.93,
+  domain: "test-generation"
+})
+```
+
+---
+
+## Learning CLI Commands
+
+### Status
+```bash
+npx aqe learn status              # Overall status
+npx aqe learn status --agent qe-test-generator  # Specific agent
+```
+
+### History
+```bash
+npx aqe learn history             # All history
+npx aqe learn history --limit 5   # Last 5 entries
+npx aqe learn history --agent qe-coverage-analyzer
+```
+
+### Metrics
+```bash
+npx aqe learn metrics             # Performance metrics
+npx aqe learn metrics --agent qe-test-generator
+```
+
+### Training
+```bash
+npx aqe learn train               # Train all agents
+npx aqe learn train --agent qe-test-generator
+npx aqe learn train --episodes 10 # Run 10 training episodes
+```
+
+### Export/Import
+```bash
+npx aqe learn export --format json --output backup.json
+npx aqe learn export --format csv --output backup.csv
+```
+
+### Reset (Caution!)
+```bash
+npx aqe learn reset               # Reset all learning data
+npx aqe learn reset --agent qe-test-generator  # Reset specific agent
+```
+
+---
+
+## Best Practices
+
+### 1. Initialize Before Using
+
+Always run `aqe init` first to create the database schema:
+
+```bash
+npx aqe init
+```
+
+### 2. Monitor Learning Progress
+
+Check status regularly:
+
+```bash
+npx aqe learn status
+```
+
+Look for:
+- Increasing experience count
+- High average reward (>0.8 is good)
+- Growing pattern library
+
+### 3. Review Stored Patterns
+
+Patterns represent learned knowledge. Review them:
+
+```bash
+node -e "
+const Database = require('better-sqlite3');
+const db = new Database('.agentic-qe/memory.db', { readonly: true });
+const patterns = db.prepare('SELECT pattern, confidence, domain FROM patterns ORDER BY confidence DESC').all();
+patterns.forEach(p => console.log(\`[\${p.domain}] (${p.confidence.toFixed(2)}) \${p.pattern}\`));
+db.close();
+"
+```
+
+### 4. Back Up Learning Data
+
+Before major changes:
+
+```bash
+npx aqe learn export --format json --output learning-backup-$(date +%Y%m%d).json
+```
+
+### 5. Don't Reset Unless Necessary
+
+Learning data is valuable. Only reset if:
+- Data is corrupted
+- Starting fresh experiment
+- Testing learning system itself
+
+---
+
+## Troubleshooting
+
+### "No learning data found"
+
+**Cause:** Database not initialized or no agents have run yet.
+
+**Fix:**
+```bash
+npx aqe init
+# Then run some agents
+```
+
+### "MCP tool not found"
+
+**Cause:** AQE MCP server not configured in Claude Code.
+
+**Fix:**
+```bash
+claude mcp add aqe-mcp npx aqe-mcp
+```
+
+### "Database locked"
+
+**Cause:** Another process is writing to the database.
+
+**Fix:** Wait for other operations to complete, or check for hanging processes:
+```bash
+lsof .agentic-qe/memory.db
+```
+
+### Q-values always empty
+
+**Cause:** Q-learning requires multiple episodes to build values.
+
+**Fix:** Run more agent tasks or trigger training:
+```bash
+npx aqe learn train --episodes 20
+```
+
+---
+
+## Technical Reference
+
+### Database Location
+```
+.agentic-qe/memory.db
+```
+
+### Configuration Files
+```
+.agentic-qe/config/learning.json    - Learning parameters
+.agentic-qe/config/improvement.json - Improvement loop settings
+```
+
+### Learning Parameters
+
+```json
+{
+  "enabled": true,
+  "learningRate": 0.1,
+  "discountFactor": 0.95,
+  "explorationRate": 0.2,
+  "explorationDecay": 0.995,
+  "minExplorationRate": 0.01,
+  "targetImprovement": 0.20
+}
+```
+
+### Source Files
+```
+src/learning/LearningEngine.ts      - Core learning logic
+src/learning/QLearning.ts           - Q-learning algorithm
+src/core/memory/SwarmMemoryManager.ts - Database operations
+src/mcp/handlers/learning/          - MCP tool handlers
+```
+
+---
+
+## Summary
+
+| What | Where | How to Access |
+|------|-------|---------------|
+| Learning data | `.agentic-qe/memory.db` | `npx aqe learn status` |
+| Experiences | `learning_experiences` table | CLI or direct query |
+| Patterns | `patterns` table | CLI or direct query |
+| Q-values | `q_values` table | CLI or direct query |
+| Config | `.agentic-qe/config/` | JSON files |
+
+The system is designed to **work automatically** - agents learn from every task. Use the CLI commands to monitor progress and the MCP tools to integrate with Claude Code.

--- a/docs/research/SUMMARY-task-agent-learning-gap.md
+++ b/docs/research/SUMMARY-task-agent-learning-gap.md
@@ -1,0 +1,222 @@
+# Executive Summary: Task Agent Learning Gap
+
+**Critical Finding**: Claude Code's Task tool does NOT automatically capture agent output for learning persistence.
+
+---
+
+## The Problem
+
+When you spawn agents using Claude Code's Task tool:
+```javascript
+Task("Generate tests", "Create test suite...", "qe-test-generator")
+```
+
+**What happens**:
+- ✅ Agent executes successfully
+- ✅ Output visible to user in conversation
+- ❌ **Learnings are NEVER persisted**
+- ❌ **No automatic hook integration**
+
+---
+
+## Root Cause
+
+### Claude Flow's ReasoningBank Requires Trajectories
+
+ReasoningBank exists but expects **manual trajectory files**:
+
+```json
+{
+  "steps": [
+    { "action": "analyze", "result": "..." },
+    { "action": "implement", "result": "..." }
+  ],
+  "query": "Task description",
+  "metadata": { "agent": "test-gen" }
+}
+```
+
+**Problem**: Nobody creates these trajectories for Task agents!
+
+### Hook System Limitation
+
+Hooks work for `Bash`, `Write`, `Edit` but **NOT for Task tool**:
+- Task agents run in **separate threads**
+- No parent-child data flow
+- Agent output stays **internal to Claude Code**
+
+---
+
+## Current State Analysis
+
+### ✅ What EXISTS in Claude Flow:
+
+1. **ReasoningBank** - Learning system with judge + distill algorithms
+2. **Post-Task Hook** - Script that processes trajectories
+3. **Memory Storage** - SQLite database with embeddings
+4. **Retrieval API** - Semantic search for memories
+
+### ❌ What's MISSING:
+
+1. **Automatic trajectory capture** from Task agents
+2. **Hook integration** for Task tool
+3. **Structured output** from agent conversations
+4. **Agent instrumentation** for step tracking
+
+---
+
+## Recommended Solution: Hybrid Self-Reporting
+
+### Architecture:
+
+```
+Agent Work
+    ↓
+Agent uses memory_store with "learning/*" key
+    ↓
+Background processor watches "learning/*"
+    ↓
+Converts to trajectory format
+    ↓
+Calls ReasoningBank judge + distill
+    ↓
+Persisted as reusable patterns
+```
+
+### Implementation (3 parts):
+
+#### 1. Agent Learning API
+```typescript
+// BaseAgent.ts
+protected async recordLearning(learning: {
+  type: 'pattern' | 'finding' | 'failure' | 'success',
+  title: string,
+  description: string,
+  confidence: number
+}): Promise<void> {
+  await this.memory.store({
+    key: `learning/${this.agentId}/${Date.now()}`,
+    value: JSON.stringify(learning),
+    namespace: "learnings",
+    persist: true
+  });
+}
+```
+
+#### 2. Updated Agent Instructions
+```markdown
+## Learning Protocol
+
+Record key learnings using:
+
+mcp__agentic-qe__memory_store({
+  key: "learning/[agent]/[timestamp]",
+  value: JSON.stringify({
+    type: "pattern",
+    title: "Edge case handling",
+    description: "Always validate null inputs...",
+    confidence: 0.85
+  }),
+  namespace: "learnings",
+  persist: true
+});
+```
+
+#### 3. Background Processor
+```bash
+# Process learnings periodically
+aqe learn process
+
+# Or automatic via cron
+*/30 * * * * cd /project && aqe learn process
+```
+
+---
+
+## Why This Works
+
+1. ✅ **Works TODAY** - No waiting for hook system changes
+2. ✅ **Explicit but simple** - Clear protocol for agents
+3. ✅ **Integrates with MCP** - Uses existing memory tools
+4. ✅ **Gradual rollout** - Start with 1-2 agents, expand
+5. ✅ **Measurable** - Can track learning coverage per agent
+
+---
+
+## Timeline
+
+### Week 1: Foundation
+- Implement `BaseAgent.recordLearning()`
+- Update 2 agent instructions (test-gen, flaky-hunter)
+- Test learning capture
+
+### Week 2: Automation
+- Build `LearningProcessor` service
+- Add CLI command `aqe learn process`
+- Integrate with ReasoningBank
+
+### Week 3: Rollout
+- Update all 19 QE agents
+- Document learning protocol
+- Monitor learning quality
+
+---
+
+## Alternative Approaches (Not Recommended)
+
+### ❌ Wait for Hook System Changes
+- **Timeline**: Unknown, depends on Anthropic
+- **Risk**: May never happen
+- **Blocker**: Prevents all learning
+
+### ❌ Parse Conversation History
+- **Challenge**: Unstructured text parsing
+- **Accuracy**: ~60-70% (lots of false positives)
+- **Maintenance**: High (conversation format changes)
+
+### ❌ Wrapper Scripts
+- **Complexity**: High
+- **Adoption**: Low (agents must use wrapper)
+- **Debugging**: Difficult
+
+---
+
+## Success Metrics
+
+**After implementing learning protocol:**
+
+1. **Learning Coverage**: % of agents recording learnings
+   - Target: 80%+ within 1 month
+
+2. **Learning Quality**: Avg confidence score of recorded patterns
+   - Target: >0.75
+
+3. **Learning Reuse**: % of tasks using retrieved memories
+   - Target: 40%+ within 2 months
+
+4. **Time to Convergence**: Iterations needed for pattern reuse
+   - Target: <3 iterations per task type
+
+---
+
+## Next Steps
+
+1. **Read**: Full analysis in `claude-flow-task-agent-learning-analysis.md`
+2. **Decide**: Approve hybrid self-reporting approach?
+3. **Build**: Start with BaseAgent.recordLearning() implementation
+4. **Test**: Pilot with qe-test-generator agent
+5. **Scale**: Roll out to all agents
+
+---
+
+## Key Takeaway
+
+**Claude Flow's ReasoningBank is powerful but requires intentional integration**. The Task tool won't automatically persist learnings. We must build an explicit learning protocol that agents follow.
+
+**This is achievable** and **worth doing** - the learning system will compound value over time.
+
+---
+
+**Full Analysis**: See `claude-flow-task-agent-learning-analysis.md` (12 sections, 800+ lines)
+**Generated**: 2025-12-08
+**Status**: ✅ Research Complete - Ready for Implementation

--- a/docs/research/claude-flow-task-agent-learning-analysis.md
+++ b/docs/research/claude-flow-task-agent-learning-analysis.md
@@ -1,0 +1,640 @@
+# Claude Flow Task Agent Learning Analysis
+
+**Research Date**: 2025-12-08
+**Researcher**: Research Agent
+**Repository**: https://github.com/ruvnet/claude-flow (agentic-flow package)
+
+---
+
+## Executive Summary
+
+After deep analysis of the claude-flow (agentic-flow) codebase, I've identified a **CRITICAL GAP**: **Claude Code's Task tool does NOT automatically capture agent output for hooks to persist as learnings**.
+
+### Key Findings:
+
+1. ✅ **Hooks work for built-in tools** (Bash, Write, Edit) - they can access tool input/output via stdin
+2. ❌ **No hook integration for Task tool** - Task agents are black boxes to the hook system
+3. ✅ **ReasoningBank exists** but requires **manual trajectory capture** - not automatic
+4. 🔧 **The problem is architectural** - Claude Code's Task tool is separate from MCP hooks
+
+---
+
+## 1. Hook Architecture Analysis
+
+### How PreToolUse/PostToolUse Hooks Work
+
+**Location**: `/workspaces/agentic-qe-cf/node_modules/agentic-flow/.claude/settings.json`
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [{
+          "type": "command",
+          "command": "cat | jq -r '.tool_input.file_path' | ... npx claude-flow hooks post-edit --file '{}'"
+        }]
+      }
+    ]
+  }
+}
+```
+
+**How it works**:
+1. **Hook receives tool data via stdin** as JSON
+2. Uses `jq` to extract specific fields (`tool_input.command`, `tool_input.file_path`)
+3. Passes extracted data to hook script
+4. Hook script processes and stores to memory
+
+**What hooks can access**:
+- ✅ Tool name (from `matcher`)
+- ✅ Tool input parameters (via `tool_input.*`)
+- ✅ Tool output (via stdin pipe)
+- ❌ **Task agent output** - NOT available
+
+---
+
+## 2. The Task Tool Problem
+
+### Task Tool is NOT Integrated with Hooks
+
+**Evidence from settings.json**:
+- Hooks defined for: `Bash`, `Write`, `Edit`, `MultiEdit`
+- **NO hooks defined for `Task` tool**
+
+**Why?**
+1. Task tool spawns **separate Claude Code agent threads**
+2. These agents run **independently** with their own context
+3. No mechanism to pipe agent conversation output to parent hooks
+4. Agent output stays **internal to Claude Code** - not exposed to hook system
+
+### Current Workflow (What Actually Happens):
+
+```mermaid
+graph TD
+    A[Claude Code - Main Agent] --> B{Uses Task Tool}
+    B --> C[Spawns Agent Thread 1]
+    B --> D[Spawns Agent Thread 2]
+    C --> E[Agent 1 does work]
+    D --> F[Agent 2 does work]
+    E --> G[Output visible to user]
+    F --> H[Output visible to user]
+    G -.->|NO HOOK ACCESS| I[Learnings Lost]
+    H -.->|NO HOOK ACCESS| I
+```
+
+**The Gap**: Task agents produce valuable learnings (code patterns, test strategies, bug fixes) but these learnings are **never persisted** because hooks can't access them.
+
+---
+
+## 3. ReasoningBank Learning System
+
+### ReasoningBank DOES Exist But Requires Manual Trajectory
+
+**Location**: `/workspaces/agentic-qe-cf/node_modules/agentic-flow/dist/reasoningbank/`
+
+**Key Components**:
+
+#### 3.1 Judge (Algorithm 2)
+**File**: `reasoningbank/core/judge.js`
+
+```javascript
+export async function judgeTrajectory(trajectory, query, options = {}) {
+    // Uses LLM to evaluate if trajectory was Success or Failure
+    const router = getRouter();
+    const response = await router.chat({
+        model: config.judge.model,
+        messages: [
+            { role: 'system', content: promptTemplate.system },
+            { role: 'user', content: prompt }
+        ]
+    });
+
+    return {
+        label: 'Success' | 'Failure',
+        confidence: 0.0 - 1.0,
+        reasons: ['why it succeeded/failed']
+    };
+}
+```
+
+**Input Required**: `trajectory` object with `steps` array
+**Problem**: **Nobody is creating this trajectory** for Task agents!
+
+#### 3.2 Distill (Algorithm 3)
+**File**: `reasoningbank/core/distill.js`
+
+```javascript
+export async function distillMemories(trajectory, verdict, query, options = {}) {
+    // Uses LLM to extract 1-3 reusable patterns from trajectory
+    const distilled = parseDistilledMemories(content);
+
+    // Stores memories with embeddings
+    for (const mem of distilled) {
+        db.upsertMemory({
+            type: 'reasoning_memory',
+            confidence: confidencePrior,
+            pattern_data: {
+                title: mem.title,
+                content: mem.content,
+                source: { task_id, agent_id, outcome }
+            }
+        });
+    }
+}
+```
+
+**Input Required**: `trajectory` + `verdict` from judge
+**Problem**: Same - no trajectory being created!
+
+#### 3.3 Post-Task Hook (Exists But Unused)
+**File**: `reasoningbank/hooks/post-task.js`
+
+```javascript
+async function main() {
+    const args = parseArgs(); // --task-id, --trajectory-file
+
+    // Load trajectory
+    const { trajectory, query } = loadTrajectory(args.trajectoryFile);
+
+    // Judge trajectory
+    const verdict = await judgeTrajectory(trajectory, query);
+
+    // Distill memories
+    const memoryIds = await distillMemories(trajectory, verdict, query);
+
+    // Check consolidation
+    if (shouldConsolidate()) {
+        await consolidate();
+    }
+}
+```
+
+**Requires**:
+- `--task-id` - task identifier
+- `--trajectory-file` - JSON file with trajectory steps
+
+**Problem**: **No automatic trajectory capture** - must be manually created!
+
+---
+
+## 4. What's Missing: The Trajectory Capture Gap
+
+### Trajectory Format Expected:
+
+```json
+{
+  "steps": [
+    {
+      "action": "read_file",
+      "file": "src/UserService.ts",
+      "result": "success"
+    },
+    {
+      "action": "generate_tests",
+      "framework": "jest",
+      "result": "created 15 tests"
+    },
+    {
+      "action": "run_tests",
+      "passed": 14,
+      "failed": 1,
+      "result": "mostly success"
+    }
+  ],
+  "query": "Generate comprehensive tests for UserService",
+  "metadata": {
+    "agent": "qe-test-generator",
+    "duration_ms": 45000
+  }
+}
+```
+
+### Current Reality:
+
+**Task agents produce output like**:
+```
+I've analyzed UserService.ts and created 15 comprehensive tests covering:
+- User registration validation
+- Email format checking
+- Password strength requirements
+- Duplicate detection
+...
+```
+
+**But this is**:
+- ✅ Visible to user in conversation
+- ❌ NOT structured as trajectory
+- ❌ NOT accessible to hooks
+- ❌ NOT persisted to ReasoningBank
+
+---
+
+## 5. Root Cause Analysis
+
+### Why Task Tool Can't Feed Hooks
+
+**Architectural Constraint**:
+
+1. **Claude Code's Task tool** is a built-in tool that spawns agent threads
+2. **Hook system** only receives data about the **tool invocation itself**, not agent output
+3. **Agent threads** are separate execution contexts with no parent-child data flow
+
+**Hook Input for Task Tool Would Only See**:
+```json
+{
+  "tool_name": "Task",
+  "tool_input": {
+    "content": "Generate tests for UserService",
+    "description": "Create comprehensive test suite",
+    "agent": "qe-test-generator"
+  }
+}
+```
+
+**What's Missing**:
+- ❌ Agent's actual work (files read, tests created, patterns discovered)
+- ❌ Agent's findings (edge cases identified, best practices applied)
+- ❌ Agent's learnings (what worked, what didn't)
+
+---
+
+## 6. Existing Workarounds in Claude Flow
+
+### 6.1 Manual Trajectory Creation
+
+**Pattern used in claude-flow tests**:
+
+```javascript
+// Agents must MANUALLY log their steps
+const trajectory = { steps: [] };
+
+// Step 1
+trajectory.steps.push({
+  action: 'analyze_code',
+  file: 'UserService.ts',
+  patterns_found: ['validation', 'error_handling']
+});
+
+// Step 2
+trajectory.steps.push({
+  action: 'generate_tests',
+  count: 15,
+  coverage: '92%'
+});
+
+// Manually call post-task
+await judgeTrajectory(trajectory, query);
+await distillMemories(trajectory, verdict, query);
+```
+
+**Problem**: Agents must be explicitly programmed to track steps - not automatic!
+
+### 6.2 Swarm Learning Optimizer
+
+**File**: `reasoningbank/hooks/swarm-learning-optimizer.js`
+
+This handles **swarm coordination** (topology selection, batch size), **NOT individual agent learnings**.
+
+```javascript
+// Stores metrics about SWARM execution (not agent internals)
+await storeExecutionPattern(taskDescription, {
+  topology: 'hierarchical',
+  agentCount: 5,
+  successRate: 92,
+  speedup: 3.5
+});
+```
+
+**Scope**: Swarm-level optimization, not agent-level learning capture.
+
+---
+
+## 7. Solution Approaches
+
+### Option 1: Agent Self-Reporting (Current Manual Approach)
+
+**How**: Agents explicitly log steps to trajectory file during execution
+
+**Pros**:
+- ✅ Works with current hook system
+- ✅ Full control over what gets captured
+
+**Cons**:
+- ❌ Requires every agent to implement logging
+- ❌ Easy to forget/inconsistent
+- ❌ High maintenance burden
+
+**Implementation**:
+```javascript
+// In agent instructions:
+"DURING your work, log each step to trajectory.json:
+{
+  steps: [
+    { action: 'analyze', result: '...' },
+    { action: 'implement', result: '...' }
+  ]
+}
+
+AFTER completing work, call:
+npx agentic-flow hooks post-task --task-id $TASK_ID --trajectory-file trajectory.json
+"
+```
+
+### Option 2: Conversation Analysis Hook (New)
+
+**How**: Create PostToolUse hook for Task tool that analyzes conversation history
+
+**Pros**:
+- ✅ Automatic - no agent changes needed
+- ✅ Works with any agent
+
+**Cons**:
+- ❌ Requires parsing unstructured conversation text
+- ❌ May miss implicit knowledge
+- ❌ Hook system limitation - Task tool may not trigger PostToolUse
+
+**Implementation** (if hooks worked):
+```json
+{
+  "hooks": {
+    "PostToolUse": [{
+      "matcher": "Task",
+      "hooks": [{
+        "type": "command",
+        "command": "cat | jq -r '.conversation_history' | npx agentic-flow hooks analyze-conversation --extract-trajectory"
+      }]
+    }]
+  }
+}
+```
+
+### Option 3: Memory Marker Pattern (Hybrid)
+
+**How**: Agents use special memory keys that trigger learning capture
+
+**Pros**:
+- ✅ Explicit but lightweight
+- ✅ Works with existing memory system
+- ✅ Can be made semi-automatic
+
+**Cons**:
+- ❌ Still requires agent awareness
+- ❌ Additional memory operations
+
+**Implementation**:
+```javascript
+// Agent stores learnings to special namespace
+mcp__agentic-qe__memory_store({
+  key: "learning/test-gen/finding-1",
+  value: JSON.stringify({
+    pattern: "Edge case testing",
+    context: "UserService validation",
+    success: true
+  }),
+  namespace: "learnings",
+  persist: true
+});
+
+// Background process watches "learnings/*" namespace
+// Automatically converts to ReasoningBank memories
+```
+
+### Option 4: Wrapper Script Approach (Recommended)
+
+**How**: Instead of using Task directly, use wrapper that captures output
+
+**Pros**:
+- ✅ Works TODAY with existing infrastructure
+- ✅ Captures full agent output
+- ✅ Can structure into trajectories
+- ✅ No hook system changes needed
+
+**Cons**:
+- ❌ Slightly more verbose
+- ❌ Requires discipline to use wrapper
+
+**Implementation**:
+```bash
+#!/bin/bash
+# task-with-learning.sh
+
+TASK_ID=$(date +%s)
+AGENT=$1
+INSTRUCTIONS=$2
+
+# Run task and capture output
+TRAJECTORY_FILE="/tmp/trajectory-$TASK_ID.json"
+
+# Initialize trajectory
+echo '{"steps":[],"query":"'"$INSTRUCTIONS"'","metadata":{"agent":"'"$AGENT"'"}}' > $TRAJECTORY_FILE
+
+# Execute agent (would need output parsing here)
+# This is the HARD part - capturing structured steps from agent work
+
+# After completion, trigger ReasoningBank
+npx agentic-flow hooks post-task --task-id $TASK_ID --trajectory-file $TRAJECTORY_FILE
+```
+
+**Challenge**: Still need agents to produce structured output
+
+---
+
+## 8. Recommended Solution for Agentic QE
+
+### Best Approach: **Hybrid Self-Reporting with Memory Markers**
+
+**Why**:
+1. Works with current architecture (no waiting for hook system changes)
+2. Explicit but not too burdensome
+3. Integrates with existing MCP memory tools
+4. Can be gradually improved
+
+### Implementation Strategy:
+
+#### Step 1: Add Learning API to BaseAgent
+
+```typescript
+// src/agents/BaseAgent.ts
+
+export abstract class BaseAgent {
+  protected async recordLearning(learning: {
+    type: 'pattern' | 'finding' | 'failure' | 'success',
+    title: string,
+    description: string,
+    context: Record<string, any>,
+    confidence: number
+  }): Promise<void> {
+    // Store to special learning namespace
+    await this.memory.store({
+      key: `learning/${this.agentId}/${Date.now()}`,
+      value: JSON.stringify(learning),
+      namespace: 'learnings',
+      persist: true
+    });
+  }
+}
+```
+
+#### Step 2: Update Agent Instructions
+
+```markdown
+## Learning Protocol
+
+During your work, record key learnings using memory:
+
+```javascript
+mcp__agentic-qe__memory_store({
+  key: "learning/[agent]/[timestamp]",
+  value: JSON.stringify({
+    type: "pattern|finding|failure|success",
+    title: "Short title",
+    description: "What you learned",
+    context: { relevant: "data" },
+    confidence: 0.8
+  }),
+  namespace: "learnings",
+  persist: true
+});
+```
+
+Record learnings when:
+- ✅ You discover a useful pattern
+- ✅ You find an edge case
+- ✅ A test strategy works well
+- ✅ Something fails (what to avoid)
+```
+
+#### Step 3: Background Learning Processor
+
+```typescript
+// src/learning/LearningProcessor.ts
+
+export class LearningProcessor {
+  async processPendingLearnings(): Promise<void> {
+    // Query all learnings since last run
+    const learnings = await this.memory.query({
+      pattern: "learning/*",
+      namespace: "learnings"
+    });
+
+    // Convert to ReasoningBank format
+    for (const learning of learnings) {
+      const trajectory = this.convertToTrajectory(learning);
+      const verdict = this.heuristicJudge(trajectory);
+      await this.storeToReasoningBank(trajectory, verdict);
+    }
+
+    // Clear processed learnings
+    await this.memory.delete({ pattern: "learning/*" });
+  }
+
+  private convertToTrajectory(learning: any): Trajectory {
+    return {
+      steps: [{
+        action: learning.value.type,
+        description: learning.value.description,
+        context: learning.value.context,
+        result: learning.value.type === 'success' ? 'success' : 'failure'
+      }],
+      query: learning.value.title,
+      metadata: {
+        agent: this.extractAgentFromKey(learning.key),
+        confidence: learning.value.confidence
+      }
+    };
+  }
+}
+```
+
+#### Step 4: CLI Command
+
+```bash
+# Run periodically (or after each major task)
+aqe learn process
+
+# Or automatic via cron/systemd timer
+```
+
+---
+
+## 9. Comparison: Our Problem vs Claude Flow's Design
+
+### Claude Flow's Assumption:
+- Agents run in **controlled environment** (E2B sandboxes, Docker containers)
+- Can **instrument agent execution** at runtime
+- Captures stdout/stderr automatically
+- Structured logging to trajectory files
+
+### Our Reality (Agentic QE):
+- Agents run as **Claude Code Task threads**
+- No access to agent internals
+- Output is conversational, not structured
+- No automatic instrumentation
+
+### The Mismatch:
+Claude Flow's ReasoningBank was designed for **instrumented runtime environments**, not for **Claude Code's black-box Task tool**.
+
+---
+
+## 10. Action Items for Agentic QE
+
+### Immediate (Week 1):
+1. ✅ **Implement BaseAgent.recordLearning()** method
+2. ✅ **Update agent instructions** with learning protocol
+3. ✅ **Test with 1-2 agents** (qe-test-generator, qe-flaky-test-hunter)
+
+### Short-term (Week 2-3):
+4. ✅ **Build LearningProcessor** background service
+5. ✅ **Add CLI command** `aqe learn process`
+6. ✅ **Integrate with MCP memory handlers**
+
+### Long-term (Month 2):
+7. 🔄 **Explore Claude Code hook enhancements** (may require upstream changes)
+8. 🔄 **Build trajectory visualization** dashboard
+9. 🔄 **Automated learning quality scoring**
+
+---
+
+## 11. Open Questions
+
+1. **Can we hook into Task tool completion?**
+   - Need to check if Claude Code exposes any events/callbacks
+   - May require feature request to Anthropic
+
+2. **Can we parse agent conversation programmatically?**
+   - Claude Code may provide conversation history API
+   - Would enable automatic trajectory extraction
+
+3. **Should we build our own trajectory format?**
+   - Start simple (JSON with steps array)
+   - Evolve based on what agents actually need to record
+
+---
+
+## 12. Conclusion
+
+**Bottom Line**: Claude Flow's ReasoningBank is powerful but **requires manual trajectory capture**. The Task tool does not automatically feed learnings to hooks.
+
+**For Agentic QE, we need**:
+1. Explicit agent learning protocol (memory markers)
+2. Background processor to convert learnings to ReasoningBank format
+3. CLI tooling to manage the learning lifecycle
+
+**This is achievable** with current tools, but requires **intentional design** in our agent instructions and memory architecture.
+
+---
+
+## References
+
+- `/workspaces/agentic-qe-cf/node_modules/agentic-flow/README.md` - Package overview
+- `/workspaces/agentic-qe-cf/node_modules/agentic-flow/dist/reasoningbank/` - ReasoningBank implementation
+- `/workspaces/agentic-qe-cf/node_modules/agentic-flow/.claude/settings.json` - Hook configuration examples
+- `/workspaces/agentic-qe-cf/node_modules/agentic-flow/docs/reasoningbank/REASONINGBANK-VALIDATION.md` - Integration documentation
+
+---
+
+**Generated by**: Research Agent
+**Task**: Deep analysis of claude-flow trajectory capture for Task tool agents
+**Status**: ✅ Complete - Recommendations provided

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentic-qe",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentic-qe",
-      "version": "2.2.2",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.64.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-qe",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "Agentic Quality Engineering Fleet System - AI-driven quality management platform with 41 QE skills, learning, pattern reuse, ML-based flaky detection, Multi-Model Router (70-81% cost savings), streaming progress updates, 84 MCP tools with lazy loading (87% context reduction), and native TypeScript hooks",
   "main": "dist/cli/index.js",
   "types": "dist/cli/index.d.ts",

--- a/scripts/hooks/capture-task-learning.js
+++ b/scripts/hooks/capture-task-learning.js
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+/**
+ * PostToolUse Hook: Automatic Task Learning Capture
+ *
+ * This hook automatically captures learnings from completed Task agents
+ * and persists them to memory.db. It provides a safety net ensuring
+ * learnings are captured even when agents don't explicitly call MCP tools.
+ *
+ * Input (via stdin): PostToolUse JSON with tool_input and tool_response
+ * Output: Stores learning_experience record to .agentic-qe/memory.db
+ *
+ * @module hooks/capture-task-learning
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// Read stdin
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', chunk => input += chunk);
+process.stdin.on('end', () => processTaskLearning(input));
+
+async function processTaskLearning(jsonInput) {
+  try {
+    const data = JSON.parse(jsonInput);
+
+    // Only process completed Task tools
+    if (data.tool_name !== 'Task' || data.tool_response?.status !== 'completed') {
+      return;
+    }
+
+    // Extract key information
+    const agentType = data.tool_input?.subagent_type || 'unknown';
+    const taskDescription = data.tool_input?.description || '';
+    const prompt = data.tool_input?.prompt || '';
+    const agentOutput = data.tool_response?.content?.[0]?.text || '';
+    const durationMs = data.tool_response?.totalDurationMs || 0;
+    const totalTokens = data.tool_response?.totalTokens || 0;
+    const toolUseCount = data.tool_response?.totalToolUseCount || 0;
+    const agentId = data.tool_response?.agentId || 'unknown';
+    const cwd = data.cwd || process.cwd();
+
+    // Skip if no meaningful output
+    if (!agentOutput || agentOutput.length < 20) {
+      return;
+    }
+
+    // Determine task type from agent type
+    const taskTypeMap = {
+      'qe-test-generator': 'test-generation',
+      'qe-coverage-analyzer': 'coverage-analysis',
+      'qe-security-scanner': 'security-scan',
+      'qe-performance-tester': 'performance-test',
+      'qe-flaky-test-hunter': 'flaky-detection',
+      'qe-chaos-engineer': 'chaos-testing',
+      'qe-code-complexity': 'complexity-analysis',
+      'qe-quality-gate': 'quality-gate',
+      'qe-regression-risk-analyzer': 'regression-analysis',
+      'qe-requirements-validator': 'requirements-validation',
+      'qe-test-data-architect': 'test-data-generation',
+      'qe-visual-tester': 'visual-testing',
+      'qe-api-contract-validator': 'contract-validation',
+      'qe-fleet-commander': 'fleet-coordination',
+      'qe-test-executor': 'test-execution',
+      'qe-quality-analyzer': 'quality-analysis',
+      'qe-deployment-readiness': 'deployment-readiness',
+      'qe-production-intelligence': 'production-intelligence',
+      'qx-partner': 'qx-analysis',
+      'researcher': 'research',
+      'coder': 'implementation',
+      'tester': 'testing',
+      'reviewer': 'code-review'
+    };
+    const taskType = taskTypeMap[agentType] || agentType;
+
+    // Calculate reward based on output quality indicators
+    let reward = 0.7; // Base reward for completion
+
+    // Increase reward for comprehensive output
+    if (agentOutput.length > 500) reward += 0.05;
+    if (agentOutput.length > 1000) reward += 0.05;
+    if (agentOutput.length > 2000) reward += 0.05;
+
+    // Increase reward for tool usage (indicates thorough work)
+    if (toolUseCount > 0) reward += 0.05;
+    if (toolUseCount > 5) reward += 0.05;
+
+    // Check for success indicators in output
+    const successIndicators = ['✓', '✅', 'success', 'complete', 'passed', 'found', 'created', 'generated'];
+    const failureIndicators = ['❌', 'failed', 'error', 'could not', 'unable to'];
+
+    const hasSuccess = successIndicators.some(ind => agentOutput.toLowerCase().includes(ind.toLowerCase()));
+    const hasFailure = failureIndicators.some(ind => agentOutput.toLowerCase().includes(ind.toLowerCase()));
+
+    if (hasSuccess && !hasFailure) reward += 0.1;
+    if (hasFailure) reward -= 0.2;
+
+    // Cap reward between 0.1 and 1.0
+    reward = Math.max(0.1, Math.min(1.0, reward));
+
+    // Find memory.db path
+    const dbPath = path.join(cwd, '.agentic-qe', 'memory.db');
+
+    // Check if database exists
+    if (!fs.existsSync(dbPath)) {
+      // Try to find it relative to this script
+      const altPath = path.join(__dirname, '../../.agentic-qe/memory.db');
+      if (!fs.existsSync(altPath)) {
+        console.error('💡 Learning: memory.db not found, skipping capture');
+        return;
+      }
+    }
+
+    // Store learning experience
+    const Database = require('better-sqlite3');
+    const db = new Database(dbPath);
+
+    // Note: Table should already exist from aqe init
+    // Schema: id, agent_id, task_id, task_type, state, action, reward, next_state, episode_id, metadata, created_at, timestamp
+
+    // DEDUPLICATION: Check if agent already stored learning via MCP in last 60 seconds
+    // This prevents double-storing when agents properly call MCP learning tools
+    const recentLearning = db.prepare(`
+      SELECT id, metadata FROM learning_experiences
+      WHERE agent_id = ?
+        AND created_at > datetime('now', '-60 seconds')
+      ORDER BY created_at DESC
+      LIMIT 1
+    `).get(agentType);
+
+    if (recentLearning) {
+      // Check if it was stored by the agent (not by hook)
+      try {
+        const meta = JSON.parse(recentLearning.metadata || '{}');
+        if (meta.capturedBy !== 'PostToolUse-hook') {
+          // Agent already stored learning via MCP - skip duplicate
+          console.log(`📚 Learning: Agent ${agentType} already stored learning via MCP - skipping hook capture`);
+          db.close();
+          return;
+        }
+      } catch { /* ignore parse errors */ }
+    }
+
+    // Extract outcome summary (first 500 chars of output)
+    const outcomeSummary = agentOutput.substring(0, 500).replace(/\n/g, ' ').trim();
+
+    // Insert learning experience (matching actual schema)
+    const stmt = db.prepare(`
+      INSERT INTO learning_experiences (agent_id, task_id, task_type, state, action, reward, next_state, episode_id, metadata)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    const metadata = JSON.stringify({
+      taskDescription,
+      durationMs,
+      totalTokens,
+      toolUseCount,
+      outputLength: agentOutput.length,
+      outputSummary: outcomeSummary,
+      success: hasSuccess && !hasFailure,
+      capturedBy: 'PostToolUse-hook',
+      sessionAgentId: agentId
+    });
+
+    const taskId = `task-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    const episodeId = `episode-${new Date().toISOString().slice(0, 10)}`;
+
+    stmt.run(
+      agentType,
+      taskId,
+      taskType,
+      'task-started',
+      'execute-task',
+      reward,
+      'task-completed',
+      episodeId,
+      metadata
+    );
+
+    db.close();
+
+    // Output confirmation (visible in hook output)
+    console.log(`📚 Learning captured: ${agentType} → ${taskType} (reward: ${reward.toFixed(2)})`);
+
+  } catch (error) {
+    // Silently fail - don't break the workflow
+    // Uncomment for debugging:
+    // console.error('Hook error:', error.message);
+  }
+}

--- a/src/agents/BaseAgent.ts
+++ b/src/agents/BaseAgent.ts
@@ -58,7 +58,7 @@ export abstract class BaseAgent extends EventEmitter {
   protected readonly agentId: AgentId;
   protected readonly capabilities: Map<string, AgentCapability>;
   protected readonly context: AgentContext;
-  protected readonly memoryStore: MemoryStore;
+  protected readonly memoryStore: MemoryStore | SwarmMemoryManager;
   protected readonly eventBus: EventEmitter;
   protected currentTask?: TaskAssignment;
   protected hookManager: VerificationHookManager;
@@ -748,7 +748,8 @@ export abstract class BaseAgent extends EventEmitter {
       console.warn(`[WARN] Memory store not available for ${this.agentId.id}`);
       return;
     }
-    const namespacedKey = `agent:${this.agentId.id}:${key}`;
+    // Standardized namespace: aqe/{agentType}/{key}
+    const namespacedKey = `aqe/${this.agentId.type}/${key}`;
     await this.memoryStore.store(namespacedKey, value, ttl);
   }
 
@@ -760,7 +761,8 @@ export abstract class BaseAgent extends EventEmitter {
       console.warn(`[WARN] Memory store not available for ${this.agentId.id}`);
       return null;
     }
-    const namespacedKey = `agent:${this.agentId.id}:${key}`;
+    // Standardized namespace: aqe/{agentType}/{key}
+    const namespacedKey = `aqe/${this.agentId.type}/${key}`;
     return await this.memoryStore.retrieve(namespacedKey);
   }
 
@@ -772,7 +774,8 @@ export abstract class BaseAgent extends EventEmitter {
       console.warn(`[WARN] Memory store not available for ${this.agentId.id}`);
       return;
     }
-    const sharedKey = `shared:${this.agentId.type}:${key}`;
+    // Standardized namespace: aqe/shared/{agentType}/{key}
+    const sharedKey = `aqe/shared/${this.agentId.type}/${key}`;
     await this.memoryStore.store(sharedKey, value, ttl);
   }
 
@@ -784,7 +787,8 @@ export abstract class BaseAgent extends EventEmitter {
       console.warn(`[WARN] Memory store not available for ${this.agentId.id}`);
       return null;
     }
-    const sharedKey = `shared:${agentType}:${key}`;
+    // Standardized namespace: aqe/shared/{agentType}/{key}
+    const sharedKey = `aqe/shared/${agentType}/${key}`;
     return await this.memoryStore.retrieve(sharedKey);
   }
 

--- a/src/cli/init/claude-config.ts
+++ b/src/cli/init/claude-config.ts
@@ -38,24 +38,35 @@ export async function generateClaudeSettings(_fleetConfig: FleetConfig): Promise
   }
 
   // Merge AQE settings with existing settings
-  // AGENTDB_PATH ensures hooks use the same database as QE agents
+  // AQE_MEMORY_PATH ensures hooks use the unified QE database (.agentic-qe/memory.db)
+  // Note: agentdb.db is deprecated - all QE agents now use memory.db
   const aqeEnv = {
-    AGENTDB_PATH: ".agentic-qe/agentdb.db",
-    AGENTDB_LEARNING_ENABLED: "true",
-    AGENTDB_REASONING_ENABLED: "true",
-    AGENTDB_AUTO_TRAIN: "true",
-    AQE_MEMORY_ENABLED: "true"
+    AQE_MEMORY_PATH: ".agentic-qe/memory.db",
+    AQE_MEMORY_ENABLED: "true",
+    AQE_LEARNING_ENABLED: "true"
   };
 
   const aqePermissions = [
-    "Bash(npx agentdb:*)",
     "Bash(npx aqe:*)",
+    "Bash(npm run lint)",
     "Bash(npm run test:*)",
+    "Bash(npm test:*)",
     "Bash(git status)",
     "Bash(git diff:*)",
     "Bash(git log:*)",
     "Bash(git add:*)",
-    "Bash(git commit:*)"
+    "Bash(git commit:*)",
+    "Bash(git push)",
+    "Bash(git config:*)",
+    "Bash(git tag:*)",
+    "Bash(git branch:*)",
+    "Bash(git checkout:*)",
+    "Bash(git stash:*)",
+    "Bash(jq:*)",
+    "Bash(node:*)",
+    "Bash(which:*)",
+    "Bash(pwd)",
+    "Bash(ls:*)"
   ];
 
   const settings = {
@@ -84,23 +95,27 @@ export async function generateClaudeSettings(_fleetConfig: FleetConfig): Promise
   if (settingsExists) {
     console.log(chalk.green('  ✓ Merged AQE configuration into existing .claude/settings.json'));
   } else {
-    console.log(chalk.green('  ✓ Created .claude/settings.json with AgentDB learning hooks'));
+    console.log(chalk.green('  ✓ Created .claude/settings.json with QE learning hooks'));
   }
-  console.log(chalk.gray('    • PreToolUse: AgentDB edit intelligence (parallel success/failure queries)'));
-  console.log(chalk.gray('    • PostToolUse: Experience replay + verdict-based quality'));
-  console.log(chalk.gray('    • Stop: Model training + memory optimization'));
+  console.log(chalk.gray('    • PreToolUse: Pattern intelligence from memory.db'));
+  console.log(chalk.gray('    • PostToolUse: Task visualization events'));
+  console.log(chalk.gray('    • PreCompact: QE agent reminder'));
+  console.log(chalk.gray('    • Stop: Session summary'));
 }
 
 /**
  * Get AQE hooks configuration
  *
- * SECURITY: All hook commands use jq -R '@sh' for proper shell escaping
+ * Clean QE-only hooks that use memory.db directly via better-sqlite3.
+ * Note: agentdb.db and agentdb CLI are deprecated - all QE agents use memory.db
+ *
+ * SECURITY: All hook commands use jq for proper input handling
  * to prevent shell injection attacks from malicious file paths/inputs.
  */
 function getAQEHooks(): any {
-  // All hooks must export AGENTDB_PATH to ensure data is saved to the correct database
-  // The env vars in settings.json are not inherited by bash -c subshells
-  const DB_PATH_PREFIX = 'export AGENTDB_PATH=.agentic-qe/agentdb.db;';
+  // Pattern intelligence hook - queries memory.db for relevant patterns when editing files
+  // Uses better-sqlite3 for direct database access (fast, no external CLI dependency)
+  const patternQueryCommand = `cat | jq -r '.tool_input.file_path // .tool_input.path // empty' | head -1 | xargs -I {} node -e "const db=require('better-sqlite3')('.agentic-qe/memory.db',{readonly:true});try{const r=db.prepare(\\"SELECT pattern,confidence FROM patterns WHERE domain='code-edits' AND pattern LIKE '%\\" + process.argv[1].replace(/'/g,\\"''\\")+\\"%' ORDER BY confidence DESC LIMIT 3\\").all();r.forEach(p=>console.log('💡 Pattern:',p.pattern.substring(0,80),'('+Math.round(p.confidence*100)+'%)'));db.close()}catch(e){}" "{}" 2>/dev/null || true`;
 
   return {
     PreToolUse: [
@@ -109,8 +124,7 @@ function getAQEHooks(): any {
         hooks: [
           {
             type: "command",
-            description: "AgentDB Edit Intelligence - Query both success patterns and failure warnings",
-            command: `cat | jq -r '.tool_input.file_path // .tool_input.path // empty' | jq -R '@sh' | xargs -I {} bash -c '${DB_PATH_PREFIX} FILE={}; { npx agentdb@latest query --domain "failed-edits" --query "file:$FILE" --k 3 --min-confidence 0.7 --format json 2>/dev/null | jq -r ".memories[]? | \\"🚨 Warning: Similar edit failed - \\(.pattern.reason // \\"unknown\\")\\" " 2>/dev/null & npx agentdb@latest query --domain "successful-edits" --query "file:$FILE" --k 5 --min-confidence 0.8 --format json 2>/dev/null | jq -r ".memories[]? | \\"💡 Past Success: \\(.pattern.summary // \\"No similar patterns found\\")\\" " 2>/dev/null & wait; } || true'`
+            command: patternQueryCommand
           }
         ]
       },
@@ -119,35 +133,42 @@ function getAQEHooks(): any {
         hooks: [
           {
             type: "command",
-            description: "Trajectory Prediction - Predict optimal task sequence",
-            command: `cat | jq -r '.tool_input.prompt // .tool_input.task // empty' | jq -R '@sh' | xargs -I {} bash -c '${DB_PATH_PREFIX} TASK={}; npx agentdb@latest query --domain "task-trajectories" --query "task:$TASK" --k 3 --min-confidence 0.75 --format json 2>/dev/null | jq -r ".memories[]? | \\"📋 Predicted Steps: \\(.pattern.trajectory // \\"No trajectory data\\") (Success Rate: \\(.confidence // 0))\\" " 2>/dev/null || true'`
+            command: "bash scripts/hooks/emit-task-spawn.sh 2>/dev/null || true"
           }
         ]
       }
     ],
     PostToolUse: [
       {
-        matcher: "Write|Edit|MultiEdit",
-        hooks: [
-          {
-            type: "command",
-            description: "Experience Replay - Capture edit as RL experience",
-            command: `cat | jq -r '.tool_input.file_path // .tool_input.path // empty' | jq -R '@sh' | xargs -I {} bash -c '${DB_PATH_PREFIX} FILE={}; TIMESTAMP=$(date +%s); npx agentdb@latest store-pattern --type "experience" --domain "code-edits" --pattern "{\\"file\\":$FILE,\\"timestamp\\":$TIMESTAMP,\\"action\\":\\"edit\\",\\"state\\":\\"pre-test\\"}" --confidence 0.5 2>/dev/null || true'`
-          },
-          {
-            type: "command",
-            description: "Verdict-Based Quality - Async verdict assignment after tests",
-            command: `cat | jq -r '.tool_input.file_path // .tool_input.path // empty' | jq -R '@sh' | xargs -I {} bash -c '${DB_PATH_PREFIX} FILE={}; (sleep 2; TEST_RESULT=$(npm test --silent 2>&1 | grep -q "pass" && echo "ACCEPT" || echo "REJECT"); REWARD=$([ "$TEST_RESULT" = "ACCEPT" ] && echo "1.0" || echo "-1.0"); npx agentdb@latest store-pattern --type "verdict" --domain "code-quality" --pattern "{\\"file\\":$FILE,\\"verdict\\":\\"$TEST_RESULT\\",\\"reward\\":$REWARD}" --confidence $([ "$TEST_RESULT" = "ACCEPT" ] && echo "0.95" || echo "0.3") 2>/dev/null; if [ "$TEST_RESULT" = "ACCEPT" ]; then npx agentdb@latest store-pattern --type "success" --domain "successful-edits" --pattern "{\\"file\\":$FILE,\\"summary\\":\\"Edit passed tests\\"}" --confidence 0.9 2>/dev/null; else npx agentdb@latest store-pattern --type "failure" --domain "failed-edits" --pattern "{\\"file\\":$FILE,\\"reason\\":\\"Tests failed\\"}" --confidence 0.8 2>/dev/null; fi) &'`
-          }
-        ]
-      },
-      {
         matcher: "Task",
         hooks: [
           {
             type: "command",
-            description: "Trajectory Storage - Record task trajectory for learning",
-            command: `cat | jq -r '.tool_input.prompt // .tool_input.task // empty, .result.success // "unknown"' | paste -d'\\n' - - | jq -Rs 'split("\\n") | {task: (.[0] | @sh), success: .[1]}' | jq -r 'CONFIDENCE=(if .success == "true" then "0.95" else "0.5" end); "export AGENTDB_PATH=.agentic-qe/agentdb.db; TASK=\\(.task); SUCCESS=\\(.success); npx agentdb@latest store-pattern --type trajectory --domain task-trajectories --pattern \\("{\\\\\\"task\\\\\\":\\" + .task + ",\\\\\\"success\\\\\\":\\(.success),\\\\\\"trajectory\\\\\\":\\\\\\"search→scaffold→test→refine\\\\\\"}" | @sh) --confidence \\(CONFIDENCE) 2>/dev/null || true"' | bash`
+            command: "node scripts/hooks/capture-task-learning.js 2>/dev/null || true"
+          },
+          {
+            type: "command",
+            command: "bash scripts/hooks/emit-task-complete.sh 2>/dev/null || true"
+          }
+        ]
+      }
+    ],
+    PreCompact: [
+      {
+        matcher: "manual",
+        hooks: [
+          {
+            type: "command",
+            command: `/bin/bash -c 'echo "🔄 PreCompact: Review CLAUDE.md for 19 QE agents, skills, and learning protocols"'`
+          }
+        ]
+      },
+      {
+        matcher: "auto",
+        hooks: [
+          {
+            type: "command",
+            command: `/bin/bash -c 'echo "🔄 Auto-Compact: 19 QE agents available. Use: npx aqe learn status"'`
           }
         ]
       }
@@ -157,8 +178,7 @@ function getAQEHooks(): any {
         hooks: [
           {
             type: "command",
-            description: "Session end - Train models and compress learnings",
-            command: `bash -c '${DB_PATH_PREFIX} npx agentdb@latest train --domain "code-edits" --epochs 10 --batch-size 32 2>/dev/null || true; npx agentdb@latest optimize-memory --compress true --consolidate-patterns true 2>/dev/null || true'`
+            command: `echo '📊 Session ended. Run: npx aqe learn status' 2>/dev/null || true`
           }
         ]
       }

--- a/src/cli/init/helpers.ts
+++ b/src/cli/init/helpers.ts
@@ -66,3 +66,69 @@ export async function copyHelperScripts(force: boolean = false): Promise<void> {
 
   console.log(chalk.green(`  ✓ Copied ${copied} helper scripts`));
 }
+
+/**
+ * Copy hook scripts to user project
+ * These scripts are called by Claude Code hooks for learning capture
+ */
+export async function copyHookScripts(force: boolean = false): Promise<void> {
+  console.log(chalk.cyan('  🪝 Copying hook scripts...'));
+
+  // Find package location
+  const possiblePaths = [
+    path.join(__dirname, '../../../scripts/hooks'),
+    path.join(process.cwd(), 'node_modules/agentic-qe/scripts/hooks'),
+    path.join(process.cwd(), '../agentic-qe/scripts/hooks')
+  ];
+
+  let sourcePath: string | null = null;
+  for (const p of possiblePaths) {
+    if (await fs.pathExists(p)) {
+      sourcePath = p;
+      break;
+    }
+  }
+
+  if (!sourcePath) {
+    console.warn(chalk.yellow('  ⚠️  Hook scripts not found - skipping'));
+    return;
+  }
+
+  const targetPath = path.join(process.cwd(), 'scripts/hooks');
+  await fs.ensureDir(targetPath);
+
+  // Copy all hook scripts
+  const items = await fs.readdir(sourcePath);
+  let copied = 0;
+
+  for (const item of items) {
+    // Skip hidden files
+    if (item.startsWith('.')) {
+      continue;
+    }
+
+    const sourceFile = path.join(sourcePath, item);
+    const targetFile = path.join(targetPath, item);
+
+    // Check if it's a file
+    const stats = await fs.stat(sourceFile);
+    if (!stats.isFile()) {
+      continue;
+    }
+
+    if (!await fs.pathExists(targetFile) || force) {
+      await fs.copy(sourceFile, targetFile);
+
+      // Make scripts executable
+      if (item.endsWith('.sh') || item.endsWith('.js')) {
+        await fs.chmod(targetFile, 0o755);
+      }
+
+      copied++;
+    }
+  }
+
+  console.log(chalk.green(`  ✓ Copied ${copied} hook scripts`));
+  console.log(chalk.gray('    • capture-task-learning.js: Auto-captures agent learnings'));
+  console.log(chalk.gray('    • emit-task-spawn/complete.sh: Visualization events'));
+}

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -22,7 +22,7 @@ import { createClaudeMd } from './claude-md';
 import { copyAgentTemplates } from './agents';
 import { copySkillTemplates } from './skills';
 import { copyCommandTemplates } from './commands';
-import { copyHelperScripts } from './helpers';
+import { copyHelperScripts, copyHookScripts } from './helpers';
 
 // Import version from package.json
 const packageJson = require('../../../package.json');
@@ -121,6 +121,12 @@ export async function initCommand(options: InitOptions): Promise<void> {
       name: 'Helper Scripts',
       description: 'Copying helper scripts to .claude/helpers',
       execute: async (cfg, opts) => copyHelperScripts(opts.force || false),
+      critical: false
+    },
+    {
+      name: 'Hook Scripts',
+      description: 'Copying hook scripts for automatic learning capture',
+      execute: async (cfg, opts) => copyHookScripts(opts.force || false),
       critical: false
     }
     // Future phases could include:

--- a/src/core/memory/HNSWVectorMemory.ts
+++ b/src/core/memory/HNSWVectorMemory.ts
@@ -660,7 +660,7 @@ export class HNSWVectorMemory implements IPatternStore {
   } {
     return {
       type: 'agentdb',
-      version: '2.2.2',
+      version: '2.3.0',
       features: ['hnsw', 'vector-search', 'persistence', 'batch-operations'],
     };
   }

--- a/src/mcp/server-instructions.ts
+++ b/src/mcp/server-instructions.ts
@@ -117,7 +117,7 @@ Example: \`mcp__agentic_qe__test_generate_enhanced\`
 `;
 
 export const SERVER_NAME = 'agentic-qe';
-export const SERVER_VERSION = '2.2.2';
+export const SERVER_VERSION = '2.3.0';
 
 /**
  * Get formatted server info for MCP initialization


### PR DESCRIPTION
## Summary

This release fixes the long-standing issue where Task agents would not reliably persist learning data. Now learnings are captured automatically via a PostToolUse hook.

### 🎯 Major Feature: Automatic Learning Capture

- **New hook**: `scripts/hooks/capture-task-learning.js`
  - Captures agent type, task output, duration, token usage
  - Calculates reward based on output quality indicators  
  - Stores to `learning_experiences` table in `memory.db`
  - Deduplication: skips if agent already stored via MCP (60s window)

- **Updated `aqe init`**:
  - Copies hook scripts to user projects (`scripts/hooks/`)
  - New phase: "Hook Scripts" in initialization pipeline

### 🧹 Clean QE-Only Configuration

- Removed all claude-flow and agentdb dependencies
- Updated settings.json with clean AQE env vars
- All persistence unified to `.agentic-qe/memory.db`

### 📝 Agent Learning Instructions Audit

- Added MANDATORY `<learning_protocol>` sections to all 30 QE agents
  - 19 main QE agents
  - 11 QE subagents

### How It Works

```
Task Agent Completes → PostToolUse Hook Fires → capture-task-learning.js:
  • Extracts agent type, output, duration from hook input
  • Calculates reward (0.7 base + quality bonuses)
  • Checks for duplicates (60s deduplication window)
  • Stores to learning_experiences table
→ 📚 Learning captured: qe-test-generator → test-generation (reward: 0.85)
```

## Test plan

- [x] Verified automatic learning capture works with real Task agent
- [x] Verified deduplication logic (60s window)
- [x] Verified `aqe init` copies hook scripts to new projects
- [x] Verified database schema compatibility
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)