### PR TITLE
fix(deps): add missing fast-glob dependency (v2.6.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.4] - 2025-12-25
+
+### Fixed
+
+- **Missing `fast-glob` dependency** - Added `fast-glob` as explicit dependency to fix "Cannot find module 'fast-glob'" error when installing globally via `npm install -g agentic-qe`. The module was used in `ComponentBoundaryAnalyzer` but only available as a transitive dependency.
+
 ## [2.6.3] - 2025-12-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Run in Smithery](https://smithery.ai/badge/skills/proffesor-for-testing)](https://smithery.ai/skills?ns=proffesor-for-testing&utm_source=github&utm_medium=badge)
 
 
-**Version 2.6.3** | [Changelog](CHANGELOG.md) | [Contributors](CONTRIBUTORS.md) | [Issues](https://github.com/proffesor-for-testing/agentic-qe/issues) | [Discussions](https://github.com/proffesor-for-testing/agentic-qe/discussions)
+**Version 2.6.4** | [Changelog](CHANGELOG.md) | [Contributors](CONTRIBUTORS.md) | [Issues](https://github.com/proffesor-for-testing/agentic-qe/issues) | [Discussions](https://github.com/proffesor-for-testing/agentic-qe/discussions)
 
 > AI-powered test automation that learns from every task, switches between 300+ AI models on-the-fly, scores code testability, visualizes agent activity in real-time, and improves autonomously overnight — with built-in safety guardrails and full observability.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentic-qe",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentic-qe",
-      "version": "2.6.3",
+      "version": "2.6.4",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.64.0",
@@ -46,6 +46,7 @@
         "commander": "^14.0.1",
         "cors": "^2.8.5",
         "express": "^5.2.1",
+        "fast-glob": "^3.3.3",
         "fs-extra": "^11.1.1",
         "gpt-tokenizer": "^2.1.2",
         "graphql": "^16.11.0",
@@ -2596,7 +2597,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -2610,7 +2610,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -2620,7 +2619,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -9018,7 +9016,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -9065,7 +9062,6 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -11993,7 +11989,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -13232,7 +13227,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13477,7 +13471,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -13567,7 +13560,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-qe",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "description": "Agentic Quality Engineering Fleet System - AI-driven quality management platform with 46 QE skills, n8n workflow testing agents, learning, pattern reuse, ML-based flaky detection, Multi-Model Router (70-81% cost savings), streaming progress updates, 91 MCP tools with lazy loading (87% context reduction), and native TypeScript hooks",
   "main": "dist/cli/index.js",
   "types": "dist/cli/index.d.ts",
@@ -152,6 +152,7 @@
     "commander": "^14.0.1",
     "cors": "^2.8.5",
     "express": "^5.2.1",
+    "fast-glob": "^3.3.3",
     "fs-extra": "^11.1.1",
     "gpt-tokenizer": "^2.1.2",
     "graphql": "^16.11.0",

--- a/src/core/memory/HNSWVectorMemory.ts
+++ b/src/core/memory/HNSWVectorMemory.ts
@@ -660,7 +660,7 @@ export class HNSWVectorMemory implements IPatternStore {
   } {
     return {
       type: 'agentdb',
-      version: '2.6.2',
+      version: '2.6.4',
       features: ['hnsw', 'vector-search', 'persistence', 'batch-operations'],
     };
   }

--- a/src/mcp/server-instructions.ts
+++ b/src/mcp/server-instructions.ts
@@ -117,7 +117,7 @@ Example: \`mcp__agentic_qe__test_generate_enhanced\`
 `;
 
 export const SERVER_NAME = 'agentic-qe';
-export const SERVER_VERSION = '2.6.3';
+export const SERVER_VERSION = '2.6.4';
 
 /**
  * Get formatted server info for MCP initialization


### PR DESCRIPTION
## Summary

- **Fix missing `fast-glob` dependency** - Added `fast-glob` as explicit dependency to resolve "Cannot find module 'fast-glob'" error when installing globally via `npm install -g agentic-qe`
- The module was imported in `ComponentBoundaryAnalyzer` but only existed as a transitive dependency

## Root Cause

The `fast-glob` module is imported at `src/code-intelligence/inference/ComponentBoundaryAnalyzer.ts:17` but was never added to `package.json` dependencies. It worked locally because it came as a transitive dependency, but global npm installs don't reliably include transitive dependencies.

## Changes

| File | Change |
|------|--------|
| `package.json` | Added `fast-glob: ^3.3.3` to dependencies, bumped version to 2.6.4 |
| `package-lock.json` | Updated with new dependency |
| `CHANGELOG.md` | Added v2.6.4 release notes |
| `README.md` | Updated version badge |
| `src/mcp/server-instructions.ts` | Updated SERVER_VERSION |
| `src/core/memory/HNSWVectorMemory.ts` | Updated version in getImplementationInfo() |

## Test plan

- [x] Verified CLI works: `node dist/cli/index.js --version` returns `2.6.4`
- [x] Verified ComponentBoundaryAnalyzer loads without error
- [x] Ran `npm run test:fast` - 56 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)