### PR TITLE
chore(release): bump version to v2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.2] - 2025-12-09
+
+### Fixed
+
+#### Dependency Resolution (Install Failure)
+Fixed npm install failure caused by transitive dependency issue:
+- **Root Cause**: `ruvector@latest` (0.1.25+) depends on `@ruvector/core@^0.1.25` which doesn't exist on npm (latest is 0.1.17)
+- **Solution**: Pinned `ruvector` to exact version `0.1.24` (removed caret `^`) which correctly depends on `@ruvector/core@^0.1.15`
+- Users can now successfully run `npm install -g agentic-qe@latest`
+
 ## [2.3.1] - 2025-12-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <img alt="NPM Downloads" src="https://img.shields.io/npm/dw/agentic-qe">
 
 
-**Version 2.3.1** | [Changelog](CHANGELOG.md) | [Contributors](CONTRIBUTORS.md) | [Issues](https://github.com/proffesor-for-testing/agentic-qe/issues) | [Discussions](https://github.com/proffesor-for-testing/agentic-qe/discussions)
+**Version 2.3.2** | [Changelog](CHANGELOG.md) | [Contributors](CONTRIBUTORS.md) | [Issues](https://github.com/proffesor-for-testing/agentic-qe/issues) | [Discussions](https://github.com/proffesor-for-testing/agentic-qe/discussions)
 
 > Agentic test automation with AI learning, real-time visualization, QUIC transport, testability scoring, OpenTelemetry observability, persistent event storage, constitutional AI governance, and intelligent model routing.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentic-qe",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentic-qe",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.64.0",
@@ -47,7 +47,7 @@
         "openai": "^6.9.1",
         "ora": "^5.4.1",
         "playwright": "^1.57.0",
-        "ruvector": "^0.1.24",
+        "ruvector": "0.1.24",
         "uuid": "^11.0.5",
         "winston": "^3.18.3",
         "ws": "^8.18.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-qe",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Agentic Quality Engineering Fleet System - AI-driven quality management platform with 41 QE skills, learning, pattern reuse, ML-based flaky detection, Multi-Model Router (70-81% cost savings), streaming progress updates, 84 MCP tools with lazy loading (87% context reduction), and native TypeScript hooks",
   "main": "dist/cli/index.js",
   "types": "dist/cli/index.d.ts",
@@ -139,7 +139,7 @@
     "openai": "^6.9.1",
     "ora": "^5.4.1",
     "playwright": "^1.57.0",
-    "ruvector": "^0.1.24",
+    "ruvector": "0.1.24",
     "uuid": "^11.0.5",
     "winston": "^3.18.3",
     "ws": "^8.18.3",

--- a/src/core/memory/HNSWVectorMemory.ts
+++ b/src/core/memory/HNSWVectorMemory.ts
@@ -660,7 +660,7 @@ export class HNSWVectorMemory implements IPatternStore {
   } {
     return {
       type: 'agentdb',
-      version: '2.3.1',
+      version: '2.3.2',
       features: ['hnsw', 'vector-search', 'persistence', 'batch-operations'],
     };
   }

--- a/src/mcp/server-instructions.ts
+++ b/src/mcp/server-instructions.ts
@@ -117,7 +117,7 @@ Example: \`mcp__agentic_qe__test_generate_enhanced\`
 `;
 
 export const SERVER_NAME = 'agentic-qe';
-export const SERVER_VERSION = '2.3.0';
+export const SERVER_VERSION = '2.3.2';
 
 /**
  * Get formatted server info for MCP initialization


### PR DESCRIPTION
## Summary
- Fix npm install failure caused by broken transitive dependency in `ruvector` package
- Pin `ruvector` to exact version `0.1.24` (removed caret `^`)
- **Root Cause**: `ruvector@0.1.25+` depends on `@ruvector/core@^0.1.25` which doesn't exist on npm (latest is 0.1.17)

## Files Changed
- `package.json` - Pin ruvector to 0.1.24, bump version to 2.3.2
- `package-lock.json` - Update lockfile
- `README.md` - Update version badge
- `CHANGELOG.md` - Document fix
- `src/mcp/server-instructions.ts` - Update SERVER_VERSION
- `src/core/memory/HNSWVectorMemory.ts` - Update version in getImplementationInfo()

## Test plan
- [x] Verify `npm ls ruvector @ruvector/core` shows 0.1.24 and 0.1.15 respectively
- [ ] After merge, verify `npm install -g agentic-qe@latest` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)