### PR TITLE
chore(release): v2.5.7 - n8n workflow testing agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.7] - 2025-12-17
+
+### Added
+
+#### n8n Workflow Testing Agents (PR #151)
+*Contributed by [@fndlalit](https://github.com/fndlalit)*
+
+Comprehensive suite of **15 n8n workflow testing agents** for production-ready workflow automation testing:
+
+- **N8nWorkflowExecutorAgent** - Execute workflows with data flow validation and assertions
+- **N8nPerformanceTesterAgent** - Load/stress testing with timing metrics and percentiles
+- **N8nChaosTesterAgent** - Fault injection using N8nTestHarness for real failure simulation
+- **N8nBDDScenarioTesterAgent** - Cucumber-style BDD testing with real execution
+- **N8nSecurityAuditorAgent** - 40+ secret patterns, runtime leak detection
+- **N8nExpressionValidatorAgent** - Safe expression validation using pattern matching
+- **N8nIntegrationTestAgent** - Real API connectivity testing via workflow execution
+- **N8nTriggerTestAgent** - Webhook testing with correct n8n URL patterns
+- **N8nComplianceValidatorAgent** - GDPR/HIPAA/SOC2/PCI-DSS compliance with runtime PII tracing
+- **N8nMonitoringValidatorAgent** - SLA compliance checking with runtime metrics
+- Plus 5 additional n8n agents (node-validator, unit-tester, version-comparator, ci-orchestrator, base-agent)
+
+**5 new n8n testing skills:**
+- `n8n-workflow-testing-fundamentals` - Core workflow testing concepts
+- `n8n-security-testing` - Credential and secret management testing
+- `n8n-integration-testing-patterns` - API and webhook testing strategies
+- `n8n-expression-testing` - Safe expression validation
+- `n8n-trigger-testing-strategies` - Trigger testing patterns
+
+**Key Design Decisions:**
+- Runtime execution is DEFAULT (not opt-in)
+- Safe expression evaluation using pattern matching (no unsafe eval)
+- Correct n8n webhook URL patterns (production + test mode)
+- Dual authentication support (API key + session cookie fallback)
+
+### Changed
+
+- Updated skill count from 41 to 46 (added 5 n8n skills)
+- Updated agent documentation with n8n workflow testing section
+- Updated `aqe init` to copy n8n agent definitions to user projects
+- Added Smithery badge to README (PR #152 by @gurdasnijor)
+
 ## [2.5.6] - 2025-12-16
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,14 +67,15 @@ npm publish --access public         # 10. npm publish
 ## 🤖 Agentic QE Fleet Quick Reference
 
 **20 QE Agents:** Test generation, coverage analysis, performance, security, flaky detection, QX analysis, accessibility
+**15 n8n Workflow Agents:** Workflow execution, chaos testing, compliance, security, performance *(contributed by [@fndlalit](https://github.com/fndlalit))*
 **11 QE Subagents:** TDD specialists, code reviewers, integration testers
-**41 QE Skills:** agentic-quality-engineering, tdd-london-chicago, api-testing-patterns, six-thinking-hats, brutal-honesty-review, sherlock-review, cicd-pipeline-qe-orchestrator, accessibility-testing, shift-left-testing, **testability-scoring** *(contributed by [@fndlalit](https://github.com/fndlalit))*
+**46 QE Skills:** agentic-quality-engineering, tdd-london-chicago, api-testing-patterns, six-thinking-hats, brutal-honesty-review, sherlock-review, cicd-pipeline-qe-orchestrator, accessibility-testing, shift-left-testing, n8n-workflow-testing, **testability-scoring** *(contributed by [@fndlalit](https://github.com/fndlalit))*
 **8 Slash Commands:** `/aqe-execute`, `/aqe-generate`, `/aqe-coverage`, `/aqe-quality`
 
 ### 📚 Complete Documentation
 
-- **[Agent Reference](docs/reference/agents.md)** - All 20 main agents + 11 subagents with capabilities and usage
-- **[Skills Reference](docs/reference/skills.md)** - All 41 QE skills organized by category
+- **[Agent Reference](docs/reference/agents.md)** - All 20 main QE agents + 15 n8n agents + 11 subagents with capabilities and usage
+- **[Skills Reference](docs/reference/skills.md)** - All 46 QE skills organized by category
 - **[Usage Guide](docs/reference/usage.md)** - Complete usage examples and workflows
 
 ### 🎯 Quick Start

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@
 [![Run in Smithery](https://smithery.ai/badge/skills/proffesor-for-testing)](https://smithery.ai/skills?ns=proffesor-for-testing&utm_source=github&utm_medium=badge)
 
 
-**Version 2.5.6** | [Changelog](CHANGELOG.md) | [Contributors](CONTRIBUTORS.md) | [Issues](https://github.com/proffesor-for-testing/agentic-qe/issues) | [Discussions](https://github.com/proffesor-for-testing/agentic-qe/discussions)
+**Version 2.5.7** | [Changelog](CHANGELOG.md) | [Contributors](CONTRIBUTORS.md) | [Issues](https://github.com/proffesor-for-testing/agentic-qe/issues) | [Discussions](https://github.com/proffesor-for-testing/agentic-qe/discussions)
 
 > AI-powered test automation that learns from every task, switches between 300+ AI models on-the-fly, scores code testability, visualizes agent activity in real-time, and improves autonomously overnight — with built-in safety guardrails and full observability.
 
-🎨 **Real-Time Visualization** | 📊 **Testability Scoring** | 🧠 **QE Agent Learning** | 🚀 **QUIC Transport** | 📋 **Constitution System** | 📚 **41 QE Skills** | 🎯 **Flaky Detection** | 💰 **Multi-Model Router**
+🎨 **Real-Time Visualization** | 📊 **Testability Scoring** | 🧠 **QE Agent Learning** | 🚀 **QUIC Transport** | 📋 **Constitution System** | 📚 **46 QE Skills** | 🎯 **Flaky Detection** | 💰 **Multi-Model Router** | 🔄 **n8n Workflow Testing**
 
 </div>
 
@@ -62,9 +62,10 @@ claude "Use qe-flaky-test-hunter to analyze the last 100 test runs and identify 
 - ✅ Learning System (20% improvement target)
 - ✅ Pattern Bank (cross-project reuse)
 - ✅ ML Flaky Detection (90%+ accuracy with root cause analysis)
-- ✅ 19 Specialized agent definitions (including qe-code-complexity)
+- ✅ 19 Specialized QE agent definitions (including qe-code-complexity)
+- ✅ 15 n8n workflow testing agents (workflow execution, chaos, compliance, security, performance by [@fndlalit](https://github.com/fndlalit))
 - ✅ 11 TDD subagent definitions (RED/GREEN/REFACTOR phases + specialized)
-- ✅ 41 World-class QE skills library (accessibility, shift-left/right, verification, visual testing, XP practices, **testability-scoring** by [@fndlalit](https://github.com/fndlalit))
+- ✅ 46 World-class QE skills library (accessibility, shift-left/right, verification, visual testing, XP practices, n8n testing, **testability-scoring** by [@fndlalit](https://github.com/fndlalit))
 - ✅ 8 AQE slash commands
 - ✅ Modular init system with comprehensive project setup
 

--- a/docs/reference/agents.md
+++ b/docs/reference/agents.md
@@ -1,6 +1,6 @@
 # Agentic QE Fleet - Agent Reference
 
-This document provides comprehensive reference for all 20 QE agents in the Agentic Quality Engineering Fleet.
+This document provides comprehensive reference for all 20 QE agents, 15 n8n workflow testing agents, and 11 subagents in the Agentic Quality Engineering Fleet.
 
 ## Overview
 
@@ -412,6 +412,95 @@ Task("Remediation", "Fix accessibility issues with code suggestions", "qe-a11y-a
 
 ---
 
+## n8n Workflow Testing Agents (15 agents)
+*Contributed by [@fndlalit](https://github.com/fndlalit)*
+
+The n8n workflow testing agents provide comprehensive testing capabilities for n8n automation workflows.
+
+### n8n-workflow-executor
+**Execute and validate n8n workflows programmatically**
+
+**Capabilities:**
+- Execute workflows via n8n REST API
+- Inject test data at workflow start or specific nodes
+- Validate node-to-node data flow
+- Assert expected outputs per node
+- Measure execution time and resource usage
+
+**Usage:**
+```javascript
+Task("Execute n8n workflow", "Test workflow with sample data", "n8n-workflow-executor")
+```
+
+---
+
+### n8n-chaos-tester
+**Fault injection and resilience testing for n8n workflows**
+
+**Capabilities:**
+- Controlled fault injection using N8nTestHarness
+- Network failure simulation
+- Node timeout testing
+- Error propagation validation
+- Recovery path verification
+
+---
+
+### n8n-security-auditor
+**Security scanning for n8n workflows**
+
+**Capabilities:**
+- 40+ secret patterns detection
+- Runtime credential leak detection
+- API key exposure scanning
+- Node permission validation
+- OWASP compliance checking
+
+---
+
+### n8n-performance-tester
+**Load and stress testing for n8n workflows**
+
+**Capabilities:**
+- Concurrent execution testing
+- Timing metrics and percentiles
+- Bottleneck identification
+- Resource usage monitoring
+- SLA validation
+
+---
+
+### n8n-compliance-validator
+**GDPR/HIPAA/SOC2/PCI-DSS compliance validation**
+
+**Capabilities:**
+- Data handling compliance checks
+- PII detection and tracing
+- Audit trail validation
+- Regulatory mapping
+- Compliance reporting
+
+---
+
+### Additional n8n Agents
+
+| Agent | Purpose |
+|-------|---------|
+| **n8n-bdd-scenario-tester** | Cucumber-style BDD testing with real execution |
+| **n8n-expression-validator** | Safe expression validation using pattern matching |
+| **n8n-integration-test** | Real API connectivity testing via workflow execution |
+| **n8n-trigger-test** | Webhook testing with correct n8n URL patterns |
+| **n8n-monitoring-validator** | SLA compliance checking with runtime metrics |
+| **n8n-node-validator** | Node configuration validation |
+| **n8n-unit-tester** | Unit testing for individual workflow nodes |
+| **n8n-version-comparator** | Version compatibility analysis |
+| **n8n-ci-orchestrator** | CI/CD pipeline integration for n8n workflows |
+| **n8n-base-agent** | Base agent with common n8n testing functionality |
+
+**Setup Guide:** [n8n Real Instance Setup](../guides/n8n-real-instance-setup.md)
+
+---
+
 ## MCP Tool Discovery System
 
 The Agentic QE Fleet uses **lazy-loaded MCP tools** to reduce initial context by 87%.
@@ -471,7 +560,7 @@ Task("Performance Test", "Load test critical paths", "qe-performance-tester")
 ---
 
 **Related Documentation:**
-- [Skills Reference](skills.md) - All 34 QE skills
+- [Skills Reference](skills.md) - All 46 QE skills
 - [Usage Guide](usage.md) - Complete usage examples
 - [AQE Hooks](../architecture/AQE-HOOKS.md) - Agent coordination details
 

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -1,6 +1,6 @@
 # Agentic QE Fleet - Skills Reference
 
-This document provides comprehensive reference for all 41 specialized QE skills available to agents.
+This document provides comprehensive reference for all 46 specialized QE skills available to agents.
 
 ## Overview
 
@@ -811,6 +811,101 @@ AUTO_OPEN=false node .claude/skills/testability-scoring/scripts/generate-html-re
 
 ---
 
+## n8n Workflow Testing Skills (5 skills)
+*Contributed by [@fndlalit](https://github.com/fndlalit)*
+
+These skills provide specialized knowledge for testing n8n automation workflows.
+
+### n8n-workflow-testing-fundamentals
+**Core concepts for testing n8n workflows**
+
+Understanding workflow structure, node types, and data flow patterns in n8n.
+
+**Key Topics:**
+- Workflow anatomy
+- Node configuration testing
+- Data transformation validation
+- Error handling patterns
+
+**Usage:**
+```javascript
+Skill("n8n-workflow-testing-fundamentals")
+```
+
+---
+
+### n8n-security-testing
+**Security testing for n8n workflows**
+
+Credential management, secret detection, and API security in n8n.
+
+**Key Topics:**
+- Credential auditing
+- Secret pattern detection
+- API key management
+- Permission validation
+
+**Usage:**
+```javascript
+Skill("n8n-security-testing")
+```
+
+---
+
+### n8n-integration-testing-patterns
+**Integration testing strategies for n8n**
+
+Testing external API connections and webhook interactions.
+
+**Key Topics:**
+- API connectivity testing
+- Webhook validation
+- Mock server patterns
+- Contract testing
+
+**Usage:**
+```javascript
+Skill("n8n-integration-testing-patterns")
+```
+
+---
+
+### n8n-expression-testing
+**Testing n8n expressions safely**
+
+Validating JavaScript expressions in n8n nodes without unsafe eval.
+
+**Key Topics:**
+- Expression patterns
+- Safe validation
+- Data access testing
+- Error handling
+
+**Usage:**
+```javascript
+Skill("n8n-expression-testing")
+```
+
+---
+
+### n8n-trigger-testing-strategies
+**Testing n8n workflow triggers**
+
+Webhook, schedule, and event-based trigger testing.
+
+**Key Topics:**
+- Webhook testing
+- Schedule validation
+- Event triggers
+- URL patterns
+
+**Usage:**
+```javascript
+Skill("n8n-trigger-testing-strategies")
+```
+
+---
+
 ## Using Skills
 
 ### Via CLI
@@ -851,7 +946,7 @@ All QE agents automatically have access to relevant skills based on their specia
 ---
 
 **Related Documentation:**
-- [Agent Reference](agents.md) - All 19 QE agents
+- [Agent Reference](agents.md) - All 19 QE agents + 15 n8n agents + 11 subagents
 - [Usage Guide](usage.md) - Complete usage examples
 
 **Related Policies:**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentic-qe",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentic-qe",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.64.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentic-qe",
-  "version": "2.5.6",
-  "description": "Agentic Quality Engineering Fleet System - AI-driven quality management platform with 41 QE skills, learning, pattern reuse, ML-based flaky detection, Multi-Model Router (70-81% cost savings), streaming progress updates, 85 MCP tools with lazy loading (87% context reduction), and native TypeScript hooks",
+  "version": "2.5.7",
+  "description": "Agentic Quality Engineering Fleet System - AI-driven quality management platform with 46 QE skills, n8n workflow testing agents, learning, pattern reuse, ML-based flaky detection, Multi-Model Router (70-81% cost savings), streaming progress updates, 85 MCP tools with lazy loading (87% context reduction), and native TypeScript hooks",
   "main": "dist/cli/index.js",
   "types": "dist/cli/index.d.ts",
   "bin": {

--- a/src/cli/init/agents.ts
+++ b/src/cli/init/agents.ts
@@ -124,6 +124,42 @@ export async function copyAgentTemplates(config?: FleetConfig, force: boolean = 
     console.log(chalk.green(`  ✓ Copied ${subagentsCopied} new subagent definitions (${subagentTemplates.length} total subagents)`));
   }
 
+  // Copy n8n folder if it exists (n8n workflow testing agents)
+  const n8nSourcePath = path.join(sourcePath, 'n8n');
+  const n8nTargetPath = path.join(targetPath, 'n8n');
+
+  if (await fs.pathExists(n8nSourcePath)) {
+    console.log(chalk.cyan('  📦 Copying n8n workflow testing agent definitions...'));
+    await fs.ensureDir(n8nTargetPath);
+
+    const n8nFiles = await fs.readdir(n8nSourcePath);
+    const n8nTemplates = n8nFiles.filter(f => f.endsWith('.md'));
+
+    let n8nCopied = 0;
+    let n8nUpdated = 0;
+
+    for (const n8nFile of n8nTemplates) {
+      const sourceFile = path.join(n8nSourcePath, n8nFile);
+      const targetFile = path.join(n8nTargetPath, n8nFile);
+
+      const targetExists = await fs.pathExists(targetFile);
+
+      if (!targetExists || force) {
+        await fs.copy(sourceFile, targetFile);
+        if (targetExists) {
+          n8nUpdated++;
+        } else {
+          n8nCopied++;
+        }
+      }
+    }
+
+    if (force && n8nUpdated > 0) {
+      console.log(chalk.green(`  ✓ Updated ${n8nUpdated} existing n8n agent definitions`));
+    }
+    console.log(chalk.green(`  ✓ Copied ${n8nCopied} new n8n agent definitions (${n8nTemplates.length} total n8n agents)`));
+  }
+
   if (force && updatedFiles > 0) {
     console.log(chalk.green(`  ✓ Updated ${updatedFiles} existing agent definitions`));
   }

--- a/src/cli/init/skills.ts
+++ b/src/cli/init/skills.ts
@@ -34,7 +34,7 @@ export async function copySkillTemplates(force: boolean = false): Promise<void> 
   await fs.ensureDir(targetPath);
 
   // QE-specific skill patterns (NOT claude-flow, github, flow-nexus, agentdb-*, hive-mind, hooks, performance-analysis, reasoningbank-*, sparc-methodology)
-  // Total: 41 QE skills (updated from 40 - added testability-scoring contributed by @fndlalit)
+  // Total: 46 QE skills (added 5 n8n testing skills contributed by @fndlalit)
   const QE_SKILL_PATTERNS = [
     /^accessibility-testing$/,
     /^agentic-quality-engineering$/,
@@ -55,6 +55,12 @@ export async function copySkillTemplates(force: boolean = false): Promise<void> 
     /^localization-testing$/,
     /^mobile-testing$/,
     /^mutation-testing$/,
+    // n8n workflow testing skills - Contributed by @fndlalit
+    /^n8n-expression-testing$/,
+    /^n8n-integration-testing-patterns$/,
+    /^n8n-security-testing$/,
+    /^n8n-trigger-testing-strategies$/,
+    /^n8n-workflow-testing-fundamentals$/,
     /^pair-programming$/,
     /^performance-testing$/,  // QE performance testing (NOT performance-analysis which is Claude Flow)
     /^quality-metrics$/,

--- a/src/core/memory/HNSWVectorMemory.ts
+++ b/src/core/memory/HNSWVectorMemory.ts
@@ -660,7 +660,7 @@ export class HNSWVectorMemory implements IPatternStore {
   } {
     return {
       type: 'agentdb',
-      version: '2.5.6',
+      version: '2.5.7',
       features: ['hnsw', 'vector-search', 'persistence', 'batch-operations'],
     };
   }

--- a/src/mcp/server-instructions.ts
+++ b/src/mcp/server-instructions.ts
@@ -117,7 +117,7 @@ Example: \`mcp__agentic_qe__test_generate_enhanced\`
 `;
 
 export const SERVER_NAME = 'agentic-qe';
-export const SERVER_VERSION = '2.5.6';
+export const SERVER_VERSION = '2.5.7';
 
 /**
  * Get formatted server info for MCP initialization


### PR DESCRIPTION
## Summary

- Add 15 n8n workflow testing agents contributed by [@fndlalit](https://github.com/fndlalit)
- Add 5 n8n testing skills to QE skill patterns
- Update `aqe init` to copy n8n agent directory to user projects
- Update all version files to v2.5.7
- Update documentation with n8n agent reference

## Changes

### New n8n Agents (15 total)
| Agent | Purpose |
|-------|---------|
| n8n-workflow-executor | Execute and validate workflows |
| n8n-node-validator | Validate node configurations |
| n8n-trigger-test | Test trigger mechanisms |
| n8n-expression-validator | Validate n8n expressions |
| n8n-integration-test | Test external integrations |
| n8n-security-auditor | Security vulnerability scanning |
| n8n-performance-tester | Performance benchmarking |
| n8n-chaos-tester | Resilience testing |
| n8n-compliance-validator | GDPR/SOC2 compliance |
| n8n-ci-orchestrator | CI/CD integration |
| + 5 more specialized agents |

### New n8n Skills (5 total)
- n8n-workflow-testing-fundamentals
- n8n-expression-testing
- n8n-trigger-testing-strategies
- n8n-integration-testing-patterns
- n8n-security-testing

## Files Updated (11 files)
- `package.json`, `package-lock.json` - version 2.5.7
- `README.md` - version badge, n8n agents line, 46 skills count
- `CHANGELOG.md` - v2.5.7 section
- `CLAUDE.md` - agent/skill counts
- `docs/reference/agents.md` - n8n section
- `docs/reference/skills.md` - n8n skills
- `src/cli/init/agents.ts` - n8n directory copying
- `src/cli/init/skills.ts` - n8n skill patterns
- `src/mcp/server-instructions.ts` - SERVER_VERSION
- `src/core/memory/HNSWVectorMemory.ts` - version

## Test plan
- [x] Verified `aqe init -y` creates all 46 skills including 5 n8n skills
- [x] Verified `aqe init -y` creates all 47 agents including 15 n8n agents
- [x] Tested n8n agents against real n8n cloud instance (security audit, node validation, execution analysis, compliance check)
- [x] All agents successfully connected and generated reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)