### PR TITLE
feat(strange-loop): infrastructure self-healing extension (ADR-057)

### DIFF
--- a/v3/implementation/adrs/ADR-057-infra-self-healing.md
+++ b/v3/implementation/adrs/ADR-057-infra-self-healing.md
@@ -1,0 +1,236 @@
+# ADR-057: Infrastructure Self-Healing Extension for Strange Loop
+
+| Field | Value |
+|-------|-------|
+| **Decision ID** | ADR-057 |
+| **Status** | Accepted |
+| **Date** | 2026-02-02 |
+| **Author** | Architecture Team |
+| **Extends** | ADR-031 (Strange Loop Self-Awareness) |
+| **Review Cadence** | 6 months |
+
+---
+
+## WH(Y) Decision Statement
+
+**In the context of** Strange Loop (ADR-031) operating exclusively on swarm agent health metrics without visibility into infrastructure service availability during test execution,
+
+**facing** tests failing due to infrastructure outages (DB down, Redis unreachable, Selenium Grid unresponsive) being misclassified as test bugs or flaky tests, requiring manual operator intervention to restart services, and loss of test execution time while waiting for human response,
+
+**we decided for** extending Strange Loop through its existing DI seams (AgentProvider wrapping, ActionExecutor composition) to detect infrastructure failures from test output, classify them using OS-level error signatures, and execute YAML-driven recovery playbooks — all without modifying the core Observe-Model-Decide-Act cycle,
+
+**and neglected** modifying the core healing controller's decide/act logic directly, building a separate independent healing system, and hardcoding recovery commands per framework,
+
+**to achieve** automatic detection and recovery of infrastructure service failures during test execution across any test framework (Jest, Pytest, JUnit, etc.) with zero code changes — only YAML playbook customization needed, recovery within seconds instead of minutes-to-hours of manual intervention, and seamless composition with existing Strange Loop capabilities,
+
+**accepting that** pattern-based detection has false positive/negative risk for ambiguous error messages, shell-based recovery commands require appropriate host permissions, and the in-process coordination lock is single-node scoped (not distributed).
+
+---
+
+## Context
+
+Strange Loop (ADR-031) provides a continuous Observe-Model-Decide-Act cycle that detects and heals swarm agent health issues. However, it has no visibility into infrastructure services that test suites depend on. When a PostgreSQL database, Redis cache, or Selenium Grid goes down during test execution, the resulting test failures are observed only as degraded agent metrics — the system cannot distinguish "agent is slow" from "the database that the agent's tests depend on is offline."
+
+This gap leads to:
+- Wasted test execution cycles running tests against unavailable infrastructure
+- Manual operator intervention to restart services
+- Incorrect self-healing actions (e.g., restarting agents when the DB is down)
+- Extended downtime during CI/CD pipelines
+
+### Design Principle: Composition + Controlled Extension
+
+The extension primarily uses composition through existing DI interfaces, with minimal additive changes to the core controller:
+
+1. **AgentProvider** — wrapped by `InfraAwareAgentProvider` to inject synthetic infrastructure agents
+2. **ActionExecutor** — composed by `CompositeActionExecutor` to route infra actions to the recovery engine
+3. **SelfHealingController** — extended with new type union members, `restart_service`/`run_playbook_recovery` action handling, and infra-agent override logic in `mapVulnerabilityToAction()`
+
+The core `decide()` algorithm is unchanged — the same vulnerability-to-action mapping, bottleneck analysis, and deduplication logic handles infra agents naturally. The `act()` method was extended with two new action type cases that delegate to the executor.
+
+---
+
+## Architecture
+
+```
+TestOutputObserver ──> InfraAwareAgentProvider ──> SwarmObserver.observe()
+                                                        │
+                                              existing decide/act cycle
+                                                        │
+                                              CompositeActionExecutor
+                                                ├── swarm executor (existing)
+                                                └── InfraActionExecutor (new)
+                                                     ├── RecoveryPlaybook (YAML)
+                                                     └── CoordinationLock
+```
+
+### Components
+
+| Component | Responsibility |
+|-----------|---------------|
+| `TestOutputObserver` | Parse test stdout/stderr, pattern-match infra errors (ECONNREFUSED, ETIMEDOUT, etc.), classify as `test_bug` / `infra_failure` / `flaky` / `unknown` |
+| `RecoveryPlaybook` | Load YAML playbook, resolve `${VAR}` interpolation, provide `ServiceRecoveryPlan` per service |
+| `CoordinationLock` | In-process TTL-based mutex preventing duplicate recovery of the same service |
+| `InfraActionExecutor` | Execute recovery cycle: healthCheck → recover → backoff → verify |
+| `CompositeActionExecutor` | Route swarm actions to original executor, infra actions to `InfraActionExecutor` |
+| `InfraAwareAgentProvider` | Wrap `AgentProvider`, add synthetic infra agents with health derived from observer state |
+| `InfraHealingOrchestrator` | Top-level coordinator: `feedTestOutput()` → `runRecoveryCycle()` → stats |
+
+### Recovery Cycle
+
+1. **Health Check** — Confirm service is actually down (avoids recovering healthy services)
+2. **Recovery Commands** — Execute playbook commands in order (e.g., `docker compose up -d postgres`)
+3. **Backoff** — Exponential wait between retry attempts
+4. **Verification** — Confirm service is back up before reporting success
+
+### YAML Playbook Format
+
+```yaml
+version: "1.0.0"
+defaults:
+  timeoutMs: 10000
+  maxRetries: 3
+  backoffMs: [2000, 5000, 10000]
+
+services:
+  postgres:
+    description: "PostgreSQL database server"
+    healthCheck:
+      command: "pg_isready -h ${PGHOST:-localhost} -p ${PGPORT:-5432}"
+      timeoutMs: 5000
+    recover:
+      - command: "docker compose up -d postgres"
+        timeoutMs: 30000
+      - command: "sleep 3"
+        timeoutMs: 5000
+        required: false
+    verify:
+      command: "pg_isready -h ${PGHOST:-localhost} -p ${PGPORT:-5432}"
+      timeoutMs: 5000
+```
+
+---
+
+## Options Considered
+
+### Option 1: Composition via DI Seams (Selected)
+
+Extend Strange Loop through existing `AgentProvider` and `ActionExecutor` interfaces. Infrastructure services appear as synthetic agents. Recovery handled by YAML playbooks.
+
+**Pros:** Zero core modifications, framework-agnostic, YAML-driven configuration, seamless composition
+**Cons:** Indirect integration via synthetic agents adds conceptual complexity
+
+### Option 2: Direct Controller Modification (Rejected)
+
+Add infrastructure-specific logic directly into `SelfHealingController.decide()` and `.act()`.
+
+**Why rejected:** Violates the Open-Closed Principle. The controller's decision logic is well-tested and domain-specific to swarm health. Mixing infrastructure concerns would create coupling and maintenance burden.
+
+### Option 3: Separate Independent System (Rejected)
+
+Build a standalone infrastructure monitor with its own detection and recovery loop.
+
+**Why rejected:** Duplicates observation infrastructure. Cannot leverage existing Strange Loop's scheduling, safety mechanisms (max actions per cycle, cooldown), or statistics collection.
+
+---
+
+## Modifications to Existing Files
+
+| File | Change |
+|------|--------|
+| `types.ts` | Added 8 infra vulnerability types to `SwarmVulnerability['type']` union, 1 infra action type (`restart_service`) to `SelfHealingActionType` union |
+| `healing-controller.ts` | (1) Mapped 8 infra vulnerability types to `'restart_service'` in `typeToAction`. (2) Added infra-agent override in `mapVulnerabilityToAction()` — when target is `infra-*`, `single_point_of_failure` overrides to `restart_service`, other topology actions are suppressed. (3) Added `restart_service` case to `act()` that delegates to `this.executor.restartAgent()` |
+| `strange-loop.ts` | Added `createStrangeLoopWithInfraHealing()` and `createInMemoryStrangeLoopWithInfraHealing()` factory functions that wire `InfraAwareAgentProvider`, `CompositeActionExecutor`, and `InfraHealingOrchestrator` into `StrangeLoopOrchestrator` |
+| `index.ts` | Added barrel re-export of `./infra-healing/index.js` and new factory function exports |
+
+---
+
+## New Files
+
+| File | Purpose |
+|------|---------|
+| `infra-healing/types.ts` | All types, interfaces, config, stats |
+| `infra-healing/coordination-lock.ts` | In-process async mutex with TTL |
+| `infra-healing/test-output-observer.ts` | Pattern matching with 22+ error signatures |
+| `infra-healing/recovery-playbook.ts` | YAML loader with `${VAR}` interpolation |
+| `infra-healing/infra-action-executor.ts` | Recovery engine + NoOpCommandRunner + ShellCommandRunner |
+| `infra-healing/composite-action-executor.ts` | ActionExecutor router |
+| `infra-healing/infra-aware-agent-provider.ts` | AgentProvider wrapper |
+| `infra-healing/infra-healing-orchestrator.ts` | Top-level coordinator with factory functions |
+| `infra-healing/default-playbook.yaml` | Reference playbook template (8 services). **Not auto-loaded** — users must pass playbook content to factory functions. Exists as a copy-and-customize starting point. |
+| `infra-healing/index.ts` | Barrel exports |
+
+---
+
+## Integration Wiring
+
+The critical factory functions that wire everything together:
+
+```typescript
+// createStrangeLoopWithInfraHealing() (strange-loop.ts)
+// 1. Creates InfraHealingOrchestrator (observer + playbook + lock + executor)
+// 2. Wraps provider with InfraAwareAgentProvider
+// 3. Wraps executor with CompositeActionExecutor
+// 4. Constructs StrangeLoopOrchestrator with wrapped dependencies
+
+const { orchestrator, infraHealing } = createStrangeLoopWithInfraHealing({
+  provider, executor, commandRunner, playbook,
+});
+
+infraHealing.feedTestOutput(testStderr);
+await orchestrator.runCycle(); // detects degraded infra → heals via playbook
+```
+
+### Data Flow When Infrastructure Fails
+
+1. `infraHealing.feedTestOutput(stderr)` → `TestOutputObserver` classifies errors, marks `postgres` as failed
+2. `orchestrator.runCycle()` → `SwarmObserver.observe()` calls `InfraAwareAgentProvider.getAgents()`
+3. `InfraAwareAgentProvider` adds synthetic `infra-postgres` agent with `responsiveness: 0.0`
+4. `SwarmObserver.detectVulnerabilities()` detects `single_point_of_failure` for `infra-postgres`
+5. `SelfHealingController.decide()` → `mapVulnerabilityToAction()` overrides to `restart_service`
+6. `SelfHealingController.act()` → `executor.restartAgent('infra-postgres')`
+7. `CompositeActionExecutor.restartAgent()` detects `infra-` prefix → `infraExecutor.recoverService('postgres')`
+8. `InfraActionExecutor` runs healthCheck → recover → verify via `CommandRunner`
+
+### Configuration for Testing
+
+```typescript
+// Important: disable cooldown and increase max actions for integration tests
+const config = { actionCooldownMs: 0, maxActionsPerCycle: 10 };
+```
+
+The default `actionCooldownMs: 10000` prevents multiple actions within the same cycle, which blocks infra recovery from executing in tests. Set to `0` for deterministic testing.
+
+---
+
+## Test Coverage
+
+- **144 unit tests** across 6 test files (5 unit + 1 integration)
+- **238 total tests** (including existing strange-loop tests) with zero regressions
+- **14 integration tests** prove end-to-end wiring through `StrangeLoopOrchestrator`
+- Tests use `NoOpCommandRunner` for deterministic execution without shell dependencies
+- Coverage includes: pattern matching, classification, deduplication, YAML loading, variable interpolation, recovery cycle, lock coordination, TTL expiry, synthetic agent observation, vulnerability-to-action mapping, CompositeActionExecutor routing, stats propagation, multi-service failure handling
+
+---
+
+## Key Design Decisions
+
+1. **CommandRunner DI interface** — Shell execution abstracted behind `run(command, timeout) → CommandResult`. `NoOpCommandRunner` for tests, `ShellCommandRunner` for production using `child_process.execFile` (not `exec`) for security.
+
+2. **Synthetic agents** — Infrastructure services appear as `AgentNode` with `type: 'infrastructure'`, `role: 'specialist'`. Failing services get `responsiveness: 0.0`, triggering existing controller restart logic.
+
+3. **Framework-agnostic patterns** — Error signatures match OS-level errors (ECONNREFUSED, ETIMEDOUT, ENOTFOUND, ENOMEM, ENOSPC) that are identical regardless of Jest, Pytest, JUnit, or any other framework.
+
+4. **YAML playbook** — Users customize recovery via YAML configuration. Default playbook includes postgres, mysql, mongodb, redis, elasticsearch, rabbitmq, selenium-grid, and generic-service.
+
+5. **CoordinationLock** — In-process Map-based mutex with TTL auto-expiry. Prevents concurrent recovery attempts for the same service. Single-process scope (not distributed).
+
+### Security: Trust Boundary
+
+Playbook commands support `${VAR}` interpolation from environment variables. Since commands execute via `/bin/sh -c`, a poisoned environment variable (e.g. `PGHOST="localhost; rm -rf /"`) could inject arbitrary shell commands.
+
+**Mitigations:**
+- Playbook YAML must come from trusted configuration (source control, operator-managed)
+- Do NOT load playbooks from untrusted user input
+- Do NOT allow untrusted processes to set environment variables referenced by playbook commands
+- `ShellCommandRunner` uses `execFile` (not `exec`) and enforces timeouts and buffer limits
+- `default-playbook.yaml` is a reference template — it is never auto-loaded

--- a/v3/implementation/adrs/v3-adrs.md
+++ b/v3/implementation/adrs/v3-adrs.md
@@ -4,7 +4,7 @@
 **Date Range:** 2026-01-07 onwards
 **Status:** Phase 10 Complete (Skill Validation System - ADR-056 Implemented)
 **Decision Authority:** Architecture Team
-**Last Verified:** 2026-02-02 (ADR-001-056: 53 Implemented, 97 skills with trust tiers)
+**Last Verified:** 2026-02-02 (ADR-001-057: 54 Implemented, 97 skills with trust tiers)
 
 ---
 
@@ -68,6 +68,7 @@
 | [ADR-054](./ADR-054-a2a-protocol.md) | A2A Protocol Integration | **Proposed** | 2026-01-30 | Agent Cards for 68 agents, JSON-RPC 2.0, discovery endpoint |
 | [ADR-055](./ADR-055-a2ui-declarative-ui.md) | A2UI Declarative UI Strategy | **Proposed** | 2026-01-30 | 15+ components, QE catalog, WCAG 2.2, AG-UI state sync |
 | [ADR-056](./ADR-056-skill-validation-system.md) | Deterministic Skill Validation System | **Implemented** | 2026-02-02 | ✅ 46 Tier 3 skills, 52 validators, CLI commands (`aqe skill`, `aqe eval`) |
+| [ADR-057](./ADR-057-infra-self-healing.md) | Infrastructure Self-Healing Extension | **Implemented** | 2026-02-02 | ✅ Extends Strange Loop to detect and recover infrastructure failures |
 
 ---
 

--- a/v3/scripts/demo-infra-healing.ts
+++ b/v3/scripts/demo-infra-healing.ts
@@ -1,0 +1,286 @@
+#!/usr/bin/env npx tsx
+/**
+ * Interactive Demo: Infrastructure Self-Healing (ADR-057)
+ *
+ * Demonstrates the full pipeline using NoOpCommandRunner:
+ *   test stderr → classify → vulnerabilities → Strange Loop cycle → recovery
+ *
+ * Run: cd v3 && npx tsx scripts/demo-infra-healing.ts
+ */
+
+import { createInMemoryStrangeLoopWithInfraHealing } from '../src/strange-loop/strange-loop.js';
+import { NoOpCommandRunner } from '../src/strange-loop/infra-healing/infra-action-executor.js';
+import { createTestOutputObserver } from '../src/strange-loop/infra-healing/test-output-observer.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const DIVIDER = '─'.repeat(72);
+const THICK_DIVIDER = '═'.repeat(72);
+
+function header(title: string): void {
+  console.log(`\n${THICK_DIVIDER}`);
+  console.log(`  ${title}`);
+  console.log(THICK_DIVIDER);
+}
+
+function section(title: string): void {
+  console.log(`\n${DIVIDER}`);
+  console.log(`  ${title}`);
+  console.log(DIVIDER);
+}
+
+function log(label: string, value: unknown): void {
+  const str = typeof value === 'object' ? JSON.stringify(value, null, 2) : String(value);
+  console.log(`  ${label}: ${str}`);
+}
+
+// ============================================================================
+// Playbook (inline YAML for demo)
+// ============================================================================
+
+const DEMO_PLAYBOOK = `
+version: "1.0.0"
+defaults:
+  timeoutMs: 5000
+  maxRetries: 2
+  backoffMs: [1000, 2000]
+
+services:
+  postgres:
+    description: "PostgreSQL database"
+    healthCheck:
+      command: "pg_isready -h localhost -p 5432"
+      timeoutMs: 3000
+    recover:
+      - command: "docker compose up -d postgres"
+        timeoutMs: 10000
+      - command: "sleep 2"
+        timeoutMs: 5000
+        required: false
+    verify:
+      command: "pg_isready -h localhost -p 5432"
+      timeoutMs: 3000
+    maxRetries: 2
+    backoffMs: [1000, 2000]
+
+  redis:
+    description: "Redis cache"
+    healthCheck:
+      command: "redis-cli -h localhost -p 6379 ping"
+      timeoutMs: 2000
+    recover:
+      - command: "docker compose up -d redis"
+        timeoutMs: 10000
+    verify:
+      command: "redis-cli -h localhost -p 6379 ping"
+      timeoutMs: 2000
+    maxRetries: 2
+    backoffMs: [1000, 2000]
+
+  elasticsearch:
+    description: "Elasticsearch"
+    healthCheck:
+      command: "curl -sf http://localhost:9200/_cluster/health"
+      timeoutMs: 5000
+    recover:
+      - command: "docker compose up -d elasticsearch"
+        timeoutMs: 30000
+    verify:
+      command: "curl -sf http://localhost:9200/_cluster/health"
+      timeoutMs: 5000
+    maxRetries: 2
+    backoffMs: [2000, 5000]
+`;
+
+// ============================================================================
+// Scenarios
+// ============================================================================
+
+const SCENARIOS: Array<{ name: string; testOutput: string }> = [
+  {
+    name: 'Scenario 1: PostgreSQL Down',
+    testOutput: [
+      'PASS src/auth/login.test.ts',
+      'FAIL src/users/create.test.ts',
+      '  Error: connect ECONNREFUSED 127.0.0.1:5432',
+      '  at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1141:16)',
+      'FAIL src/users/list.test.ts',
+      '  Error: connect ECONNREFUSED 127.0.0.1:5432',
+      'Tests: 2 failed, 1 passed, 3 total',
+    ].join('\n'),
+  },
+  {
+    name: 'Scenario 2: Redis + Elasticsearch Down (Multi-Failure)',
+    testOutput: [
+      'FAIL src/cache/session.test.ts',
+      '  Error: connect ECONNREFUSED 127.0.0.1:6379',
+      '  at RedisClient.connect (redis.js:42)',
+      'FAIL src/search/index.test.ts',
+      '  Error: connect ECONNREFUSED 127.0.0.1:9200',
+      '  at SearchClient.ping (elastic.js:18)',
+      'FAIL src/cache/rate-limit.test.ts',
+      '  Error: connect ECONNREFUSED 127.0.0.1:6379',
+      'Tests: 3 failed, 0 passed, 3 total',
+    ].join('\n'),
+  },
+  {
+    name: 'Scenario 3: DNS + OOM (Resource Exhaustion)',
+    testOutput: [
+      'FAIL src/external/api-client.test.ts',
+      '  Error: getaddrinfo ENOTFOUND api.external-service.local',
+      'FAIL src/workers/processor.test.ts',
+      '  java.lang.OutOfMemoryError: Heap space',
+      '  at java.util.Arrays.copyOf(Arrays.java:3236)',
+      'Tests: 2 failed, 0 passed, 2 total',
+    ].join('\n'),
+  },
+  {
+    name: 'Scenario 4: Clean Run (No Failures)',
+    testOutput: [
+      'PASS src/auth/login.test.ts',
+      'PASS src/users/create.test.ts',
+      'PASS src/cache/session.test.ts',
+      'Tests: 3 passed, 3 total',
+      'Time: 4.2s',
+    ].join('\n'),
+  },
+];
+
+// ============================================================================
+// Main
+// ============================================================================
+
+async function main(): Promise<void> {
+  header('ADR-057: Infrastructure Self-Healing Demo');
+  console.log('  Using NoOpCommandRunner (no real shell execution)');
+  console.log('  All recovery commands are logged, not executed.\n');
+
+  // ── Step 1: Demonstrate standalone observer ──
+  section('STEP 1: TestOutputObserver — Pattern Matching');
+  const observer = createTestOutputObserver();
+
+  for (const scenario of SCENARIOS) {
+    console.log(`\n  >> ${scenario.name}`);
+    const result = observer.observe(scenario.testOutput);
+    log('    Lines parsed', result.totalLinesParsed);
+    log('    Infra failures', result.infraFailures.length);
+    log('    Vulnerabilities', result.vulnerabilities.length);
+
+    for (const vuln of result.vulnerabilities) {
+      console.log(`    [VULN] type=${vuln.type}  severity=${vuln.severity}  agent=${vuln.affectedAgents[0]}  action=${vuln.suggestedAction}`);
+    }
+
+    if (result.infraFailures.length === 0) {
+      console.log('    (clean output — no infrastructure issues detected)');
+    }
+  }
+
+  // ── Step 2: Full Strange Loop pipeline ──
+  section('STEP 2: Full Strange Loop Pipeline (NoOpCommandRunner)');
+
+  const runner = new NoOpCommandRunner();
+
+  // Configure: health checks fail (exit 1), recovery succeeds (exit 0), verify succeeds (exit 0)
+  runner.setResponse('pg_isready', { exitCode: 1, stderr: 'no response', stdout: '' });
+  runner.setResponse('docker compose up -d postgres', { exitCode: 0, stdout: 'Starting postgres...' });
+  runner.setResponse('redis-cli', { exitCode: 1, stderr: 'Could not connect' });
+  runner.setResponse('docker compose up -d redis', { exitCode: 0, stdout: 'Starting redis...' });
+  runner.setResponse('curl -sf http://localhost:9200', { exitCode: 1, stderr: 'Connection refused' });
+  runner.setResponse('docker compose up -d elasticsearch', { exitCode: 0, stdout: 'Starting elasticsearch...' });
+  // sleep commands always succeed (default)
+  // After recovery, health checks pass — set verify responses
+  // (NoOp returns first match, so we need a different approach for verify after recovery)
+  // For this demo, the verify will also use pg_isready which returns exit 1, showing a "failed" verify.
+  // To show a successful verify, we'd need stateful mock. Instead we'll show both paths.
+
+  const { orchestrator, infraHealing } = createInMemoryStrangeLoopWithInfraHealing(
+    'observer-0',
+    runner,
+    DEMO_PLAYBOOK,
+    { actionCooldownMs: 0, maxActionsPerCycle: 10 },
+  );
+
+  console.log('\n  >> Feeding Scenario 1 (PostgreSQL down) into full pipeline...');
+  infraHealing.feedTestOutput(SCENARIOS[0].testOutput);
+
+  console.log('  >> Running Strange Loop cycle...');
+  const cycleResult = await orchestrator.runCycle();
+
+  log('  Vulnerabilities observed', cycleResult.observation.vulnerabilities.length);
+  for (const v of cycleResult.observation.vulnerabilities) {
+    console.log(`    [VULN] type=${v.type}  severity=${v.severity}  agents=${v.affectedAgents.join(',')}`);
+  }
+  log('  Actions decided', cycleResult.actions.length);
+  log('  Results executed', cycleResult.results.length);
+  for (const result of cycleResult.results) {
+    console.log(`    [RESULT] type=${result.action.type}  target=${result.action.targetAgentId}  success=${result.success}  msg=${result.message}`);
+  }
+
+  console.log('\n  >> Commands the runner received:');
+  for (const call of runner.getCalls()) {
+    console.log(`    $ ${call.command}  (timeout: ${call.timeoutMs}ms)`);
+  }
+
+  const stats = infraHealing.getStats();
+  log('\n  Total observations', stats.totalObservations);
+  log('  Infra failures detected', stats.infraFailuresDetected);
+  log('  Recoveries attempted', stats.recoveriesAttempted);
+  log('  Recoveries succeeded', stats.recoveriesSucceeded);
+  log('  Recoveries failed', stats.recoveriesFailed);
+
+  // ── Step 3: Multi-service failure ──
+  section('STEP 3: Multi-Service Failure (Redis + Elasticsearch)');
+  runner.reset();
+
+  // Re-configure responses
+  runner.setResponse('redis-cli', { exitCode: 1, stderr: 'Could not connect' });
+  runner.setResponse('docker compose up -d redis', { exitCode: 0, stdout: 'Starting redis...' });
+  runner.setResponse('curl -sf http://localhost:9200', { exitCode: 1, stderr: 'Connection refused' });
+  runner.setResponse('docker compose up -d elasticsearch', { exitCode: 0, stdout: 'Starting elasticsearch...' });
+
+  const { orchestrator: orch2, infraHealing: ih2 } = createInMemoryStrangeLoopWithInfraHealing(
+    'observer-1',
+    runner,
+    DEMO_PLAYBOOK,
+    { actionCooldownMs: 0, maxActionsPerCycle: 10 },
+  );
+
+  console.log('\n  >> Feeding Scenario 2 (Redis + Elasticsearch down)...');
+  ih2.feedTestOutput(SCENARIOS[1].testOutput);
+
+  console.log('  >> Running Strange Loop cycle...');
+  const cycleResult2 = await orch2.runCycle();
+
+  log('  Vulnerabilities detected', cycleResult2.observation.vulnerabilities.length);
+  for (const v of cycleResult2.observation.vulnerabilities) {
+    console.log(`    [VULN] type=${v.type}  severity=${v.severity}  agents=${v.affectedAgents.join(',')}`);
+  }
+  log('  Actions decided', cycleResult2.actions.length);
+  log('  Results executed', cycleResult2.results.length);
+  for (const result of cycleResult2.results) {
+    console.log(`    [RESULT] type=${result.action.type}  target=${result.action.targetAgentId}  success=${result.success}`);
+  }
+
+  console.log('\n  >> Commands executed:');
+  for (const call of runner.getCalls()) {
+    console.log(`    $ ${call.command}`);
+  }
+
+  const stats2 = ih2.getStats();
+  log('\n  By-service stats', stats2.byService);
+
+  // ── Summary ──
+  header('Demo Complete');
+  console.log('  The pipeline correctly:');
+  console.log('  1. Parsed test output and classified infra errors');
+  console.log('  2. Generated SwarmVulnerability objects per service');
+  console.log('  3. Strange Loop detected degraded synthetic agents');
+  console.log('  4. Controller decided restart_service actions');
+  console.log('  5. CompositeActionExecutor routed to InfraActionExecutor');
+  console.log('  6. Recovery commands executed via NoOpCommandRunner');
+  console.log('  7. Stats tracked per-service failure/recovery counts\n');
+}
+
+main().catch(console.error);

--- a/v3/src/strange-loop/index.ts
+++ b/v3/src/strange-loop/index.ts
@@ -101,6 +101,9 @@ export {
   StrangeLoopOrchestrator,
   createStrangeLoopOrchestrator,
   createInMemoryStrangeLoop,
+  createStrangeLoopWithInfraHealing,
+  createInMemoryStrangeLoopWithInfraHealing,
+  type InfraHealingIntegrationOptions,
 } from './strange-loop.js';
 
 // Belief Reconciler (ADR-052)
@@ -120,3 +123,6 @@ export {
   type BeliefReconcilerEventType,
   type BeliefReconcilerEventListener,
 } from './belief-reconciler.js';
+
+// Infrastructure Self-Healing (ADR-057)
+export * from './infra-healing/index.js';

--- a/v3/src/strange-loop/infra-healing/composite-action-executor.ts
+++ b/v3/src/strange-loop/infra-healing/composite-action-executor.ts
@@ -1,0 +1,104 @@
+/**
+ * Composite Action Executor
+ * ADR-057: Infrastructure Self-Healing Extension
+ *
+ * Routes healing actions to the appropriate executor:
+ * - Swarm actions (spawn_redundant_agent, add_connection, etc.) → original swarm executor
+ * - Infrastructure actions (restart_service for infra-* agents) → InfraActionExecutor
+ *
+ * Implements the existing ActionExecutor interface so it's a drop-in replacement.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import type { SwarmHealthObservation } from '../types.js';
+import type { ActionExecutor } from '../healing-controller.js';
+import type { InfraActionExecutor } from './infra-action-executor.js';
+
+/**
+ * Check if an agent ID represents a synthetic infrastructure agent.
+ * Infrastructure agents are prefixed with 'infra-' by convention.
+ */
+function isInfraAgent(agentId: string | undefined): boolean {
+  return agentId?.startsWith('infra-') ?? false;
+}
+
+// ============================================================================
+// Composite Action Executor
+// ============================================================================
+
+/**
+ * Composes a swarm ActionExecutor with an InfraActionExecutor.
+ * Routes actions based on action type and target agent ID.
+ *
+ * For `restart_agent` actions targeting infra agents (infra-postgres, infra-redis),
+ * the action is routed to InfraActionExecutor for playbook-driven recovery.
+ */
+export class CompositeActionExecutor implements ActionExecutor {
+  private readonly swarmExecutor: ActionExecutor;
+  private readonly infraExecutor: InfraActionExecutor;
+
+  constructor(swarmExecutor: ActionExecutor, infraExecutor: InfraActionExecutor) {
+    this.swarmExecutor = swarmExecutor;
+    this.infraExecutor = infraExecutor;
+  }
+
+  // ============================================================================
+  // ActionExecutor Interface (delegated to swarm executor)
+  // ============================================================================
+
+  async spawnAgent(agentId: string, config?: Record<string, unknown>): Promise<string> {
+    return this.swarmExecutor.spawnAgent(agentId, config);
+  }
+
+  async terminateAgent(agentId: string): Promise<void> {
+    return this.swarmExecutor.terminateAgent(agentId);
+  }
+
+  async addConnection(sourceId: string, targetId: string): Promise<void> {
+    return this.swarmExecutor.addConnection(sourceId, targetId);
+  }
+
+  async removeConnection(sourceId: string, targetId: string): Promise<void> {
+    return this.swarmExecutor.removeConnection(sourceId, targetId);
+  }
+
+  async redistributeLoad(agentId: string): Promise<void> {
+    return this.swarmExecutor.redistributeLoad(agentId);
+  }
+
+  async restartAgent(agentId: string): Promise<void> {
+    // Route infra agents to infrastructure recovery
+    if (isInfraAgent(agentId)) {
+      const serviceName = agentId.replace(/^infra-/, '');
+      await this.infraExecutor.recoverService(serviceName, uuidv4());
+      return;
+    }
+    return this.swarmExecutor.restartAgent(agentId);
+  }
+
+  async promoteToCoordinator(agentId: string): Promise<void> {
+    return this.swarmExecutor.promoteToCoordinator(agentId);
+  }
+
+  async demoteCoordinator(agentId: string): Promise<void> {
+    return this.swarmExecutor.demoteCoordinator(agentId);
+  }
+
+  async observe(): Promise<SwarmHealthObservation> {
+    return this.swarmExecutor.observe();
+  }
+}
+
+// ============================================================================
+// Factory
+// ============================================================================
+
+/**
+ * Factory function for creating a CompositeActionExecutor.
+ */
+export function createCompositeActionExecutor(
+  swarmExecutor: ActionExecutor,
+  infraExecutor: InfraActionExecutor,
+): CompositeActionExecutor {
+  return new CompositeActionExecutor(swarmExecutor, infraExecutor);
+}

--- a/v3/src/strange-loop/infra-healing/coordination-lock.ts
+++ b/v3/src/strange-loop/infra-healing/coordination-lock.ts
@@ -1,0 +1,118 @@
+/**
+ * Coordination Lock
+ * ADR-057: Infrastructure Self-Healing Extension
+ *
+ * In-process async mutex keyed by service name.
+ * Prevents duplicate recovery attempts for the same infrastructure service.
+ * Includes TTL auto-expiry to prevent stale locks from blocking recovery.
+ */
+
+import type { CoordinationLockEntry, LockAcquireResult } from './types.js';
+
+// ============================================================================
+// Coordination Lock
+// ============================================================================
+
+/**
+ * Async mutex for coordinating infrastructure recovery operations.
+ * Keyed by service name — only one recovery can run per service at a time.
+ */
+export class CoordinationLock {
+  private locks: Map<string, CoordinationLockEntry> = new Map();
+  private readonly defaultTtlMs: number;
+
+  constructor(defaultTtlMs: number = 120_000) {
+    this.defaultTtlMs = defaultTtlMs;
+  }
+
+  /**
+   * Attempt to acquire the lock for a service.
+   * Returns immediately — does not block.
+   */
+  acquire(serviceName: string, holderId: string, ttlMs?: number): LockAcquireResult {
+    this.evictExpired();
+
+    const existing = this.locks.get(serviceName);
+    if (existing) {
+      return {
+        acquired: false,
+        currentHolder: existing.holderId,
+        expiresAt: existing.acquiredAt + existing.ttlMs,
+      };
+    }
+
+    const entry: CoordinationLockEntry = {
+      serviceName,
+      holderId,
+      acquiredAt: Date.now(),
+      ttlMs: ttlMs ?? this.defaultTtlMs,
+    };
+
+    this.locks.set(serviceName, entry);
+    return { acquired: true };
+  }
+
+  /**
+   * Release the lock for a service.
+   * Only the holder can release it.
+   * Returns true if the lock was released, false if not held or wrong holder.
+   */
+  release(serviceName: string, holderId: string): boolean {
+    const existing = this.locks.get(serviceName);
+    if (!existing) return false;
+    if (existing.holderId !== holderId) return false;
+
+    this.locks.delete(serviceName);
+    return true;
+  }
+
+  /**
+   * Check if a service is currently locked.
+   */
+  isLocked(serviceName: string): boolean {
+    this.evictExpired();
+    return this.locks.has(serviceName);
+  }
+
+  /**
+   * Get the lock entry for a service (if any).
+   */
+  getLock(serviceName: string): CoordinationLockEntry | undefined {
+    this.evictExpired();
+    return this.locks.get(serviceName);
+  }
+
+  /**
+   * Get all active (non-expired) locks.
+   */
+  getActiveLocks(): readonly CoordinationLockEntry[] {
+    this.evictExpired();
+    return Array.from(this.locks.values());
+  }
+
+  /**
+   * Force-release all locks (for shutdown/reset).
+   */
+  releaseAll(): void {
+    this.locks.clear();
+  }
+
+  /**
+   * Evict expired locks based on TTL.
+   */
+  private evictExpired(): void {
+    const now = Date.now();
+    for (const [serviceName, entry] of this.locks) {
+      if (now >= entry.acquiredAt + entry.ttlMs) {
+        this.locks.delete(serviceName);
+      }
+    }
+  }
+}
+
+/**
+ * Factory function for creating a CoordinationLock.
+ */
+export function createCoordinationLock(defaultTtlMs?: number): CoordinationLock {
+  return new CoordinationLock(defaultTtlMs);
+}

--- a/v3/src/strange-loop/infra-healing/default-playbook.yaml
+++ b/v3/src/strange-loop/infra-healing/default-playbook.yaml
@@ -1,0 +1,148 @@
+# Infrastructure Recovery Playbook
+# ADR-057: Infrastructure Self-Healing Extension for Strange Loop
+#
+# Each service entry defines:
+#   healthCheck: command that returns exit 0 if service is healthy
+#   recover: ordered list of recovery commands
+#   verify: command that returns exit 0 if recovery succeeded
+#
+# Framework-agnostic: change commands for your environment.
+# Supports ${VAR} interpolation from environment variables.
+
+version: "1.0.0"
+
+defaults:
+  timeoutMs: 10000
+  maxRetries: 3
+  backoffMs: [2000, 5000, 10000]
+
+services:
+  postgres:
+    description: "PostgreSQL database server"
+    healthCheck:
+      command: "pg_isready -h ${PGHOST:-localhost} -p ${PGPORT:-5432}"
+      timeoutMs: 5000
+    recover:
+      - command: "docker compose up -d postgres"
+        timeoutMs: 30000
+      - command: "sleep 3"
+        timeoutMs: 5000
+        required: false
+    verify:
+      command: "pg_isready -h ${PGHOST:-localhost} -p ${PGPORT:-5432}"
+      timeoutMs: 5000
+    maxRetries: 3
+    backoffMs: [3000, 5000, 10000]
+
+  mysql:
+    description: "MySQL database server"
+    healthCheck:
+      command: "mysqladmin ping -h ${MYSQL_HOST:-localhost} -P ${MYSQL_PORT:-3306} -u root"
+      timeoutMs: 5000
+    recover:
+      - command: "docker compose up -d mysql"
+        timeoutMs: 30000
+      - command: "sleep 5"
+        timeoutMs: 10000
+        required: false
+    verify:
+      command: "mysqladmin ping -h ${MYSQL_HOST:-localhost} -P ${MYSQL_PORT:-3306} -u root"
+      timeoutMs: 5000
+    maxRetries: 3
+    backoffMs: [3000, 5000, 10000]
+
+  mongodb:
+    description: "MongoDB database server"
+    healthCheck:
+      command: "mongosh --host ${MONGO_HOST:-localhost} --port ${MONGO_PORT:-27017} --eval 'db.runCommand({ping:1})' --quiet"
+      timeoutMs: 5000
+    recover:
+      - command: "docker compose up -d mongodb"
+        timeoutMs: 30000
+      - command: "sleep 3"
+        timeoutMs: 5000
+        required: false
+    verify:
+      command: "mongosh --host ${MONGO_HOST:-localhost} --port ${MONGO_PORT:-27017} --eval 'db.runCommand({ping:1})' --quiet"
+      timeoutMs: 5000
+    maxRetries: 3
+    backoffMs: [3000, 5000, 10000]
+
+  redis:
+    description: "Redis cache server"
+    healthCheck:
+      command: "redis-cli -h ${REDIS_HOST:-localhost} -p ${REDIS_PORT:-6379} ping"
+      timeoutMs: 3000
+    recover:
+      - command: "docker compose up -d redis"
+        timeoutMs: 15000
+    verify:
+      command: "redis-cli -h ${REDIS_HOST:-localhost} -p ${REDIS_PORT:-6379} ping"
+      timeoutMs: 3000
+    maxRetries: 3
+    backoffMs: [2000, 3000, 5000]
+
+  elasticsearch:
+    description: "Elasticsearch search engine"
+    healthCheck:
+      command: "curl -sf http://${ES_HOST:-localhost}:${ES_PORT:-9200}/_cluster/health -o /dev/null"
+      timeoutMs: 10000
+    recover:
+      - command: "docker compose up -d elasticsearch"
+        timeoutMs: 45000
+      - command: "sleep 10"
+        timeoutMs: 15000
+        required: false
+    verify:
+      command: "curl -sf http://${ES_HOST:-localhost}:${ES_PORT:-9200}/_cluster/health -o /dev/null"
+      timeoutMs: 10000
+    maxRetries: 2
+    backoffMs: [5000, 15000]
+
+  rabbitmq:
+    description: "RabbitMQ message broker"
+    healthCheck:
+      command: "rabbitmq-diagnostics -q ping"
+      timeoutMs: 5000
+    recover:
+      - command: "docker compose up -d rabbitmq"
+        timeoutMs: 30000
+      - command: "sleep 5"
+        timeoutMs: 10000
+        required: false
+    verify:
+      command: "rabbitmq-diagnostics -q ping"
+      timeoutMs: 5000
+    maxRetries: 3
+    backoffMs: [3000, 5000, 10000]
+
+  selenium-grid:
+    description: "Selenium Grid browser automation hub"
+    healthCheck:
+      command: "curl -sf http://${SELENIUM_HOST:-localhost}:${SELENIUM_PORT:-4444}/status -o /dev/null"
+      timeoutMs: 5000
+    recover:
+      - command: "docker compose restart selenium-hub selenium-node-chrome"
+        timeoutMs: 45000
+      - command: "sleep 5"
+        timeoutMs: 10000
+        required: false
+    verify:
+      command: "curl -sf http://${SELENIUM_HOST:-localhost}:${SELENIUM_PORT:-4444}/status -o /dev/null"
+      timeoutMs: 5000
+    maxRetries: 2
+    backoffMs: [5000, 10000]
+
+  generic-service:
+    description: "Generic HTTP service"
+    healthCheck:
+      command: "curl -sf http://${SERVICE_HOST:-localhost}:${SERVICE_PORT:-8080}/health -o /dev/null"
+      timeoutMs: 5000
+    recover:
+      - command: "docker compose up -d ${SERVICE_NAME:-app}"
+        timeoutMs: 30000
+    verify:
+      command: "curl -sf http://${SERVICE_HOST:-localhost}:${SERVICE_PORT:-8080}/health -o /dev/null"
+      timeoutMs: 5000
+    maxRetries: 3
+    backoffMs: [3000, 5000, 10000]

--- a/v3/src/strange-loop/infra-healing/index.ts
+++ b/v3/src/strange-loop/infra-healing/index.ts
@@ -1,0 +1,78 @@
+/**
+ * Infrastructure Self-Healing Module
+ * ADR-057: Infrastructure Self-Healing Extension for Strange Loop
+ *
+ * Extends the Strange Loop self-awareness system to detect and recover from
+ * infrastructure failures during test execution. Framework-agnostic via
+ * YAML-driven recovery playbooks.
+ *
+ * @module strange-loop/infra-healing
+ */
+
+// Types
+export type {
+  TestOutputClassification,
+  InfraErrorSignature,
+  ClassifiedError,
+  TestOutputObservation,
+  CommandRunner,
+  CommandResult,
+  RecoveryCommand,
+  ServiceRecoveryPlan,
+  RecoveryPlaybookConfig,
+  CoordinationLockEntry,
+  LockAcquireResult,
+  RecoveryAttemptResult,
+  ServiceRecoveryResult,
+  InfraHealingConfig,
+  InfraHealingStats,
+} from './types.js';
+
+export { DEFAULT_INFRA_HEALING_CONFIG, createEmptyStats } from './types.js';
+
+// Test Output Observer
+export {
+  TestOutputObserver,
+  createTestOutputObserver,
+  DEFAULT_ERROR_SIGNATURES,
+} from './test-output-observer.js';
+
+// Recovery Playbook
+export {
+  RecoveryPlaybook,
+  createRecoveryPlaybook,
+} from './recovery-playbook.js';
+
+// Coordination Lock
+export {
+  CoordinationLock,
+  createCoordinationLock,
+} from './coordination-lock.js';
+
+// Infrastructure Action Executor
+export {
+  InfraActionExecutor,
+  createInfraActionExecutor,
+  NoOpCommandRunner,
+  ShellCommandRunner,
+} from './infra-action-executor.js';
+
+// Composite Action Executor
+export {
+  CompositeActionExecutor,
+  createCompositeActionExecutor,
+} from './composite-action-executor.js';
+
+// Infrastructure-Aware Agent Provider
+export {
+  InfraAwareAgentProvider,
+  createInfraAwareAgentProvider,
+} from './infra-aware-agent-provider.js';
+
+// Orchestrator
+export {
+  InfraHealingOrchestrator,
+  createInfraHealingOrchestrator,
+  createInfraHealingOrchestratorSync,
+  type InfraHealingOrchestratorOptions,
+} from './infra-healing-orchestrator.js';

--- a/v3/src/strange-loop/infra-healing/infra-action-executor.ts
+++ b/v3/src/strange-loop/infra-healing/infra-action-executor.ts
@@ -1,0 +1,331 @@
+/**
+ * Infrastructure Action Executor
+ * ADR-057: Infrastructure Self-Healing Extension
+ *
+ * Executes infrastructure recovery using a health-check → recover → backoff → verify
+ * cycle. Uses CommandRunner (DI) for shell execution so tests can inject NoOpCommandRunner.
+ *
+ * This is NOT an ActionExecutor implementation — it's the recovery engine that
+ * CompositeActionExecutor delegates to for infrastructure-specific actions.
+ */
+
+import type {
+  CommandRunner,
+  CommandResult,
+  ServiceRecoveryPlan,
+  RecoveryAttemptResult,
+  ServiceRecoveryResult,
+  InfraHealingStats,
+} from './types.js';
+import { createEmptyStats } from './types.js';
+import type { RecoveryPlaybook } from './recovery-playbook.js';
+import type { CoordinationLock } from './coordination-lock.js';
+
+// ============================================================================
+// NoOp Command Runner (for testing)
+// ============================================================================
+
+/**
+ * NoOp command runner for testing — follows existing NoOpActionExecutor pattern.
+ * Returns configurable results per command.
+ */
+export class NoOpCommandRunner implements CommandRunner {
+  private responses: Map<string, CommandResult> = new Map();
+  private callLog: Array<{ command: string; timeoutMs: number }> = [];
+
+  async run(command: string, timeoutMs: number): Promise<CommandResult> {
+    this.callLog.push({ command, timeoutMs });
+
+    const result =
+      this.responses.get(command) ??
+      this.findPrefixMatch(command) ??
+      { exitCode: 0, stdout: '', stderr: '', durationMs: 10, timedOut: false };
+
+    return result;
+  }
+
+  /** Configure a response for a specific command */
+  setResponse(command: string, result: Partial<CommandResult>): void {
+    this.responses.set(command, {
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      durationMs: 10,
+      timedOut: false,
+      ...result,
+    });
+  }
+
+  /** Get the call log for assertions */
+  getCalls(): ReadonlyArray<{ command: string; timeoutMs: number }> {
+    return this.callLog;
+  }
+
+  /** Clear call log and responses */
+  reset(): void {
+    this.callLog = [];
+    this.responses.clear();
+  }
+
+  private findPrefixMatch(command: string): CommandResult | undefined {
+    for (const [key, value] of this.responses) {
+      if (command.startsWith(key)) return value;
+    }
+    return undefined;
+  }
+}
+
+// ============================================================================
+// Shell Command Runner (real implementation)
+// ============================================================================
+
+/**
+ * Real command runner using child_process.execFile for security.
+ * Wraps commands in sh -c for shell interpretation.
+ */
+export class ShellCommandRunner implements CommandRunner {
+  async run(command: string, timeoutMs: number): Promise<CommandResult> {
+    const { execFile } = await import('node:child_process');
+    const startTime = Date.now();
+
+    return new Promise<CommandResult>((resolve) => {
+      const child = execFile(
+        '/bin/sh',
+        ['-c', command],
+        { timeout: timeoutMs, maxBuffer: 1024 * 1024 },
+        (error, stdout, stderr) => {
+          const durationMs = Date.now() - startTime;
+          const timedOut = (error?.message?.includes('TIMEOUT') ||
+            (error as NodeJS.ErrnoException)?.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER') ?? false;
+
+          const errWithCode = error as NodeJS.ErrnoException & { code?: string | number } | null;
+          const exitCode = error ? (typeof errWithCode?.code === 'number' ? errWithCode.code : 1) : 0;
+          resolve({
+            exitCode,
+            stdout: stdout ?? '',
+            stderr: stderr ?? '',
+            durationMs,
+            timedOut,
+          });
+        },
+      );
+
+      // Handle kill timeout
+      child.on('error', () => {
+        resolve({
+          exitCode: 1,
+          stdout: '',
+          stderr: 'Process execution error',
+          durationMs: Date.now() - startTime,
+          timedOut: false,
+        });
+      });
+    });
+  }
+}
+
+// ============================================================================
+// Infrastructure Action Executor
+// ============================================================================
+
+/**
+ * Executes infrastructure recovery for a specific service using:
+ * 1. Health check — confirm service is actually down
+ * 2. Recovery commands — run in order
+ * 3. Exponential backoff — wait between retries
+ * 4. Verification — confirm service is back up
+ */
+export class InfraActionExecutor {
+  private readonly runner: CommandRunner;
+  private readonly playbook: RecoveryPlaybook;
+  private readonly lock: CoordinationLock;
+  private readonly stats: InfraHealingStats;
+
+  constructor(
+    runner: CommandRunner,
+    playbook: RecoveryPlaybook,
+    lock: CoordinationLock,
+  ) {
+    this.runner = runner;
+    this.playbook = playbook;
+    this.lock = lock;
+    this.stats = createEmptyStats();
+  }
+
+  /**
+   * Attempt to recover a service using its playbook entry.
+   * Acquires a coordination lock to prevent duplicate recovery.
+   */
+  async recoverService(serviceName: string, actionId: string): Promise<ServiceRecoveryResult> {
+    const plan = this.playbook.getRecoveryPlan(serviceName);
+    if (!plan) {
+      return {
+        serviceName,
+        recovered: false,
+        totalAttempts: 0,
+        attempts: [],
+        totalDurationMs: 0,
+        escalated: true,
+      };
+    }
+
+    // Acquire lock
+    const lockResult = this.lock.acquire(serviceName, actionId);
+    if (!lockResult.acquired) {
+      this.stats.lockContentionEvents++;
+      return {
+        serviceName,
+        recovered: false,
+        totalAttempts: 0,
+        attempts: [],
+        totalDurationMs: 0,
+        escalated: false,
+      };
+    }
+
+    const startTime = Date.now();
+    const attempts: RecoveryAttemptResult[] = [];
+    let recovered = false;
+
+    try {
+      this.stats.recoveriesAttempted++;
+      this.updateServiceStats(serviceName, 'recoveries');
+
+      for (let attempt = 1; attempt <= plan.maxRetries; attempt++) {
+        const result = await this.executeRecoveryAttempt(plan, attempt);
+        attempts.push(result);
+
+        if (result.success) {
+          recovered = true;
+          this.stats.recoveriesSucceeded++;
+          this.updateServiceStats(serviceName, 'successes');
+          break;
+        }
+
+        // Backoff before next attempt (unless last attempt)
+        if (attempt < plan.maxRetries) {
+          const backoffMs = plan.backoffMs[attempt - 1] ?? plan.backoffMs[plan.backoffMs.length - 1] ?? 2000;
+          await this.sleep(backoffMs);
+        }
+      }
+
+      if (!recovered) {
+        this.stats.recoveriesFailed++;
+      }
+    } finally {
+      this.lock.release(serviceName, actionId);
+    }
+
+    return {
+      serviceName,
+      recovered,
+      totalAttempts: attempts.length,
+      attempts,
+      totalDurationMs: Date.now() - startTime,
+      escalated: !recovered,
+    };
+  }
+
+  /**
+   * Get recovery statistics.
+   */
+  getStats(): Readonly<InfraHealingStats> {
+    return this.stats;
+  }
+
+  // ============================================================================
+  // Private Methods
+  // ============================================================================
+
+  private async executeRecoveryAttempt(
+    plan: ServiceRecoveryPlan,
+    attempt: number,
+  ): Promise<RecoveryAttemptResult> {
+    const startTime = Date.now();
+
+    // 1. Health check — confirm service is actually down
+    const healthCheckResult = await this.runner.run(
+      plan.healthCheck.command,
+      plan.healthCheck.timeoutMs,
+    );
+
+    // If health check passes, service is already up
+    if (healthCheckResult.exitCode === 0) {
+      return {
+        serviceName: plan.serviceName,
+        success: true,
+        attempt,
+        healthCheckResult,
+        recoveryResults: [],
+        durationMs: Date.now() - startTime,
+        attemptedAt: startTime,
+      };
+    }
+
+    // 2. Execute recovery commands in order
+    const recoveryResults: CommandResult[] = [];
+    for (const cmd of plan.recover) {
+      const result = await this.runner.run(cmd.command, cmd.timeoutMs);
+      recoveryResults.push(result);
+
+      if (result.exitCode !== 0 && cmd.required) {
+        return {
+          serviceName: plan.serviceName,
+          success: false,
+          attempt,
+          healthCheckResult,
+          recoveryResults,
+          durationMs: Date.now() - startTime,
+          error: `Required recovery command failed: ${cmd.command}`,
+          attemptedAt: startTime,
+        };
+      }
+    }
+
+    // 3. Verify recovery
+    const verifyResult = await this.runner.run(
+      plan.verify.command,
+      plan.verify.timeoutMs,
+    );
+
+    const success = verifyResult.exitCode === 0;
+
+    return {
+      serviceName: plan.serviceName,
+      success,
+      attempt,
+      healthCheckResult,
+      recoveryResults,
+      verifyResult,
+      durationMs: Date.now() - startTime,
+      error: success ? undefined : 'Verification failed after recovery',
+      attemptedAt: startTime,
+    };
+  }
+
+  private updateServiceStats(serviceName: string, field: 'failures' | 'recoveries' | 'successes'): void {
+    if (!this.stats.byService[serviceName]) {
+      this.stats.byService[serviceName] = { failures: 0, recoveries: 0, successes: 0 };
+    }
+    this.stats.byService[serviceName][field]++;
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}
+
+// ============================================================================
+// Factory
+// ============================================================================
+
+/**
+ * Factory function for creating an InfraActionExecutor.
+ */
+export function createInfraActionExecutor(
+  runner: CommandRunner,
+  playbook: RecoveryPlaybook,
+  lock: CoordinationLock,
+): InfraActionExecutor {
+  return new InfraActionExecutor(runner, playbook, lock);
+}

--- a/v3/src/strange-loop/infra-healing/infra-aware-agent-provider.ts
+++ b/v3/src/strange-loop/infra-healing/infra-aware-agent-provider.ts
@@ -1,0 +1,136 @@
+/**
+ * Infrastructure-Aware Agent Provider
+ * ADR-057: Infrastructure Self-Healing Extension
+ *
+ * Wraps an existing AgentProvider and enriches it with synthetic "agents"
+ * representing infrastructure services. When a service is down (detected by
+ * TestOutputObserver), the synthetic agent's health metrics reflect the failure,
+ * causing the existing Strange Loop to detect it as a vulnerability and trigger
+ * healing actions.
+ */
+
+import type { AgentNode, AgentHealthMetrics, CommunicationEdge } from '../types.js';
+import type { AgentProvider } from '../swarm-observer.js';
+import type { TestOutputObserver } from './test-output-observer.js';
+import type { RecoveryPlaybook } from './recovery-playbook.js';
+
+// ============================================================================
+// Infrastructure-Aware Agent Provider
+// ============================================================================
+
+/**
+ * Wraps an AgentProvider and adds synthetic infrastructure agents.
+ * Each service in the recovery playbook becomes a synthetic agent.
+ * Health metrics are derived from the TestOutputObserver's last observation.
+ */
+export class InfraAwareAgentProvider implements AgentProvider {
+  private readonly delegate: AgentProvider;
+  private readonly observer: TestOutputObserver;
+  private readonly playbook: RecoveryPlaybook;
+  private readonly prefix: string;
+
+  constructor(
+    delegate: AgentProvider,
+    observer: TestOutputObserver,
+    playbook: RecoveryPlaybook,
+    infraAgentPrefix: string = 'infra-',
+  ) {
+    this.delegate = delegate;
+    this.observer = observer;
+    this.playbook = playbook;
+    this.prefix = infraAgentPrefix;
+  }
+
+  /**
+   * Get all agents: real swarm agents + synthetic infra agents.
+   */
+  async getAgents(): Promise<AgentNode[]> {
+    const realAgents = await this.delegate.getAgents();
+    const infraAgents = this.createInfraAgents();
+    return [...realAgents, ...infraAgents];
+  }
+
+  /**
+   * Get communication edges: real edges only (infra agents don't communicate).
+   */
+  async getEdges(): Promise<CommunicationEdge[]> {
+    return this.delegate.getEdges();
+  }
+
+  /**
+   * Get agent health. For infra agents, derive from observer state.
+   */
+  async getAgentHealth(agentId: string): Promise<AgentHealthMetrics> {
+    if (agentId.startsWith(this.prefix)) {
+      return this.getInfraAgentHealth(agentId);
+    }
+    return this.delegate.getAgentHealth(agentId);
+  }
+
+  /**
+   * Get observer ID (delegates to wrapped provider).
+   */
+  getObserverId(): string {
+    return this.delegate.getObserverId();
+  }
+
+  // ============================================================================
+  // Private Methods
+  // ============================================================================
+
+  /**
+   * Create synthetic AgentNode for each service in the playbook.
+   */
+  private createInfraAgents(): AgentNode[] {
+    const services = this.playbook.listServices();
+    const failingServices = this.observer.getFailingServices();
+
+    return services.map((serviceName) => ({
+      id: `${this.prefix}${serviceName}`,
+      type: 'infrastructure',
+      role: 'specialist' as const,
+      status: failingServices.has(serviceName) ? 'degraded' as const : 'active' as const,
+      joinedAt: Date.now(),
+      metadata: { serviceName, isInfraAgent: true },
+    }));
+  }
+
+  /**
+   * Get health metrics for a synthetic infra agent.
+   * Failing services get responsiveness=0, healthy services get 1.0.
+   */
+  private getInfraAgentHealth(agentId: string): AgentHealthMetrics {
+    const serviceName = agentId.replace(new RegExp(`^${this.prefix}`), '');
+    const failingServices = this.observer.getFailingServices();
+    const isFailing = failingServices.has(serviceName);
+
+    return {
+      responsiveness: isFailing ? 0.0 : 1.0,
+      taskCompletionRate: isFailing ? 0.0 : 1.0,
+      memoryUtilization: 0.1,
+      cpuUtilization: 0.1,
+      activeConnections: 0,
+      isBottleneck: false,
+      degree: 0,
+      queuedTasks: 0,
+      lastHeartbeat: isFailing ? 0 : Date.now(),
+      errorRate: isFailing ? 1.0 : 0.0,
+    };
+  }
+}
+
+// ============================================================================
+// Factory
+// ============================================================================
+
+/**
+ * Factory function for creating an InfraAwareAgentProvider.
+ */
+export function createInfraAwareAgentProvider(
+  delegate: AgentProvider,
+  observer: TestOutputObserver,
+  playbook: RecoveryPlaybook,
+  infraAgentPrefix?: string,
+): InfraAwareAgentProvider {
+  return new InfraAwareAgentProvider(delegate, observer, playbook, infraAgentPrefix);
+}

--- a/v3/src/strange-loop/infra-healing/infra-healing-orchestrator.ts
+++ b/v3/src/strange-loop/infra-healing/infra-healing-orchestrator.ts
@@ -1,0 +1,271 @@
+/**
+ * Infrastructure Healing Orchestrator
+ * ADR-057: Infrastructure Self-Healing Extension
+ *
+ * Top-level coordinator that wires TestOutputObserver, InfraActionExecutor,
+ * RecoveryPlaybook, and CoordinationLock together. Provides a simple API:
+ *
+ *   const orchestrator = createInfraHealingOrchestrator({ ... });
+ *   orchestrator.feedTestOutput(testStderr);
+ *   const result = await orchestrator.runRecoveryCycle();
+ *
+ * Designed to work alongside (not replace) the existing StrangeLoopOrchestrator.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import type {
+  InfraHealingConfig,
+  InfraHealingStats,
+  CommandRunner,
+  ServiceRecoveryResult,
+} from './types.js';
+import { DEFAULT_INFRA_HEALING_CONFIG, createEmptyStats } from './types.js';
+import { TestOutputObserver, createTestOutputObserver } from './test-output-observer.js';
+import { RecoveryPlaybook, createRecoveryPlaybook } from './recovery-playbook.js';
+import { CoordinationLock, createCoordinationLock } from './coordination-lock.js';
+import { InfraActionExecutor, createInfraActionExecutor } from './infra-action-executor.js';
+import type { InfraErrorSignature } from './types.js';
+
+// ============================================================================
+// Orchestrator Options
+// ============================================================================
+
+/**
+ * Options for creating an InfraHealingOrchestrator.
+ * All dependencies injected via this options object.
+ */
+export interface InfraHealingOrchestratorOptions {
+  /** Command runner for shell execution (inject NoOpCommandRunner for tests) */
+  commandRunner: CommandRunner;
+  /** YAML playbook content (string) or path to YAML file */
+  playbook: string;
+  /** Whether playbook is a file path (true) or inline YAML (false) */
+  playbookIsFile?: boolean;
+  /** Custom error signatures (extends defaults) */
+  customSignatures?: readonly InfraErrorSignature[];
+  /** Variable overrides for playbook interpolation */
+  variables?: Record<string, string>;
+  /** Configuration overrides */
+  config?: Partial<InfraHealingConfig>;
+}
+
+// ============================================================================
+// Infrastructure Healing Orchestrator
+// ============================================================================
+
+/**
+ * Orchestrates infrastructure self-healing during test execution.
+ *
+ * Usage:
+ * 1. Create with createInfraHealingOrchestrator()
+ * 2. Call feedTestOutput() with test runner stderr/stdout
+ * 3. Call runRecoveryCycle() to detect and recover failing services
+ * 4. Call getStats() to check recovery metrics
+ */
+export class InfraHealingOrchestrator {
+  private readonly observer: TestOutputObserver;
+  private readonly playbook: RecoveryPlaybook;
+  private readonly lock: CoordinationLock;
+  private readonly executor: InfraActionExecutor;
+  private readonly config: InfraHealingConfig;
+  private readonly stats: InfraHealingStats;
+  private initialized = false;
+
+  constructor(
+    observer: TestOutputObserver,
+    playbook: RecoveryPlaybook,
+    lock: CoordinationLock,
+    executor: InfraActionExecutor,
+    config: InfraHealingConfig,
+  ) {
+    this.observer = observer;
+    this.playbook = playbook;
+    this.lock = lock;
+    this.executor = executor;
+    this.config = config;
+    this.stats = createEmptyStats();
+  }
+
+  /**
+   * Feed test output (stdout + stderr) for analysis.
+   * Can be called multiple times — each call observes the new output.
+   */
+  feedTestOutput(output: string): void {
+    const observation = this.observer.observe(output);
+    this.stats.totalObservations++;
+    this.stats.infraFailuresDetected += observation.infraFailures.length;
+
+    // Update per-service failure counts
+    for (const failure of observation.infraFailures) {
+      if (failure.serviceName) {
+        if (!this.stats.byService[failure.serviceName]) {
+          this.stats.byService[failure.serviceName] = { failures: 0, recoveries: 0, successes: 0 };
+        }
+        this.stats.byService[failure.serviceName].failures++;
+      }
+    }
+  }
+
+  /**
+   * Run a recovery cycle for all currently-failing services.
+   * Returns recovery results for each service attempted.
+   */
+  async runRecoveryCycle(): Promise<readonly ServiceRecoveryResult[]> {
+    const failingServices = this.observer.getFailingServices();
+    if (failingServices.size === 0) return [];
+
+    const results: ServiceRecoveryResult[] = [];
+    let activeRecoveries = 0;
+
+    for (const serviceName of failingServices) {
+      if (activeRecoveries >= this.config.maxConcurrentRecoveries) break;
+
+      // Skip if no playbook entry
+      if (!this.playbook.getRecoveryPlan(serviceName)) continue;
+
+      // Skip if already locked (recovery in progress)
+      if (this.lock.isLocked(serviceName)) {
+        this.stats.lockContentionEvents++;
+        continue;
+      }
+
+      activeRecoveries++;
+      const actionId = uuidv4();
+      const result = await this.executor.recoverService(serviceName, actionId);
+      results.push(result);
+
+      // Merge executor stats
+      this.mergeExecutorStats();
+    }
+
+    // Clear observation if all services recovered
+    const stillFailing = this.observer.getFailingServices();
+    if (stillFailing.size === 0) {
+      this.observer.clearObservation();
+    }
+
+    return results;
+  }
+
+  /**
+   * Get the test output observer (for wiring into InfraAwareAgentProvider).
+   */
+  getObserver(): TestOutputObserver {
+    return this.observer;
+  }
+
+  /**
+   * Get the recovery playbook (for wiring into InfraAwareAgentProvider).
+   */
+  getPlaybook(): RecoveryPlaybook {
+    return this.playbook;
+  }
+
+  /**
+   * Get the coordination lock.
+   */
+  getLock(): CoordinationLock {
+    return this.lock;
+  }
+
+  /**
+   * Get the infrastructure action executor.
+   */
+  getExecutor(): InfraActionExecutor {
+    return this.executor;
+  }
+
+  /**
+   * Get aggregated statistics.
+   */
+  getStats(): Readonly<InfraHealingStats> {
+    this.mergeExecutorStats();
+    return this.stats;
+  }
+
+  /**
+   * Check if the orchestrator has been initialized with a loaded playbook.
+   */
+  isReady(): boolean {
+    return this.playbook.isLoaded();
+  }
+
+  // ============================================================================
+  // Private Methods
+  // ============================================================================
+
+  private mergeExecutorStats(): void {
+    const execStats = this.executor.getStats();
+    this.stats.recoveriesAttempted = execStats.recoveriesAttempted;
+    this.stats.recoveriesSucceeded = execStats.recoveriesSucceeded;
+    this.stats.recoveriesFailed = execStats.recoveriesFailed;
+
+    // Merge per-service recovery stats from executor
+    for (const [service, execServiceStats] of Object.entries(execStats.byService)) {
+      if (!this.stats.byService[service]) {
+        this.stats.byService[service] = { failures: 0, recoveries: 0, successes: 0 };
+      }
+      this.stats.byService[service].recoveries = execServiceStats.recoveries;
+      this.stats.byService[service].successes = execServiceStats.successes;
+    }
+  }
+}
+
+// ============================================================================
+// Factory
+// ============================================================================
+
+/**
+ * Factory function for creating a fully-wired InfraHealingOrchestrator.
+ * Handles playbook loading, component creation, and dependency wiring.
+ */
+export async function createInfraHealingOrchestrator(
+  options: InfraHealingOrchestratorOptions,
+): Promise<InfraHealingOrchestrator> {
+  const config: InfraHealingConfig = {
+    ...DEFAULT_INFRA_HEALING_CONFIG,
+    ...options.config,
+  };
+
+  // Create components
+  const observer = createTestOutputObserver(options.customSignatures);
+  const playbook = createRecoveryPlaybook(options.variables);
+  const lock = createCoordinationLock(config.lockTtlMs);
+
+  // Load playbook
+  if (options.playbookIsFile !== false && !options.playbook.includes('\n')) {
+    // Looks like a file path
+    await playbook.loadFromFile(options.playbook);
+  } else {
+    // Inline YAML content
+    playbook.loadFromString(options.playbook);
+  }
+
+  const executor = createInfraActionExecutor(options.commandRunner, playbook, lock);
+
+  return new InfraHealingOrchestrator(observer, playbook, lock, executor, config);
+}
+
+/**
+ * Synchronous factory for creating an InfraHealingOrchestrator with inline YAML.
+ * Useful for tests where you don't want async setup.
+ */
+export function createInfraHealingOrchestratorSync(
+  options: Omit<InfraHealingOrchestratorOptions, 'playbookIsFile'>,
+): InfraHealingOrchestrator {
+  const config: InfraHealingConfig = {
+    ...DEFAULT_INFRA_HEALING_CONFIG,
+    ...options.config,
+  };
+
+  const observer = createTestOutputObserver(options.customSignatures);
+  const playbook = createRecoveryPlaybook(options.variables);
+  const lock = createCoordinationLock(config.lockTtlMs);
+
+  // Load inline YAML
+  playbook.loadFromString(options.playbook);
+
+  const executor = createInfraActionExecutor(options.commandRunner, playbook, lock);
+
+  return new InfraHealingOrchestrator(observer, playbook, lock, executor, config);
+}

--- a/v3/src/strange-loop/infra-healing/recovery-playbook.ts
+++ b/v3/src/strange-loop/infra-healing/recovery-playbook.ts
@@ -1,0 +1,218 @@
+/**
+ * Recovery Playbook
+ * ADR-057: Infrastructure Self-Healing Extension
+ *
+ * YAML-driven configuration for infrastructure recovery.
+ * Maps service names to health-check / recover / verify shell commands.
+ * Framework-agnostic — changing the YAML switches from Jest to Pytest
+ * to JUnit with zero code changes.
+ *
+ * Supports ${VAR} interpolation from environment variables or an
+ * explicit variables map.
+ *
+ * ## Security: Trust Boundary
+ *
+ * Playbook commands are passed to ShellCommandRunner which executes them
+ * via `execFile('/bin/sh', ['-c', command])`. The ${VAR} interpolation
+ * merges process.env with any explicit variables map — if an environment
+ * variable contains shell metacharacters (e.g. `PGHOST="localhost; rm -rf /"`),
+ * those will be interpreted by the shell.
+ *
+ * **Mitigation**: Playbook YAML must come from trusted configuration (checked
+ * into source control, operator-managed). Do NOT load playbooks from untrusted
+ * user input. Do NOT allow untrusted processes to set environment variables
+ * that playbook commands reference.
+ */
+
+import * as fs from 'node:fs/promises';
+import { parse as parseYaml } from 'yaml';
+import type {
+  RecoveryPlaybookConfig,
+  ServiceRecoveryPlan,
+  RecoveryCommand,
+} from './types.js';
+
+// ============================================================================
+// Recovery Playbook
+// ============================================================================
+
+/**
+ * Loads and manages a YAML recovery playbook.
+ * Provides service recovery plans with variable interpolation.
+ */
+export class RecoveryPlaybook {
+  private config: RecoveryPlaybookConfig | null = null;
+  private readonly variables: Record<string, string>;
+
+  constructor(variables?: Record<string, string>) {
+    this.variables = { ...process.env, ...(variables ?? {}) } as Record<string, string>;
+  }
+
+  /**
+   * Load playbook from a YAML file path.
+   */
+  async loadFromFile(filePath: string): Promise<void> {
+    const content = await fs.readFile(filePath, 'utf-8');
+    this.loadFromString(content);
+  }
+
+  /**
+   * Load playbook from a YAML string (for testing or inline config).
+   */
+  loadFromString(yamlContent: string): void {
+    const raw = parseYaml(yamlContent) as RawPlaybookYaml;
+    this.config = this.parsePlaybook(raw);
+  }
+
+  /**
+   * Get the recovery plan for a specific service.
+   * Returns undefined if the service is not defined in the playbook.
+   */
+  getRecoveryPlan(serviceName: string): ServiceRecoveryPlan | undefined {
+    if (!this.config) return undefined;
+    return this.config.services[serviceName];
+  }
+
+  /**
+   * List all service names defined in the playbook.
+   */
+  listServices(): readonly string[] {
+    if (!this.config) return [];
+    return Object.keys(this.config.services);
+  }
+
+  /**
+   * Check if the playbook has been loaded.
+   */
+  isLoaded(): boolean {
+    return this.config !== null;
+  }
+
+  /**
+   * Get the full playbook configuration.
+   */
+  getConfig(): RecoveryPlaybookConfig | null {
+    return this.config;
+  }
+
+  // ============================================================================
+  // Parsing
+  // ============================================================================
+
+  private parsePlaybook(raw: RawPlaybookYaml): RecoveryPlaybookConfig {
+    const defaults = raw.defaults ?? {};
+    const defaultTimeoutMs = defaults.timeoutMs ?? 10_000;
+    const defaultMaxRetries = defaults.maxRetries ?? 3;
+    const defaultBackoffMs = defaults.backoffMs ?? [2000, 5000, 10_000];
+
+    const services: Record<string, ServiceRecoveryPlan> = {};
+
+    if (raw.services) {
+      for (const [name, rawService] of Object.entries(raw.services)) {
+        services[name] = this.parseService(
+          name,
+          rawService,
+          defaultTimeoutMs,
+          defaultMaxRetries,
+          defaultBackoffMs,
+        );
+      }
+    }
+
+    return {
+      version: raw.version ?? '1.0.0',
+      defaultTimeoutMs,
+      defaultMaxRetries,
+      defaultBackoffMs,
+      services,
+    };
+  }
+
+  private parseService(
+    name: string,
+    raw: RawServiceYaml,
+    defaultTimeoutMs: number,
+    defaultMaxRetries: number,
+    defaultBackoffMs: readonly number[],
+  ): ServiceRecoveryPlan {
+    return {
+      serviceName: name,
+      description: raw.description ?? name,
+      healthCheck: this.parseCommand(raw.healthCheck, defaultTimeoutMs),
+      recover: Array.isArray(raw.recover)
+        ? raw.recover.map((cmd) => this.parseCommand(cmd, defaultTimeoutMs))
+        : [this.parseCommand(raw.recover, defaultTimeoutMs)],
+      verify: this.parseCommand(raw.verify, defaultTimeoutMs),
+      maxRetries: raw.maxRetries ?? defaultMaxRetries,
+      backoffMs: raw.backoffMs ?? defaultBackoffMs,
+    };
+  }
+
+  private parseCommand(raw: RawCommandYaml | string, defaultTimeoutMs: number): RecoveryCommand {
+    if (typeof raw === 'string') {
+      return {
+        command: this.interpolate(raw),
+        timeoutMs: defaultTimeoutMs,
+        required: true,
+      };
+    }
+    return {
+      command: this.interpolate(raw.command),
+      timeoutMs: raw.timeoutMs ?? defaultTimeoutMs,
+      required: raw.required ?? true,
+    };
+  }
+
+  /**
+   * Interpolate ${VAR} placeholders in a command string.
+   * Uses the variables map (env vars + explicit overrides).
+   * Leaves unresolved variables as-is (does not fail).
+   */
+  private interpolate(template: string): string {
+    return template.replace(/\$\{([^}]+)\}/g, (_match, varName: string) => {
+      return this.variables[varName] ?? _match;
+    });
+  }
+}
+
+// ============================================================================
+// Raw YAML Types (internal, not exported)
+// ============================================================================
+
+interface RawPlaybookYaml {
+  version?: string;
+  defaults?: {
+    timeoutMs?: number;
+    maxRetries?: number;
+    backoffMs?: number[];
+  };
+  services?: Record<string, RawServiceYaml>;
+}
+
+interface RawServiceYaml {
+  description?: string;
+  healthCheck: RawCommandYaml | string;
+  recover: (RawCommandYaml | string)[] | RawCommandYaml | string;
+  verify: RawCommandYaml | string;
+  maxRetries?: number;
+  backoffMs?: number[];
+}
+
+interface RawCommandYaml {
+  command: string;
+  timeoutMs?: number;
+  required?: boolean;
+}
+
+// ============================================================================
+// Factory
+// ============================================================================
+
+/**
+ * Factory function for creating a RecoveryPlaybook.
+ */
+export function createRecoveryPlaybook(
+  variables?: Record<string, string>
+): RecoveryPlaybook {
+  return new RecoveryPlaybook(variables);
+}

--- a/v3/src/strange-loop/infra-healing/test-output-observer.ts
+++ b/v3/src/strange-loop/infra-healing/test-output-observer.ts
@@ -1,0 +1,386 @@
+/**
+ * Test Output Observer
+ * ADR-057: Infrastructure Self-Healing Extension
+ *
+ * Parses test runner stdout/stderr, pattern-matches infrastructure error
+ * signatures, classifies errors as test_bug | infra_failure | flaky | unknown,
+ * and converts infrastructure failures into SwarmVulnerability objects that
+ * the existing Strange Loop Observe-Model-Decide-Act cycle can consume.
+ *
+ * Framework-agnostic: infrastructure errors (ECONNREFUSED, ETIMEDOUT, etc.)
+ * are OS-level and appear the same regardless of Jest, Pytest, JUnit, etc.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import type { SwarmVulnerability } from '../types.js';
+import type {
+  InfraErrorSignature,
+  ClassifiedError,
+  TestOutputObservation,
+  TestOutputClassification,
+} from './types.js';
+
+// ============================================================================
+// Default Error Signatures (Framework-Agnostic)
+// ============================================================================
+
+/**
+ * Built-in infrastructure error patterns.
+ * Covers common OS-level and service-level errors that appear in test output
+ * regardless of the test framework being used.
+ */
+export const DEFAULT_ERROR_SIGNATURES: readonly InfraErrorSignature[] = [
+  // Database connection errors
+  {
+    pattern: /ECONNREFUSED.*(?::5432|postgres)/i,
+    classification: 'infra_failure',
+    vulnerabilityType: 'db_connection_failure',
+    serviceName: 'postgres',
+    defaultSeverity: 0.95,
+    description: 'PostgreSQL connection refused',
+  },
+  {
+    pattern: /ECONNREFUSED.*(?::3306|mysql)/i,
+    classification: 'infra_failure',
+    vulnerabilityType: 'db_connection_failure',
+    serviceName: 'mysql',
+    defaultSeverity: 0.95,
+    description: 'MySQL connection refused',
+  },
+  {
+    pattern: /ECONNREFUSED.*(?::27017|mongo)/i,
+    classification: 'infra_failure',
+    vulnerabilityType: 'db_connection_failure',
+    serviceName: 'mongodb',
+    defaultSeverity: 0.95,
+    description: 'MongoDB connection refused',
+  },
+
+  // Cache / message broker errors
+  {
+    pattern: /ECONNREFUSED.*(?::6379|redis)/i,
+    classification: 'infra_failure',
+    vulnerabilityType: 'service_unreachable',
+    serviceName: 'redis',
+    defaultSeverity: 0.85,
+    description: 'Redis connection refused',
+  },
+  {
+    pattern: /ECONNREFUSED.*(?::5672|rabbitmq|amqp)/i,
+    classification: 'infra_failure',
+    vulnerabilityType: 'service_unreachable',
+    serviceName: 'rabbitmq',
+    defaultSeverity: 0.85,
+    description: 'RabbitMQ connection refused',
+  },
+  {
+    pattern: /ECONNREFUSED.*(?::9092|kafka)/i,
+    classification: 'infra_failure',
+    vulnerabilityType: 'service_unreachable',
+    serviceName: 'kafka',
+    defaultSeverity: 0.85,
+    description: 'Kafka connection refused',
+  },
+
+  // Search engine errors
+  {
+    pattern: /ECONNREFUSED.*(?::9200|elasticsearch)/i,
+    classification: 'infra_failure',
+    vulnerabilityType: 'service_unreachable',
+    serviceName: 'elasticsearch',
+    defaultSeverity: 0.8,
+    description: 'Elasticsearch connection refused',
+  },
+
+  // Generic connection errors
+  {
+    pattern: /ECONNREFUSED\s+[\d.]+:\d+/,
+    classification: 'infra_failure',
+    vulnerabilityType: 'service_unreachable',
+    serviceName: 'generic-service',
+    defaultSeverity: 0.8,
+    description: 'Service connection refused on unknown port',
+  },
+
+  // Timeout errors
+  {
+    pattern: /ETIMEDOUT/,
+    classification: 'infra_failure',
+    vulnerabilityType: 'infra_timeout',
+    serviceName: 'network',
+    defaultSeverity: 0.7,
+    description: 'Network connection timed out',
+  },
+  {
+    pattern: /ESOCKETTIMEDOUT/,
+    classification: 'infra_failure',
+    vulnerabilityType: 'infra_timeout',
+    serviceName: 'network',
+    defaultSeverity: 0.7,
+    description: 'Socket connection timed out',
+  },
+  {
+    pattern: /ECONNRESET/,
+    classification: 'infra_failure',
+    vulnerabilityType: 'service_unreachable',
+    serviceName: 'network',
+    defaultSeverity: 0.6,
+    description: 'Connection reset by peer',
+  },
+
+  // DNS errors
+  {
+    pattern: /ENOTFOUND/,
+    classification: 'infra_failure',
+    vulnerabilityType: 'dns_resolution_failure',
+    serviceName: 'dns',
+    defaultSeverity: 0.9,
+    description: 'DNS resolution failed',
+  },
+  {
+    pattern: /EAI_AGAIN/,
+    classification: 'infra_failure',
+    vulnerabilityType: 'dns_resolution_failure',
+    serviceName: 'dns',
+    defaultSeverity: 0.7,
+    description: 'DNS resolution temporary failure',
+  },
+
+  // Resource exhaustion
+  {
+    pattern: /ENOMEM|out of memory|OutOfMemoryError|java\.lang\.OutOfMemoryError/i,
+    classification: 'infra_failure',
+    vulnerabilityType: 'out_of_memory',
+    serviceName: 'memory',
+    defaultSeverity: 0.95,
+    description: 'Out of memory',
+  },
+  {
+    pattern: /ENOSPC|No space left on device/i,
+    classification: 'infra_failure',
+    vulnerabilityType: 'disk_full',
+    serviceName: 'disk',
+    defaultSeverity: 0.9,
+    description: 'Disk space exhausted',
+  },
+
+  // Port / bind errors
+  {
+    pattern: /EADDRINUSE/,
+    classification: 'infra_failure',
+    vulnerabilityType: 'port_bind_failure',
+    serviceName: 'port',
+    defaultSeverity: 0.8,
+    description: 'Port already in use',
+  },
+
+  // TLS / certificate errors
+  {
+    pattern: /certificate.*(?:expired|invalid|self.signed)|CERT_HAS_EXPIRED|UNABLE_TO_VERIFY_LEAF_SIGNATURE/i,
+    classification: 'infra_failure',
+    vulnerabilityType: 'certificate_expired',
+    serviceName: 'tls',
+    defaultSeverity: 0.85,
+    description: 'TLS certificate error',
+  },
+
+  // Connection pool exhaustion
+  {
+    pattern: /pool.*(?:exhausted|timeout|full)|too many (?:connections|clients)|max.*connections.*reached/i,
+    classification: 'infra_failure',
+    vulnerabilityType: 'service_unreachable',
+    serviceName: 'connection-pool',
+    defaultSeverity: 0.8,
+    description: 'Connection pool exhausted',
+  },
+
+  // Docker / container errors
+  {
+    pattern: /Cannot connect to the Docker daemon|docker.*not running/i,
+    classification: 'infra_failure',
+    vulnerabilityType: 'service_unreachable',
+    serviceName: 'docker',
+    defaultSeverity: 0.9,
+    description: 'Docker daemon unreachable',
+  },
+
+  // Selenium / browser automation errors
+  {
+    pattern: /WebDriverError.*session not created|ECONNREFUSED.*(?::4444|selenium)/i,
+    classification: 'infra_failure',
+    vulnerabilityType: 'service_unreachable',
+    serviceName: 'selenium-grid',
+    defaultSeverity: 0.85,
+    description: 'Selenium Grid unreachable',
+  },
+
+  // Python-specific DB errors (framework-agnostic at OS level)
+  {
+    pattern: /psycopg2\.OperationalError.*(?:could not connect|Connection refused)/i,
+    classification: 'infra_failure',
+    vulnerabilityType: 'db_connection_failure',
+    serviceName: 'postgres',
+    defaultSeverity: 0.95,
+    description: 'Python psycopg2 PostgreSQL connection failed',
+  },
+  {
+    pattern: /(?:java\.sql\.SQLException|com\.mysql).*(?:Communications link failure|Connection refused)/i,
+    classification: 'infra_failure',
+    vulnerabilityType: 'db_connection_failure',
+    serviceName: 'mysql',
+    defaultSeverity: 0.95,
+    description: 'Java JDBC connection failed',
+  },
+];
+
+// ============================================================================
+// Test Output Observer
+// ============================================================================
+
+/**
+ * Observes test runner output and classifies errors as infrastructure
+ * failures or test bugs. Converts infra failures into SwarmVulnerability
+ * objects consumable by the existing Strange Loop pipeline.
+ */
+export class TestOutputObserver {
+  private readonly signatures: readonly InfraErrorSignature[];
+  private lastObservation: TestOutputObservation | null = null;
+
+  constructor(customSignatures?: readonly InfraErrorSignature[]) {
+    this.signatures = customSignatures ?? DEFAULT_ERROR_SIGNATURES;
+  }
+
+  /**
+   * Observe a block of test output (stdout + stderr combined).
+   * Parses line-by-line and classifies each error found.
+   */
+  observe(output: string): TestOutputObservation {
+    const startTime = Date.now();
+    const lines = output.split('\n');
+    const classifiedErrors: ClassifiedError[] = [];
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i].trim();
+      if (!line) continue;
+
+      const classified = this.classifyLine(line, i + 1);
+      if (classified) {
+        classifiedErrors.push(classified);
+      }
+    }
+
+    const infraFailures = classifiedErrors.filter(
+      (e) => e.classification === 'infra_failure'
+    );
+
+    const vulnerabilities = this.toVulnerabilities(infraFailures);
+
+    const observation: TestOutputObservation = {
+      id: uuidv4(),
+      totalLinesParsed: lines.length,
+      classifiedErrors,
+      infraFailures,
+      vulnerabilities,
+      observedAt: Date.now(),
+      parsingDurationMs: Date.now() - startTime,
+    };
+
+    this.lastObservation = observation;
+    return observation;
+  }
+
+  /**
+   * Get the most recent observation (for AgentProvider health reporting).
+   */
+  getLastObservation(): TestOutputObservation | null {
+    return this.lastObservation;
+  }
+
+  /**
+   * Get the set of currently-failing service names from the last observation.
+   */
+  getFailingServices(): ReadonlySet<string> {
+    if (!this.lastObservation) return new Set();
+    const services = new Set<string>();
+    for (const failure of this.lastObservation.infraFailures) {
+      if (failure.serviceName) {
+        services.add(failure.serviceName);
+      }
+    }
+    return services;
+  }
+
+  /**
+   * Clear the last observation (e.g., after recovery).
+   */
+  clearObservation(): void {
+    this.lastObservation = null;
+  }
+
+  /**
+   * Classify a single line of output.
+   * Returns null if the line doesn't match any error signature.
+   */
+  classifyLine(line: string, lineNumber?: number): ClassifiedError | null {
+    for (const signature of this.signatures) {
+      if (signature.pattern.test(line)) {
+        return {
+          rawOutput: line,
+          lineNumber,
+          classification: signature.classification,
+          matchedSignature: signature,
+          confidence: 0.9,
+          serviceName: signature.serviceName,
+          classifiedAt: Date.now(),
+        };
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Convert classified infra failures into SwarmVulnerability objects.
+   * Deduplicates by service name — one vulnerability per failing service.
+   */
+  private toVulnerabilities(
+    infraFailures: readonly ClassifiedError[]
+  ): SwarmVulnerability[] {
+    const byService = new Map<string, ClassifiedError[]>();
+
+    for (const failure of infraFailures) {
+      const service = failure.serviceName ?? 'unknown';
+      const existing = byService.get(service) ?? [];
+      existing.push(failure);
+      byService.set(service, existing);
+    }
+
+    const vulnerabilities: SwarmVulnerability[] = [];
+    for (const [service, failures] of byService) {
+      const maxSeverity = Math.max(
+        ...failures.map((f) => f.matchedSignature?.defaultSeverity ?? 0.5)
+      );
+      const description = failures[0]?.matchedSignature?.description ?? `Service ${service} failure`;
+      const vulnType = failures[0]?.matchedSignature?.vulnerabilityType ?? 'service_unreachable';
+
+      vulnerabilities.push({
+        type: vulnType,
+        severity: maxSeverity,
+        affectedAgents: [`infra-${service}`],
+        description: `${description} (${failures.length} occurrence${failures.length > 1 ? 's' : ''})`,
+        suggestedAction: 'restart_service',
+        detectedAt: Date.now(),
+      });
+    }
+
+    return vulnerabilities;
+  }
+}
+
+/**
+ * Factory function for creating a TestOutputObserver.
+ */
+export function createTestOutputObserver(
+  customSignatures?: readonly InfraErrorSignature[]
+): TestOutputObserver {
+  return new TestOutputObserver(customSignatures);
+}

--- a/v3/src/strange-loop/infra-healing/types.ts
+++ b/v3/src/strange-loop/infra-healing/types.ts
@@ -1,0 +1,319 @@
+/**
+ * Infrastructure Self-Healing Types
+ * ADR-057: Infrastructure Self-Healing Extension for Strange Loop
+ *
+ * Defines types for detecting infrastructure failures during test execution
+ * and orchestrating automated recovery via YAML-driven playbooks.
+ */
+
+import type { SwarmVulnerability } from '../types.js';
+
+// ============================================================================
+// Classification Types
+// ============================================================================
+
+/**
+ * Classification of a test output error
+ */
+export type TestOutputClassification =
+  | 'test_bug'
+  | 'infra_failure'
+  | 'flaky'
+  | 'unknown';
+
+/**
+ * Infrastructure error signature for pattern matching
+ */
+export interface InfraErrorSignature {
+  /** Regex pattern to match against test output */
+  readonly pattern: RegExp;
+  /** Classification when this pattern matches */
+  readonly classification: TestOutputClassification;
+  /** Vulnerability type to emit when classified as infra_failure */
+  readonly vulnerabilityType: SwarmVulnerability['type'];
+  /** Service name to associate with (for playbook lookup) */
+  readonly serviceName: string;
+  /** Default severity (0-1) */
+  readonly defaultSeverity: number;
+  /** Human-readable description */
+  readonly description: string;
+}
+
+/**
+ * Result of classifying a single test output line or block
+ */
+export interface ClassifiedError {
+  /** The original output text that matched */
+  readonly rawOutput: string;
+  /** Line number in the output (if available) */
+  readonly lineNumber?: number;
+  /** Classification result */
+  readonly classification: TestOutputClassification;
+  /** Matched signature (if any) */
+  readonly matchedSignature?: InfraErrorSignature;
+  /** Confidence in classification (0-1) */
+  readonly confidence: number;
+  /** Extracted service name */
+  readonly serviceName?: string;
+  /** Timestamp of classification */
+  readonly classifiedAt: number;
+}
+
+/**
+ * Aggregated result from observing an entire test run's output
+ */
+export interface TestOutputObservation {
+  /** Unique observation ID */
+  readonly id: string;
+  /** Total lines parsed */
+  readonly totalLinesParsed: number;
+  /** Classified errors found */
+  readonly classifiedErrors: readonly ClassifiedError[];
+  /** Infra failures detected (subset of classifiedErrors) */
+  readonly infraFailures: readonly ClassifiedError[];
+  /** Generated vulnerabilities for the Strange Loop */
+  readonly vulnerabilities: readonly SwarmVulnerability[];
+  /** Timestamp */
+  readonly observedAt: number;
+  /** Duration of parsing in ms */
+  readonly parsingDurationMs: number;
+}
+
+// ============================================================================
+// Command Runner Interface (DI for shell execution)
+// ============================================================================
+
+/**
+ * Result of executing a shell command
+ */
+export interface CommandResult {
+  /** Exit code (0 = success) */
+  readonly exitCode: number;
+  /** Standard output */
+  readonly stdout: string;
+  /** Standard error */
+  readonly stderr: string;
+  /** Execution duration in ms */
+  readonly durationMs: number;
+  /** Whether the command timed out */
+  readonly timedOut: boolean;
+}
+
+/**
+ * Interface for executing shell commands.
+ * Injected into InfraActionExecutor for testability.
+ */
+export interface CommandRunner {
+  /**
+   * Execute a shell command and return the result.
+   * @param command - The command to execute
+   * @param timeoutMs - Timeout in milliseconds
+   * @returns Result with exit code, stdout, stderr
+   */
+  run(command: string, timeoutMs: number): Promise<CommandResult>;
+}
+
+// ============================================================================
+// Recovery Playbook Types
+// ============================================================================
+
+/**
+ * A single recovery step command
+ */
+export interface RecoveryCommand {
+  /** Shell command to execute */
+  readonly command: string;
+  /** Timeout in milliseconds */
+  readonly timeoutMs: number;
+  /** Whether this command must succeed for recovery to continue */
+  readonly required: boolean;
+}
+
+/**
+ * Recovery plan for a single service
+ */
+export interface ServiceRecoveryPlan {
+  /** Service identifier (matches InfraErrorSignature.serviceName) */
+  readonly serviceName: string;
+  /** Human-readable service description */
+  readonly description: string;
+  /** Health check command — returns exit 0 if service is healthy */
+  readonly healthCheck: RecoveryCommand;
+  /** Recovery commands — executed in order */
+  readonly recover: readonly RecoveryCommand[];
+  /** Verification command — returns exit 0 if recovery succeeded */
+  readonly verify: RecoveryCommand;
+  /** Maximum retry attempts */
+  readonly maxRetries: number;
+  /** Backoff delays in milliseconds per attempt */
+  readonly backoffMs: readonly number[];
+}
+
+/**
+ * Complete playbook configuration loaded from YAML
+ */
+export interface RecoveryPlaybookConfig {
+  /** Playbook version */
+  readonly version: string;
+  /** Default timeout for commands if not specified */
+  readonly defaultTimeoutMs: number;
+  /** Default max retries if not specified */
+  readonly defaultMaxRetries: number;
+  /** Default backoff delays */
+  readonly defaultBackoffMs: readonly number[];
+  /** Services and their recovery plans */
+  readonly services: Record<string, ServiceRecoveryPlan>;
+}
+
+// ============================================================================
+// Coordination Lock Types
+// ============================================================================
+
+/**
+ * A lock entry for a service recovery in progress
+ */
+export interface CoordinationLockEntry {
+  /** Service being recovered */
+  readonly serviceName: string;
+  /** ID of the holder (e.g., action ID) */
+  readonly holderId: string;
+  /** When the lock was acquired */
+  readonly acquiredAt: number;
+  /** TTL in milliseconds (auto-release after) */
+  readonly ttlMs: number;
+}
+
+/**
+ * Result of attempting to acquire a lock
+ */
+export interface LockAcquireResult {
+  /** Whether the lock was acquired */
+  readonly acquired: boolean;
+  /** If not acquired, who holds it */
+  readonly currentHolder?: string;
+  /** If not acquired, when it expires */
+  readonly expiresAt?: number;
+}
+
+// ============================================================================
+// Recovery Result Types
+// ============================================================================
+
+/**
+ * Result of a single recovery attempt for a service
+ */
+export interface RecoveryAttemptResult {
+  /** Service that was recovered */
+  readonly serviceName: string;
+  /** Whether recovery succeeded */
+  readonly success: boolean;
+  /** Attempt number (1-based) */
+  readonly attempt: number;
+  /** Health check result before recovery */
+  readonly healthCheckResult: CommandResult;
+  /** Recovery command results */
+  readonly recoveryResults: readonly CommandResult[];
+  /** Verification result after recovery */
+  readonly verifyResult?: CommandResult;
+  /** Total duration in ms */
+  readonly durationMs: number;
+  /** Error message if failed */
+  readonly error?: string;
+  /** Timestamp */
+  readonly attemptedAt: number;
+}
+
+/**
+ * Aggregate result of all recovery attempts for a service
+ */
+export interface ServiceRecoveryResult {
+  /** Service name */
+  readonly serviceName: string;
+  /** Whether the service was ultimately recovered */
+  readonly recovered: boolean;
+  /** Total attempts made */
+  readonly totalAttempts: number;
+  /** Individual attempt results */
+  readonly attempts: readonly RecoveryAttemptResult[];
+  /** Total time spent on recovery */
+  readonly totalDurationMs: number;
+  /** Whether escalation was triggered */
+  readonly escalated: boolean;
+}
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+/**
+ * Configuration for the infrastructure healing subsystem
+ */
+export interface InfraHealingConfig {
+  /** Path to the recovery playbook YAML file (or inline YAML content) */
+  readonly playbookPath: string;
+  /** Whether to auto-classify test output */
+  readonly autoClassifyEnabled: boolean;
+  /** Lock TTL in milliseconds (default: 120_000 = 2 min) */
+  readonly lockTtlMs: number;
+  /** Maximum concurrent recoveries */
+  readonly maxConcurrentRecoveries: number;
+  /** Whether verbose logging is enabled */
+  readonly verboseLogging: boolean;
+  /** Prefix for synthetic infra agent IDs */
+  readonly infraAgentPrefix: string;
+}
+
+/**
+ * Default configuration for infrastructure healing
+ */
+export const DEFAULT_INFRA_HEALING_CONFIG: InfraHealingConfig = {
+  playbookPath: './recovery-playbook.yaml',
+  autoClassifyEnabled: true,
+  lockTtlMs: 120_000,
+  maxConcurrentRecoveries: 3,
+  verboseLogging: false,
+  infraAgentPrefix: 'infra-',
+};
+
+// ============================================================================
+// Statistics
+// ============================================================================
+
+/**
+ * Statistics for the infrastructure healing subsystem
+ */
+export interface InfraHealingStats {
+  /** Total test outputs observed */
+  totalObservations: number;
+  /** Total infra failures detected */
+  infraFailuresDetected: number;
+  /** Total recoveries attempted */
+  recoveriesAttempted: number;
+  /** Successful recoveries */
+  recoveriesSucceeded: number;
+  /** Failed recoveries */
+  recoveriesFailed: number;
+  /** Lock contention events (lock was already held) */
+  lockContentionEvents: number;
+  /** Breakdown by service name */
+  byService: Record<string, {
+    failures: number;
+    recoveries: number;
+    successes: number;
+  }>;
+}
+
+/**
+ * Create initial empty stats
+ */
+export function createEmptyStats(): InfraHealingStats {
+  return {
+    totalObservations: 0,
+    infraFailuresDetected: 0,
+    recoveriesAttempted: 0,
+    recoveriesSucceeded: 0,
+    recoveriesFailed: 0,
+    lockContentionEvents: 0,
+    byService: {},
+  };
+}

--- a/v3/src/strange-loop/strange-loop.ts
+++ b/v3/src/strange-loop/strange-loop.ts
@@ -40,6 +40,11 @@ import { DEFAULT_STRANGE_LOOP_CONFIG } from './types.js';
 import { SwarmObserver, AgentProvider, InMemoryAgentProvider } from './swarm-observer.js';
 import { SwarmSelfModel } from './self-model.js';
 import { SelfHealingController, ActionExecutor, NoOpActionExecutor } from './healing-controller.js';
+import type { CommandRunner, InfraHealingConfig } from './infra-healing/types.js';
+import type { InfraErrorSignature } from './infra-healing/types.js';
+import { createInfraHealingOrchestratorSync, InfraHealingOrchestrator } from './infra-healing/infra-healing-orchestrator.js';
+import { createInfraAwareAgentProvider } from './infra-healing/infra-aware-agent-provider.js';
+import { createCompositeActionExecutor } from './infra-healing/composite-action-executor.js';
 import type {
   ICoherenceService,
   CoherenceNode,
@@ -1040,4 +1045,125 @@ export function createInMemoryStrangeLoopWithCoherence(
   );
 
   return { orchestrator, provider, executor };
+}
+
+// ============================================================================
+// Infrastructure Self-Healing Integration (ADR-057)
+// ============================================================================
+
+/**
+ * Options for creating a StrangeLoopOrchestrator with infrastructure self-healing.
+ */
+export interface InfraHealingIntegrationOptions {
+  /** Agent provider for observing swarm state */
+  provider: AgentProvider;
+  /** Action executor for swarm healing actions (will be wrapped with CompositeActionExecutor) */
+  executor: ActionExecutor;
+  /** Command runner for shell execution (inject NoOpCommandRunner for tests) */
+  commandRunner: CommandRunner;
+  /** YAML playbook content (string) */
+  playbook: string;
+  /** Custom error signatures (extends defaults) */
+  customSignatures?: readonly InfraErrorSignature[];
+  /** Variable overrides for playbook interpolation */
+  variables?: Record<string, string>;
+  /** Strange Loop configuration overrides */
+  config?: Partial<StrangeLoopConfig>;
+  /** Infrastructure healing configuration overrides */
+  infraConfig?: Partial<InfraHealingConfig>;
+  /** Prefix for synthetic infra agent IDs (default: 'infra-') */
+  infraAgentPrefix?: string;
+}
+
+/**
+ * Create a StrangeLoopOrchestrator with infrastructure self-healing wired in.
+ *
+ * This is the real integration point — it wraps the provider with
+ * InfraAwareAgentProvider and the executor with CompositeActionExecutor,
+ * so infrastructure failures detected by TestOutputObserver surface as
+ * degraded synthetic agents and healing actions route through the playbook.
+ *
+ * @example
+ * ```typescript
+ * const { orchestrator, infraHealing } = createStrangeLoopWithInfraHealing({
+ *   provider: new InMemoryAgentProvider('obs-0'),
+ *   executor: new NoOpActionExecutor(),
+ *   commandRunner: new ShellCommandRunner(),
+ *   playbook: fs.readFileSync('./recovery-playbook.yaml', 'utf-8'),
+ * });
+ *
+ * // Feed test output → infra failures become degraded synthetic agents
+ * infraHealing.feedTestOutput(testStderr);
+ *
+ * // Strange Loop cycle detects degraded infra agents → heals via playbook
+ * await orchestrator.runCycle();
+ * ```
+ */
+export function createStrangeLoopWithInfraHealing(
+  options: InfraHealingIntegrationOptions,
+): {
+  orchestrator: StrangeLoopOrchestrator;
+  infraHealing: InfraHealingOrchestrator;
+} {
+  // 1. Create the infra healing orchestrator (observer + playbook + lock + executor)
+  const infraHealing = createInfraHealingOrchestratorSync({
+    commandRunner: options.commandRunner,
+    playbook: options.playbook,
+    customSignatures: options.customSignatures,
+    variables: options.variables,
+    config: options.infraConfig,
+  });
+
+  // 2. Wrap the provider — adds synthetic infra agents whose health
+  //    reflects the observer's failure state (responsiveness=0 when down)
+  const wrappedProvider = createInfraAwareAgentProvider(
+    options.provider,
+    infraHealing.getObserver(),
+    infraHealing.getPlaybook(),
+    options.infraAgentPrefix,
+  );
+
+  // 3. Wrap the executor — routes restart_agent for infra-* agents to
+  //    InfraActionExecutor for playbook-driven recovery
+  const wrappedExecutor = createCompositeActionExecutor(
+    options.executor,
+    infraHealing.getExecutor(),
+  );
+
+  // 4. Create the Strange Loop with wrapped dependencies
+  const orchestrator = new StrangeLoopOrchestrator(
+    wrappedProvider,
+    wrappedExecutor,
+    options.config,
+  );
+
+  return { orchestrator, infraHealing };
+}
+
+/**
+ * Create a StrangeLoopOrchestrator with in-memory components and infrastructure
+ * self-healing wired in. Convenience factory for testing.
+ */
+export function createInMemoryStrangeLoopWithInfraHealing(
+  observerId: string = 'observer-0',
+  commandRunner: CommandRunner,
+  playbook: string,
+  config?: Partial<StrangeLoopConfig>,
+): {
+  orchestrator: StrangeLoopOrchestrator;
+  provider: InMemoryAgentProvider;
+  infraHealing: InfraHealingOrchestrator;
+} {
+  const provider = new InMemoryAgentProvider(observerId);
+  const executor = new NoOpActionExecutor();
+
+  const { orchestrator, infraHealing } = createStrangeLoopWithInfraHealing({
+    provider,
+    executor,
+    commandRunner,
+    playbook,
+    config,
+  });
+
+  return { orchestrator, provider, infraHealing };
 }

--- a/v3/src/strange-loop/types.ts
+++ b/v3/src/strange-loop/types.ts
@@ -151,7 +151,11 @@ export interface ConnectivityMetrics {
  */
 export interface SwarmVulnerability {
   /** Vulnerability type */
-  type: 'bottleneck' | 'isolated_agent' | 'overloaded_agent' | 'single_point_of_failure' | 'network_partition' | 'degraded_connectivity';
+  type: 'bottleneck' | 'isolated_agent' | 'overloaded_agent' | 'single_point_of_failure' | 'network_partition' | 'degraded_connectivity'
+    // ADR-057: Infrastructure self-healing vulnerability types
+    | 'db_connection_failure' | 'service_unreachable' | 'dns_resolution_failure'
+    | 'port_bind_failure' | 'out_of_memory' | 'disk_full'
+    | 'certificate_expired' | 'infra_timeout';
 
   /** Severity (0-1) */
   severity: number;
@@ -373,7 +377,9 @@ export type SelfHealingActionType =
   | 'trigger_failover'
   | 'scale_up'
   | 'scale_down'
-  | 'rebalance_topology';
+  | 'rebalance_topology'
+  // ADR-057: Infrastructure self-healing action type
+  | 'restart_service';
 
 /**
  * Priority levels for healing actions

--- a/v3/tests/integration/infra-healing-docker.test.ts
+++ b/v3/tests/integration/infra-healing-docker.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Real Docker Integration Test: Infrastructure Self-Healing (ADR-057)
+ *
+ * Tests the FULL pipeline with a real PostgreSQL container:
+ *   1. Start postgres container
+ *   2. Verify it's healthy (pg_isready via docker exec)
+ *   3. Stop the container (simulate infrastructure failure)
+ *   4. Feed the connection error into the orchestrator
+ *   5. ShellCommandRunner executes real `docker start` recovery
+ *   6. Verify postgres is accepting connections again
+ *
+ * Requirements: Docker with postgres:16-alpine image available.
+ * Run: cd v3 && npx vitest run tests/integration/infra-healing-docker.test.ts
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execSync } from 'node:child_process';
+import { ShellCommandRunner } from '../../src/strange-loop/infra-healing/infra-action-executor.js';
+import { createInfraHealingOrchestratorSync } from '../../src/strange-loop/infra-healing/infra-healing-orchestrator.js';
+import { createStrangeLoopWithInfraHealing } from '../../src/strange-loop/strange-loop.js';
+import { InMemoryAgentProvider } from '../../src/strange-loop/swarm-observer.js';
+import { NoOpActionExecutor } from '../../src/strange-loop/healing-controller.js';
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+const CONTAINER_NAME = 'aqe-test-postgres';
+const PG_PORT = '15432';
+const PG_PASSWORD = 'testpass';
+const TIMEOUT = 60_000;
+
+const PLAYBOOK = `
+version: "1.0.0"
+defaults:
+  timeoutMs: 10000
+  maxRetries: 3
+  backoffMs: [1000, 2000, 3000]
+
+services:
+  postgres:
+    description: "PostgreSQL test container"
+    healthCheck:
+      command: "docker exec ${CONTAINER_NAME} pg_isready -U postgres"
+      timeoutMs: 5000
+    recover:
+      - command: "docker start ${CONTAINER_NAME}"
+        timeoutMs: 15000
+      - command: "sleep 2"
+        timeoutMs: 5000
+        required: false
+    verify:
+      command: "docker exec ${CONTAINER_NAME} pg_isready -U postgres"
+      timeoutMs: 5000
+    maxRetries: 3
+    backoffMs: [1000, 2000, 3000]
+`;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function imageExists(): boolean {
+  try {
+    execSync('docker image inspect postgres:16-alpine', { stdio: 'ignore', timeout: 5000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function containerIsRunning(): boolean {
+  try {
+    const result = execSync(
+      `docker inspect ${CONTAINER_NAME} --format='{{.State.Running}}'`,
+      { encoding: 'utf-8', timeout: 5000 },
+    );
+    return result.trim() === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function removeContainer(): void {
+  try {
+    execSync(`docker rm -f ${CONTAINER_NAME}`, { timeout: 10000, stdio: 'ignore' });
+  } catch {
+    // Already removed
+  }
+}
+
+function waitForHealthy(maxWaitMs: number = 20000): boolean {
+  const start = Date.now();
+  while (Date.now() - start < maxWaitMs) {
+    try {
+      execSync(`docker exec ${CONTAINER_NAME} pg_isready -U postgres`, {
+        timeout: 3000,
+        stdio: 'ignore',
+      });
+      return true;
+    } catch {
+      execSync('sleep 1', { timeout: 2000 });
+    }
+  }
+  return false;
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+const skip = !imageExists();
+
+if (skip) {
+  console.warn(
+    '\n⚠️  DOCKER TESTS SKIPPED: postgres:16-alpine image not available.\n' +
+    '   These 5 tests prove real container recovery and are critical.\n' +
+    '   Pull the image to run them: docker pull postgres:16-alpine\n',
+  );
+}
+
+describe('Infrastructure Self-Healing: Real Docker Integration', () => {
+  beforeAll(() => {
+    if (skip) return;
+    removeContainer();
+    execSync(
+      `docker run -d --name ${CONTAINER_NAME} -e POSTGRES_PASSWORD=${PG_PASSWORD} -p ${PG_PORT}:5432 postgres:16-alpine`,
+      { timeout: 30000 },
+    );
+    const healthy = waitForHealthy();
+    if (!healthy) throw new Error('PostgreSQL container failed to start');
+    console.log(`[setup] Container "${CONTAINER_NAME}" healthy on port ${PG_PORT}`);
+  }, TIMEOUT);
+
+  afterAll(() => {
+    if (skip) return;
+    removeContainer();
+    console.log(`[teardown] Removed "${CONTAINER_NAME}"`);
+  }, TIMEOUT);
+
+  // --------------------------------------------------------------------------
+  // 1. ShellCommandRunner health check against real postgres
+  // --------------------------------------------------------------------------
+
+  it.skipIf(skip)('ShellCommandRunner detects healthy postgres', async () => {
+    const runner = new ShellCommandRunner();
+    const result = await runner.run(
+      `docker exec ${CONTAINER_NAME} pg_isready -U postgres`,
+      5000,
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('accepting connections');
+    console.log(`  exit=${result.exitCode} duration=${result.durationMs}ms stdout="${result.stdout.trim()}"`);
+  }, 10000);
+
+  it.skipIf(skip)('ShellCommandRunner detects stopped postgres', async () => {
+    execSync(`docker stop ${CONTAINER_NAME}`, { timeout: 15000 });
+    expect(containerIsRunning()).toBe(false);
+
+    const runner = new ShellCommandRunner();
+    const result = await runner.run(
+      `docker exec ${CONTAINER_NAME} pg_isready -U postgres`,
+      5000,
+    );
+
+    expect(result.exitCode).not.toBe(0);
+    console.log(`  exit=${result.exitCode} (container stopped)`);
+
+    // Restore for next tests
+    execSync(`docker start ${CONTAINER_NAME}`, { timeout: 15000 });
+    expect(waitForHealthy()).toBe(true);
+  }, TIMEOUT);
+
+  // --------------------------------------------------------------------------
+  // 2. InfraHealingOrchestrator: stop container, detect, recover, verify
+  // --------------------------------------------------------------------------
+
+  it.skipIf(skip)('recovers a stopped postgres container via playbook', async () => {
+    const runner = new ShellCommandRunner();
+    const orchestrator = createInfraHealingOrchestratorSync({
+      commandRunner: runner,
+      playbook: PLAYBOOK,
+    });
+
+    // -- STOP the container --
+    execSync(`docker stop ${CONTAINER_NAME}`, { timeout: 15000 });
+    expect(containerIsRunning()).toBe(false);
+    console.log('  [1] Container STOPPED');
+
+    // -- FEED test output with connection error --
+    // Use standard postgres port (5432) in the error message so the observer
+    // classifies it as 'postgres' (the playbook entry uses docker exec, not TCP port)
+    orchestrator.feedTestOutput(
+      'FAIL src/users/create.test.ts\n  Error: connect ECONNREFUSED 127.0.0.1:5432\nTests: 1 failed',
+    );
+    expect(orchestrator.getObserver().getFailingServices().has('postgres')).toBe(true);
+    console.log('  [2] Observer detected postgres failure');
+
+    // -- RUN recovery cycle --
+    const results = await orchestrator.runRecoveryCycle();
+    console.log('  [3] Recovery cycle complete');
+
+    expect(results).toHaveLength(1);
+    const pgResult = results[0];
+    expect(pgResult.serviceName).toBe('postgres');
+    expect(pgResult.recovered).toBe(true);
+    console.log(`  [3] recovered=${pgResult.recovered} attempts=${pgResult.totalAttempts} duration=${pgResult.totalDurationMs}ms`);
+
+    // -- VERIFY container is actually running again --
+    expect(containerIsRunning()).toBe(true);
+    expect(waitForHealthy(10000)).toBe(true);
+    console.log('  [4] Container is RUNNING and HEALTHY');
+
+    // -- CHECK stats --
+    const stats = orchestrator.getStats();
+    expect(stats.recoveriesAttempted).toBe(1);
+    expect(stats.recoveriesSucceeded).toBe(1);
+    expect(stats.recoveriesFailed).toBe(0);
+    console.log(`  [stats] attempted=${stats.recoveriesAttempted} succeeded=${stats.recoveriesSucceeded} failed=${stats.recoveriesFailed}`);
+  }, TIMEOUT);
+
+  // --------------------------------------------------------------------------
+  // 3. Full Strange Loop cycle: observe → decide → act with real Docker
+  // --------------------------------------------------------------------------
+
+  it.skipIf(skip)('full Strange Loop cycle recovers stopped postgres', async () => {
+    const runner = new ShellCommandRunner();
+    const provider = new InMemoryAgentProvider('obs-0');
+    const executor = new NoOpActionExecutor();
+
+    const { orchestrator, infraHealing } = createStrangeLoopWithInfraHealing({
+      provider,
+      executor,
+      commandRunner: runner,
+      playbook: PLAYBOOK,
+      config: { actionCooldownMs: 0, maxActionsPerCycle: 10 },
+    });
+
+    // -- STOP postgres --
+    execSync(`docker stop ${CONTAINER_NAME}`, { timeout: 15000 });
+    expect(containerIsRunning()).toBe(false);
+    console.log('  [1] Container STOPPED');
+
+    // -- FEED error output --
+    infraHealing.feedTestOutput(
+      'FAIL src/db.test.ts\n  Error: connect ECONNREFUSED 127.0.0.1:5432\nTests: 1 failed',
+    );
+    console.log('  [2] Fed test output');
+
+    // -- RUN Strange Loop cycle --
+    const cycle = await orchestrator.runCycle();
+    console.log('  [3] Strange Loop cycle complete');
+
+    // Verify infra vulnerabilities detected
+    const infraVulns = cycle.observation.vulnerabilities.filter(
+      (v) => v.affectedAgents.some((a) => a.startsWith('infra-')),
+    );
+    expect(infraVulns.length).toBeGreaterThan(0);
+    console.log(`  [3] Infra vulnerabilities: ${infraVulns.length}`);
+    for (const v of infraVulns) {
+      console.log(`      type=${v.type} severity=${v.severity} agents=${v.affectedAgents}`);
+    }
+
+    // Verify restart_service was executed
+    const restartResults = cycle.results.filter(
+      (r) => r.action.type === 'restart_service' && r.action.targetAgentId?.startsWith('infra-'),
+    );
+    expect(restartResults.length).toBeGreaterThan(0);
+    console.log(`  [3] restart_service results: ${restartResults.length}`);
+    for (const r of restartResults) {
+      console.log(`      target=${r.action.targetAgentId} success=${r.success}`);
+    }
+
+    // -- VERIFY postgres is back --
+    expect(waitForHealthy(15000)).toBe(true);
+    expect(containerIsRunning()).toBe(true);
+    console.log('  [4] Container is RUNNING and HEALTHY');
+
+    // -- CHECK infra healing stats --
+    const stats = infraHealing.getStats();
+    expect(stats.infraFailuresDetected).toBeGreaterThan(0);
+    expect(stats.recoveriesAttempted).toBeGreaterThan(0);
+    expect(stats.recoveriesSucceeded).toBeGreaterThan(0);
+    console.log(`  [stats] failures=${stats.infraFailuresDetected} attempted=${stats.recoveriesAttempted} succeeded=${stats.recoveriesSucceeded}`);
+  }, TIMEOUT);
+
+  // --------------------------------------------------------------------------
+  // 4. Already-healthy path (no recovery needed)
+  // --------------------------------------------------------------------------
+
+  it.skipIf(skip)('skips recovery when postgres is already healthy', async () => {
+    // Container should be running from previous test
+    expect(containerIsRunning()).toBe(true);
+
+    const runner = new ShellCommandRunner();
+    const orchestrator = createInfraHealingOrchestratorSync({
+      commandRunner: runner,
+      playbook: PLAYBOOK,
+    });
+
+    // Feed error even though postgres is up
+    orchestrator.feedTestOutput('Error: connect ECONNREFUSED 127.0.0.1:5432');
+    const results = await orchestrator.runRecoveryCycle();
+
+    expect(results).toHaveLength(1);
+    expect(results[0].recovered).toBe(true);
+    expect(results[0].totalAttempts).toBe(1);
+    // Health check passed → zero recovery commands executed
+    expect(results[0].attempts[0].recoveryResults).toHaveLength(0);
+    console.log('  Service was already healthy — recovery commands skipped');
+  }, 15000);
+});

--- a/v3/tests/unit/strange-loop/infra-healing/coordination-lock.test.ts
+++ b/v3/tests/unit/strange-loop/infra-healing/coordination-lock.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Coordination Lock Tests
+ * ADR-057: Infrastructure Self-Healing Extension
+ *
+ * Tests for the in-process async mutex that prevents duplicate
+ * infrastructure recovery attempts.
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  CoordinationLock,
+  createCoordinationLock,
+} from '../../../../src/strange-loop/infra-healing/coordination-lock.js';
+
+// ============================================================================
+// Coordination Lock Tests
+// ============================================================================
+
+describe('CoordinationLock', () => {
+  let lock: CoordinationLock;
+
+  beforeEach(() => {
+    lock = createCoordinationLock();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ==========================================================================
+  // Factory
+  // ==========================================================================
+
+  describe('createCoordinationLock', () => {
+    it('creates a lock with default TTL', () => {
+      const l = createCoordinationLock();
+      expect(l).toBeInstanceOf(CoordinationLock);
+    });
+
+    it('creates a lock with custom TTL', () => {
+      const l = createCoordinationLock(5000);
+      expect(l).toBeInstanceOf(CoordinationLock);
+    });
+  });
+
+  // ==========================================================================
+  // Acquire
+  // ==========================================================================
+
+  describe('acquire()', () => {
+    it('acquires lock for a service', () => {
+      const result = lock.acquire('postgres', 'action-1');
+      expect(result.acquired).toBe(true);
+      expect(result.currentHolder).toBeUndefined();
+    });
+
+    it('fails to acquire lock already held by another holder', () => {
+      lock.acquire('postgres', 'action-1');
+      const result = lock.acquire('postgres', 'action-2');
+      expect(result.acquired).toBe(false);
+      expect(result.currentHolder).toBe('action-1');
+      expect(result.expiresAt).toBeGreaterThan(0);
+    });
+
+    it('allows acquiring locks for different services', () => {
+      const r1 = lock.acquire('postgres', 'action-1');
+      const r2 = lock.acquire('redis', 'action-2');
+      expect(r1.acquired).toBe(true);
+      expect(r2.acquired).toBe(true);
+    });
+
+    it('allows the same holder to acquire different services', () => {
+      const r1 = lock.acquire('postgres', 'action-1');
+      const r2 = lock.acquire('redis', 'action-1');
+      expect(r1.acquired).toBe(true);
+      expect(r2.acquired).toBe(true);
+    });
+
+    it('accepts custom TTL per acquisition', () => {
+      lock.acquire('postgres', 'action-1', 5000);
+      const entry = lock.getLock('postgres');
+      expect(entry?.ttlMs).toBe(5000);
+    });
+  });
+
+  // ==========================================================================
+  // Release
+  // ==========================================================================
+
+  describe('release()', () => {
+    it('releases a lock held by the correct holder', () => {
+      lock.acquire('postgres', 'action-1');
+      const released = lock.release('postgres', 'action-1');
+      expect(released).toBe(true);
+      expect(lock.isLocked('postgres')).toBe(false);
+    });
+
+    it('refuses release by wrong holder', () => {
+      lock.acquire('postgres', 'action-1');
+      const released = lock.release('postgres', 'action-2');
+      expect(released).toBe(false);
+      expect(lock.isLocked('postgres')).toBe(true);
+    });
+
+    it('returns false for non-existent lock', () => {
+      const released = lock.release('postgres', 'action-1');
+      expect(released).toBe(false);
+    });
+
+    it('allows reacquisition after release', () => {
+      lock.acquire('postgres', 'action-1');
+      lock.release('postgres', 'action-1');
+      const result = lock.acquire('postgres', 'action-2');
+      expect(result.acquired).toBe(true);
+    });
+  });
+
+  // ==========================================================================
+  // isLocked
+  // ==========================================================================
+
+  describe('isLocked()', () => {
+    it('returns false for unlocked service', () => {
+      expect(lock.isLocked('postgres')).toBe(false);
+    });
+
+    it('returns true for locked service', () => {
+      lock.acquire('postgres', 'action-1');
+      expect(lock.isLocked('postgres')).toBe(true);
+    });
+  });
+
+  // ==========================================================================
+  // TTL Expiry
+  // ==========================================================================
+
+  describe('TTL auto-expiry', () => {
+    it('evicts expired locks on isLocked()', () => {
+      const shortLock = createCoordinationLock(50);
+      shortLock.acquire('postgres', 'action-1');
+      expect(shortLock.isLocked('postgres')).toBe(true);
+
+      // Simulate time passing beyond TTL
+      vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 100);
+      expect(shortLock.isLocked('postgres')).toBe(false);
+    });
+
+    it('evicts expired locks on acquire()', () => {
+      const shortLock = createCoordinationLock(50);
+      shortLock.acquire('postgres', 'action-1');
+
+      // Simulate time passing beyond TTL
+      const future = Date.now() + 100;
+      vi.spyOn(Date, 'now').mockReturnValue(future);
+
+      const result = shortLock.acquire('postgres', 'action-2');
+      expect(result.acquired).toBe(true);
+    });
+  });
+
+  // ==========================================================================
+  // getActiveLocks
+  // ==========================================================================
+
+  describe('getActiveLocks()', () => {
+    it('returns empty array when no locks held', () => {
+      expect(lock.getActiveLocks()).toHaveLength(0);
+    });
+
+    it('returns all active locks', () => {
+      lock.acquire('postgres', 'action-1');
+      lock.acquire('redis', 'action-2');
+      const active = lock.getActiveLocks();
+      expect(active).toHaveLength(2);
+      expect(active.map((l) => l.serviceName)).toContain('postgres');
+      expect(active.map((l) => l.serviceName)).toContain('redis');
+    });
+
+    it('excludes expired locks', () => {
+      const shortLock = createCoordinationLock(50);
+      shortLock.acquire('postgres', 'action-1');
+      shortLock.acquire('redis', 'action-2', 999_999);
+
+      vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 100);
+      const active = shortLock.getActiveLocks();
+      expect(active).toHaveLength(1);
+      expect(active[0].serviceName).toBe('redis');
+    });
+  });
+
+  // ==========================================================================
+  // releaseAll
+  // ==========================================================================
+
+  describe('releaseAll()', () => {
+    it('releases all locks', () => {
+      lock.acquire('postgres', 'action-1');
+      lock.acquire('redis', 'action-2');
+      lock.acquire('mongodb', 'action-3');
+
+      lock.releaseAll();
+      expect(lock.getActiveLocks()).toHaveLength(0);
+      expect(lock.isLocked('postgres')).toBe(false);
+      expect(lock.isLocked('redis')).toBe(false);
+      expect(lock.isLocked('mongodb')).toBe(false);
+    });
+  });
+
+  // ==========================================================================
+  // getLock
+  // ==========================================================================
+
+  describe('getLock()', () => {
+    it('returns undefined for non-existent lock', () => {
+      expect(lock.getLock('postgres')).toBeUndefined();
+    });
+
+    it('returns lock entry for held lock', () => {
+      lock.acquire('postgres', 'action-1');
+      const entry = lock.getLock('postgres');
+      expect(entry).toBeDefined();
+      expect(entry!.serviceName).toBe('postgres');
+      expect(entry!.holderId).toBe('action-1');
+      expect(entry!.acquiredAt).toBeGreaterThan(0);
+      expect(entry!.ttlMs).toBe(120_000);
+    });
+  });
+});

--- a/v3/tests/unit/strange-loop/infra-healing/infra-action-executor.test.ts
+++ b/v3/tests/unit/strange-loop/infra-healing/infra-action-executor.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Infrastructure Action Executor Tests
+ * ADR-057: Infrastructure Self-Healing Extension
+ *
+ * Tests for the recovery cycle: healthCheck → recover → backoff → verify.
+ * Uses NoOpCommandRunner for deterministic testing.
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  InfraActionExecutor,
+  createInfraActionExecutor,
+  NoOpCommandRunner,
+} from '../../../../src/strange-loop/infra-healing/infra-action-executor.js';
+import {
+  RecoveryPlaybook,
+  createRecoveryPlaybook,
+} from '../../../../src/strange-loop/infra-healing/recovery-playbook.js';
+import {
+  CoordinationLock,
+  createCoordinationLock,
+} from '../../../../src/strange-loop/infra-healing/coordination-lock.js';
+
+// ============================================================================
+// Test YAML
+// ============================================================================
+
+const TEST_PLAYBOOK = `
+version: "1.0.0"
+defaults:
+  timeoutMs: 5000
+  maxRetries: 2
+  backoffMs: [100, 200]
+
+services:
+  postgres:
+    description: "PostgreSQL"
+    healthCheck:
+      command: "pg_isready"
+      timeoutMs: 3000
+    recover:
+      - command: "docker compose up -d postgres"
+        timeoutMs: 10000
+      - command: "sleep 1"
+        timeoutMs: 2000
+        required: false
+    verify:
+      command: "pg_isready"
+      timeoutMs: 3000
+    maxRetries: 2
+    backoffMs: [10, 20]
+
+  redis:
+    description: "Redis"
+    healthCheck:
+      command: "redis-cli ping"
+      timeoutMs: 2000
+    recover:
+      - command: "docker compose up -d redis"
+        timeoutMs: 10000
+    verify:
+      command: "redis-cli ping"
+      timeoutMs: 2000
+    maxRetries: 1
+    backoffMs: [10]
+`;
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+function createTestComponents() {
+  const runner = new NoOpCommandRunner();
+  const playbook = createRecoveryPlaybook();
+  playbook.loadFromString(TEST_PLAYBOOK);
+  const lock = createCoordinationLock(60_000);
+  const executor = createInfraActionExecutor(runner, playbook, lock);
+  return { runner, playbook, lock, executor };
+}
+
+// ============================================================================
+// Infrastructure Action Executor Tests
+// ============================================================================
+
+describe('InfraActionExecutor', () => {
+  let runner: NoOpCommandRunner;
+  let lock: CoordinationLock;
+  let executor: InfraActionExecutor;
+
+  beforeEach(() => {
+    const components = createTestComponents();
+    runner = components.runner;
+    lock = components.lock;
+    executor = components.executor;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ==========================================================================
+  // Factory
+  // ==========================================================================
+
+  describe('createInfraActionExecutor', () => {
+    it('creates an executor', () => {
+      const components = createTestComponents();
+      expect(components.executor).toBeInstanceOf(InfraActionExecutor);
+    });
+  });
+
+  // ==========================================================================
+  // NoOpCommandRunner
+  // ==========================================================================
+
+  describe('NoOpCommandRunner', () => {
+    it('returns success by default', async () => {
+      const noopRunner = new NoOpCommandRunner();
+      const result = await noopRunner.run('any command', 5000);
+      expect(result.exitCode).toBe(0);
+      expect(result.timedOut).toBe(false);
+    });
+
+    it('returns configured response for exact command match', async () => {
+      const noopRunner = new NoOpCommandRunner();
+      noopRunner.setResponse('fail-cmd', { exitCode: 1, stderr: 'error' });
+      const result = await noopRunner.run('fail-cmd', 5000);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toBe('error');
+    });
+
+    it('matches command prefix', async () => {
+      const noopRunner = new NoOpCommandRunner();
+      noopRunner.setResponse('pg_isready', { exitCode: 1 });
+      const result = await noopRunner.run('pg_isready -h localhost', 5000);
+      expect(result.exitCode).toBe(1);
+    });
+
+    it('logs all calls', async () => {
+      const noopRunner = new NoOpCommandRunner();
+      await noopRunner.run('cmd1', 1000);
+      await noopRunner.run('cmd2', 2000);
+      const calls = noopRunner.getCalls();
+      expect(calls).toHaveLength(2);
+      expect(calls[0]).toEqual({ command: 'cmd1', timeoutMs: 1000 });
+      expect(calls[1]).toEqual({ command: 'cmd2', timeoutMs: 2000 });
+    });
+
+    it('resets state', async () => {
+      const noopRunner = new NoOpCommandRunner();
+      noopRunner.setResponse('cmd', { exitCode: 1 });
+      await noopRunner.run('cmd', 1000);
+      noopRunner.reset();
+      expect(noopRunner.getCalls()).toHaveLength(0);
+      const result = await noopRunner.run('cmd', 1000);
+      expect(result.exitCode).toBe(0); // default after reset
+    });
+  });
+
+  // ==========================================================================
+  // Recovery: Service Already Healthy
+  // ==========================================================================
+
+  describe('service already healthy', () => {
+    it('skips recovery when health check passes', async () => {
+      // Default NoOp returns exitCode=0 (healthy)
+      const result = await executor.recoverService('postgres', 'action-1');
+      expect(result.recovered).toBe(true);
+      expect(result.totalAttempts).toBe(1);
+      expect(result.attempts[0].success).toBe(true);
+      expect(result.attempts[0].recoveryResults).toHaveLength(0);
+    });
+  });
+
+  // ==========================================================================
+  // Recovery: Successful After Commands
+  // ==========================================================================
+
+  describe('successful recovery', () => {
+    it('runs health check, recovery commands, and verify', async () => {
+      // Health check fails, recovery commands succeed, verify succeeds
+      runner.setResponse('pg_isready', { exitCode: 1, stderr: 'not ready' });
+      runner.setResponse('docker compose up -d postgres', { exitCode: 0 });
+      runner.setResponse('sleep 1', { exitCode: 0 });
+
+      // Override verify to succeed (pg_isready exact match already set to fail,
+      // but we need the verify to pass — so we remove the general override
+      // and use a more specific approach)
+      runner.reset();
+      let healthCheckCalls = 0;
+      const origRun = runner.run.bind(runner);
+      vi.spyOn(runner, 'run').mockImplementation(async (cmd, timeout) => {
+        if (cmd === 'pg_isready') {
+          healthCheckCalls++;
+          // First call (health check) fails, second call (verify) succeeds
+          return {
+            exitCode: healthCheckCalls === 1 ? 1 : 0,
+            stdout: '',
+            stderr: healthCheckCalls === 1 ? 'not ready' : '',
+            durationMs: 10,
+            timedOut: false,
+          };
+        }
+        return { exitCode: 0, stdout: '', stderr: '', durationMs: 10, timedOut: false };
+      });
+
+      const result = await executor.recoverService('postgres', 'action-1');
+      expect(result.recovered).toBe(true);
+      expect(result.totalAttempts).toBe(1);
+      expect(result.escalated).toBe(false);
+    });
+  });
+
+  // ==========================================================================
+  // Recovery: Failed After All Retries
+  // ==========================================================================
+
+  describe('failed recovery', () => {
+    it('reports failure after exhausting retries', async () => {
+      // All commands fail
+      vi.spyOn(runner, 'run').mockResolvedValue({
+        exitCode: 1,
+        stdout: '',
+        stderr: 'still down',
+        durationMs: 10,
+        timedOut: false,
+      });
+
+      const result = await executor.recoverService('postgres', 'action-1');
+      expect(result.recovered).toBe(false);
+      expect(result.totalAttempts).toBe(2); // maxRetries=2
+      expect(result.escalated).toBe(true);
+    });
+
+    it('stops on required recovery command failure', async () => {
+      let callCount = 0;
+      vi.spyOn(runner, 'run').mockImplementation(async () => {
+        callCount++;
+        // Health check fails (1), docker compose fails (2)
+        return {
+          exitCode: 1,
+          stdout: '',
+          stderr: 'failed',
+          durationMs: 10,
+          timedOut: false,
+        };
+      });
+
+      const result = await executor.recoverService('postgres', 'action-1');
+      expect(result.recovered).toBe(false);
+      // Should have errored on the required recovery command
+      expect(result.attempts[0].error).toContain('Required recovery command failed');
+    });
+  });
+
+  // ==========================================================================
+  // Recovery: Non-required Command Failure
+  // ==========================================================================
+
+  describe('non-required command failure', () => {
+    it('continues recovery when non-required command fails', async () => {
+      let callIndex = 0;
+      vi.spyOn(runner, 'run').mockImplementation(async () => {
+        callIndex++;
+        // 1: health check fails, 2: docker compose succeeds,
+        // 3: sleep fails (non-required), 4: verify succeeds
+        const exitCode = callIndex === 1 ? 1 : callIndex === 3 ? 1 : 0;
+        return { exitCode, stdout: '', stderr: '', durationMs: 10, timedOut: false };
+      });
+
+      const result = await executor.recoverService('postgres', 'action-1');
+      expect(result.recovered).toBe(true);
+    });
+  });
+
+  // ==========================================================================
+  // Coordination Lock
+  // ==========================================================================
+
+  describe('lock coordination', () => {
+    it('acquires and releases lock during recovery', async () => {
+      await executor.recoverService('postgres', 'action-1');
+      // Lock should be released after recovery
+      expect(lock.isLocked('postgres')).toBe(false);
+    });
+
+    it('returns early when lock is already held', async () => {
+      lock.acquire('postgres', 'other-action');
+      const result = await executor.recoverService('postgres', 'action-1');
+      expect(result.recovered).toBe(false);
+      expect(result.totalAttempts).toBe(0);
+    });
+
+    it('releases lock even when recovery throws', async () => {
+      vi.spyOn(runner, 'run').mockRejectedValue(new Error('crash'));
+      try {
+        await executor.recoverService('postgres', 'action-1');
+      } catch {
+        // expected
+      }
+      // Lock should still be released via finally
+      expect(lock.isLocked('postgres')).toBe(false);
+    });
+  });
+
+  // ==========================================================================
+  // Unknown Service
+  // ==========================================================================
+
+  describe('unknown service', () => {
+    it('returns escalated result for service not in playbook', async () => {
+      const result = await executor.recoverService('nonexistent', 'action-1');
+      expect(result.recovered).toBe(false);
+      expect(result.totalAttempts).toBe(0);
+      expect(result.escalated).toBe(true);
+    });
+  });
+
+  // ==========================================================================
+  // Statistics
+  // ==========================================================================
+
+  describe('getStats()', () => {
+    it('tracks recoveries attempted', async () => {
+      await executor.recoverService('postgres', 'action-1');
+      const stats = executor.getStats();
+      expect(stats.recoveriesAttempted).toBe(1);
+    });
+
+    it('tracks successful recoveries', async () => {
+      // Default NoOp returns healthy
+      await executor.recoverService('postgres', 'action-1');
+      const stats = executor.getStats();
+      expect(stats.recoveriesSucceeded).toBe(1);
+    });
+
+    it('tracks failed recoveries', async () => {
+      vi.spyOn(runner, 'run').mockResolvedValue({
+        exitCode: 1,
+        stdout: '',
+        stderr: 'failed',
+        durationMs: 10,
+        timedOut: false,
+      });
+      await executor.recoverService('postgres', 'action-1');
+      const stats = executor.getStats();
+      expect(stats.recoveriesFailed).toBe(1);
+    });
+
+    it('tracks lock contention events', async () => {
+      lock.acquire('postgres', 'blocker');
+      await executor.recoverService('postgres', 'action-1');
+      const stats = executor.getStats();
+      expect(stats.lockContentionEvents).toBe(1);
+    });
+
+    it('tracks per-service stats', async () => {
+      await executor.recoverService('postgres', 'action-1');
+      await executor.recoverService('redis', 'action-2');
+      const stats = executor.getStats();
+      expect(stats.byService['postgres']).toBeDefined();
+      expect(stats.byService['redis']).toBeDefined();
+    });
+  });
+});

--- a/v3/tests/unit/strange-loop/infra-healing/infra-healing-integration.test.ts
+++ b/v3/tests/unit/strange-loop/infra-healing/infra-healing-integration.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Infrastructure Healing Integration Tests
+ * ADR-057: Infrastructure Self-Healing Extension
+ *
+ * These tests prove the ACTUAL end-to-end wiring:
+ * - InfraAwareAgentProvider is plugged into StrangeLoopOrchestrator
+ * - CompositeActionExecutor routes infra actions to InfraActionExecutor
+ * - feedTestOutput → runCycle → recovery commands flow works
+ * - Synthetic infra agents appear in observations
+ * - Healing actions are generated and routed correctly
+ *
+ * If any of these tests fail, the integration is broken — not just a library.
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  createStrangeLoopWithInfraHealing,
+  createInMemoryStrangeLoopWithInfraHealing,
+  StrangeLoopOrchestrator,
+} from '../../../../src/strange-loop/strange-loop.js';
+import { InMemoryAgentProvider } from '../../../../src/strange-loop/swarm-observer.js';
+import { NoOpActionExecutor } from '../../../../src/strange-loop/healing-controller.js';
+import { NoOpCommandRunner } from '../../../../src/strange-loop/infra-healing/infra-action-executor.js';
+import type { InfraHealingOrchestrator } from '../../../../src/strange-loop/infra-healing/infra-healing-orchestrator.js';
+
+// ============================================================================
+// Test YAML Playbook
+// ============================================================================
+
+const INTEGRATION_PLAYBOOK = `
+version: "1.0.0"
+defaults:
+  timeoutMs: 5000
+  maxRetries: 1
+  backoffMs: [10]
+
+services:
+  postgres:
+    description: "PostgreSQL"
+    healthCheck:
+      command: "pg_isready"
+      timeoutMs: 3000
+    recover:
+      - command: "docker compose up -d postgres"
+        timeoutMs: 10000
+    verify:
+      command: "pg_isready"
+      timeoutMs: 3000
+
+  redis:
+    description: "Redis"
+    healthCheck:
+      command: "redis-cli ping"
+      timeoutMs: 2000
+    recover:
+      - command: "docker compose up -d redis"
+        timeoutMs: 10000
+    verify:
+      command: "redis-cli ping"
+      timeoutMs: 2000
+`;
+
+// ============================================================================
+// Integration Tests
+// ============================================================================
+
+describe('Infra-Healing Integration with StrangeLoop', () => {
+  let orchestrator: StrangeLoopOrchestrator;
+  let infraHealing: InfraHealingOrchestrator;
+  let provider: InMemoryAgentProvider;
+  let runner: NoOpCommandRunner;
+
+  beforeEach(() => {
+    runner = new NoOpCommandRunner();
+
+    const result = createInMemoryStrangeLoopWithInfraHealing(
+      'observer-0',
+      runner,
+      INTEGRATION_PLAYBOOK,
+      {
+        // Disable cooldown so multiple actions execute within a single cycle
+        actionCooldownMs: 0,
+        // Allow enough actions for infra recovery + swarm healing in one cycle
+        maxActionsPerCycle: 10,
+      },
+    );
+
+    orchestrator = result.orchestrator;
+    provider = result.provider;
+    infraHealing = result.infraHealing;
+
+    // Add a real swarm agent so the topology has at least one real node
+    provider.addAgent({
+      id: 'observer-0',
+      type: 'observer',
+      role: 'coordinator',
+      status: 'active',
+      joinedAt: Date.now(),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ==========================================================================
+  // Fix #1: createStrangeLoopWithInfraHealing wires everything
+  // ==========================================================================
+
+  describe('createStrangeLoopWithInfraHealing()', () => {
+    it('returns orchestrator and infraHealing', () => {
+      expect(orchestrator).toBeInstanceOf(StrangeLoopOrchestrator);
+      expect(infraHealing).toBeDefined();
+      expect(infraHealing.isReady()).toBe(true);
+    });
+
+    it('wires InfraAwareAgentProvider — synthetic agents appear in observation', async () => {
+      const cycle = await orchestrator.runCycle();
+      const agentIds = [...cycle.observation.agentHealth.keys()];
+
+      // Should include the real agent AND synthetic infra agents from playbook
+      expect(agentIds).toContain('observer-0');
+      expect(agentIds).toContain('infra-postgres');
+      expect(agentIds).toContain('infra-redis');
+    });
+
+    it('wires CompositeActionExecutor — restartAgent for infra-* routes to recovery', async () => {
+      // Feed failure so infra-postgres appears degraded
+      infraHealing.feedTestOutput('Error: connect ECONNREFUSED 127.0.0.1:5432');
+
+      // Run cycle — should detect infra-postgres degraded and attempt restart
+      const cycle = await orchestrator.runCycle();
+
+      // The runner should have been called with pg_isready (health check)
+      const calls = runner.getCalls();
+      const pgCalls = calls.filter(c => c.command.includes('pg_isready'));
+      expect(pgCalls.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ==========================================================================
+  // Fix #2: typeToAction maps infra vulns to restart_service
+  // ==========================================================================
+
+  describe('typeToAction generates actions for infra vulnerabilities', () => {
+    it('generates restart_service action when infra agent has low responsiveness', async () => {
+      // Feed failure → infra-postgres responsiveness = 0.0
+      infraHealing.feedTestOutput('Error: connect ECONNREFUSED 127.0.0.1:5432');
+
+      const cycle = await orchestrator.runCycle();
+
+      // Check that a restart_service action was generated for infra-postgres
+      const infraActions = cycle.actions.filter(
+        a => a.targetAgentId?.startsWith('infra-') && a.type === 'restart_service'
+      );
+      expect(infraActions.length).toBeGreaterThan(0);
+      expect(infraActions[0].targetAgentId).toBe('infra-postgres');
+    });
+
+    it('does NOT generate restart_service for healthy infra agents', async () => {
+      // No failure fed — all infra agents healthy (responsiveness 1.0)
+      const cycle = await orchestrator.runCycle();
+
+      const infraActions = cycle.actions.filter(
+        a => a.targetAgentId?.startsWith('infra-') && a.type === 'restart_service'
+      );
+      expect(infraActions).toHaveLength(0);
+    });
+  });
+
+  // ==========================================================================
+  // Full Pipeline: feed → observe → detect → decide → act → recover
+  // ==========================================================================
+
+  describe('full pipeline: feed → observe → decide → act → recover', () => {
+    it('detects postgres failure and executes playbook recovery commands', async () => {
+      // Setup: health check fails first, then recovery commands succeed, then verify succeeds
+      let healthCheckCalls = 0;
+      const runSpy = vi.spyOn(runner, 'run').mockImplementation(async (cmd) => {
+        if (cmd === 'pg_isready') {
+          healthCheckCalls++;
+          // First call = health check (fail), second = verify (pass)
+          return {
+            exitCode: healthCheckCalls === 1 ? 1 : 0,
+            stdout: '',
+            stderr: healthCheckCalls === 1 ? 'not ready' : '',
+            durationMs: 10,
+            timedOut: false,
+          };
+        }
+        // docker compose and other commands succeed
+        return { exitCode: 0, stdout: '', stderr: '', durationMs: 10, timedOut: false };
+      });
+
+      // 1. Feed test output with postgres error
+      infraHealing.feedTestOutput('Error: connect ECONNREFUSED 127.0.0.1:5432');
+
+      // 2. Run Strange Loop cycle
+      const cycle = await orchestrator.runCycle();
+
+      // 3. Verify actions were generated for infra-postgres
+      const infraActions = cycle.actions.filter(a => a.targetAgentId === 'infra-postgres');
+      expect(infraActions.length).toBeGreaterThan(0);
+
+      // 4. Verify the recovery commands were actually executed via the spy
+      // (vi.spyOn replaces .run() so callLog isn't populated — check spy calls instead)
+      expect(runSpy).toHaveBeenCalledWith('pg_isready', expect.any(Number));
+      expect(runSpy).toHaveBeenCalledWith(expect.stringContaining('docker compose'), expect.any(Number));
+    });
+
+    it('handles multiple failing services in a single cycle', async () => {
+      infraHealing.feedTestOutput(
+        'Error: connect ECONNREFUSED 127.0.0.1:5432\n' +
+        'Error: connect ECONNREFUSED 127.0.0.1:6379'
+      );
+
+      const cycle = await orchestrator.runCycle();
+
+      // Both infra agents should have actions
+      const infraTargets = cycle.actions
+        .filter(a => a.targetAgentId?.startsWith('infra-'))
+        .map(a => a.targetAgentId);
+      expect(infraTargets).toContain('infra-postgres');
+      expect(infraTargets).toContain('infra-redis');
+
+      // Recovery commands for both should have been called
+      const calls = runner.getCalls();
+      expect(calls.some(c => c.command.includes('pg_isready'))).toBe(true);
+      expect(calls.some(c => c.command.includes('redis-cli'))).toBe(true);
+    });
+
+    it('does not route real agent restarts to infra executor', async () => {
+      // Real agent should not trigger infra recovery
+      const cycle = await orchestrator.runCycle();
+
+      // runner should only be called for infra agents, not real ones
+      const calls = runner.getCalls();
+      const observerCalls = calls.filter(c =>
+        c.command.includes('observer-0')
+      );
+      expect(observerCalls).toHaveLength(0);
+    });
+  });
+
+  // ==========================================================================
+  // Synthetic Agents in Observation
+  // ==========================================================================
+
+  describe('synthetic infra agents in observation', () => {
+    it('healthy infra agents have responsiveness 1.0', async () => {
+      const cycle = await orchestrator.runCycle();
+      const pgHealth = cycle.observation.agentHealth.get('infra-postgres');
+      expect(pgHealth).toBeDefined();
+      expect(pgHealth!.responsiveness).toBe(1.0);
+    });
+
+    it('failing infra agents have responsiveness 0.0', async () => {
+      infraHealing.feedTestOutput('Error: connect ECONNREFUSED 127.0.0.1:5432');
+
+      const cycle = await orchestrator.runCycle();
+      const pgHealth = cycle.observation.agentHealth.get('infra-postgres');
+      expect(pgHealth).toBeDefined();
+      expect(pgHealth!.responsiveness).toBe(0.0);
+      expect(pgHealth!.errorRate).toBe(1.0);
+    });
+
+    it('redis is independent of postgres failure', async () => {
+      infraHealing.feedTestOutput('Error: connect ECONNREFUSED 127.0.0.1:5432');
+
+      const cycle = await orchestrator.runCycle();
+      const redisHealth = cycle.observation.agentHealth.get('infra-redis');
+      expect(redisHealth).toBeDefined();
+      expect(redisHealth!.responsiveness).toBe(1.0);
+    });
+  });
+
+  // ==========================================================================
+  // Stats flow through
+  // ==========================================================================
+
+  describe('stats propagation', () => {
+    it('infraHealing stats update after Strange Loop cycle triggers recovery', async () => {
+      infraHealing.feedTestOutput('Error: connect ECONNREFUSED 127.0.0.1:5432');
+      await orchestrator.runCycle();
+
+      const stats = infraHealing.getStats();
+      expect(stats.infraFailuresDetected).toBe(1);
+      // Recovery was attempted via the CompositeActionExecutor → InfraActionExecutor path
+      // so the infra executor stats should reflect actual activity
+      const executorStats = infraHealing.getExecutor().getStats();
+      expect(executorStats.recoveriesAttempted).toBeGreaterThan(0);
+    });
+  });
+
+  // ==========================================================================
+  // createStrangeLoopWithInfraHealing (non-in-memory variant)
+  // ==========================================================================
+
+  describe('createStrangeLoopWithInfraHealing() with explicit dependencies', () => {
+    it('accepts explicit provider and executor', () => {
+      const customProvider = new InMemoryAgentProvider('custom-obs');
+      const customExecutor = new NoOpActionExecutor();
+      const customRunner = new NoOpCommandRunner();
+
+      const result = createStrangeLoopWithInfraHealing({
+        provider: customProvider,
+        executor: customExecutor,
+        commandRunner: customRunner,
+        playbook: INTEGRATION_PLAYBOOK,
+      });
+
+      expect(result.orchestrator).toBeInstanceOf(StrangeLoopOrchestrator);
+      expect(result.infraHealing.isReady()).toBe(true);
+    });
+
+    it('passes custom variables to playbook', () => {
+      const result = createStrangeLoopWithInfraHealing({
+        provider: new InMemoryAgentProvider('obs'),
+        executor: new NoOpActionExecutor(),
+        commandRunner: new NoOpCommandRunner(),
+        playbook: INTEGRATION_PLAYBOOK,
+        variables: { PGHOST: 'db.custom.local' },
+      });
+
+      const plan = result.infraHealing.getPlaybook().getRecoveryPlan('postgres');
+      expect(plan).toBeDefined();
+    });
+  });
+});

--- a/v3/tests/unit/strange-loop/infra-healing/infra-healing-orchestrator.test.ts
+++ b/v3/tests/unit/strange-loop/infra-healing/infra-healing-orchestrator.test.ts
@@ -1,0 +1,434 @@
+/**
+ * Infrastructure Healing Orchestrator Tests
+ * ADR-057: Infrastructure Self-Healing Extension
+ *
+ * Full pipeline tests: feed output → observe → detect → recover → verify.
+ * Tests the top-level coordinator that wires all components together.
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  InfraHealingOrchestrator,
+  createInfraHealingOrchestratorSync,
+  createInfraHealingOrchestrator,
+} from '../../../../src/strange-loop/infra-healing/infra-healing-orchestrator.js';
+import { NoOpCommandRunner } from '../../../../src/strange-loop/infra-healing/infra-action-executor.js';
+
+// ============================================================================
+// Test YAML
+// ============================================================================
+
+const TEST_PLAYBOOK = `
+version: "1.0.0"
+defaults:
+  timeoutMs: 5000
+  maxRetries: 2
+  backoffMs: [10, 20]
+
+services:
+  postgres:
+    description: "PostgreSQL"
+    healthCheck:
+      command: "pg_isready"
+      timeoutMs: 3000
+    recover:
+      - command: "docker compose up -d postgres"
+        timeoutMs: 10000
+    verify:
+      command: "pg_isready"
+      timeoutMs: 3000
+    maxRetries: 2
+    backoffMs: [10, 20]
+
+  redis:
+    description: "Redis"
+    healthCheck:
+      command: "redis-cli ping"
+      timeoutMs: 2000
+    recover:
+      - command: "docker compose up -d redis"
+        timeoutMs: 10000
+    verify:
+      command: "redis-cli ping"
+      timeoutMs: 2000
+    maxRetries: 1
+    backoffMs: [10]
+`;
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+function createTestOrchestrator(runner?: NoOpCommandRunner) {
+  const commandRunner = runner ?? new NoOpCommandRunner();
+  return {
+    orchestrator: createInfraHealingOrchestratorSync({
+      commandRunner,
+      playbook: TEST_PLAYBOOK,
+    }),
+    runner: commandRunner,
+  };
+}
+
+// ============================================================================
+// Orchestrator Tests
+// ============================================================================
+
+describe('InfraHealingOrchestrator', () => {
+  let orchestrator: InfraHealingOrchestrator;
+  let runner: NoOpCommandRunner;
+
+  beforeEach(() => {
+    const components = createTestOrchestrator();
+    orchestrator = components.orchestrator;
+    runner = components.runner;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ==========================================================================
+  // Factory
+  // ==========================================================================
+
+  describe('createInfraHealingOrchestratorSync', () => {
+    it('creates an orchestrator with inline YAML', () => {
+      expect(orchestrator).toBeInstanceOf(InfraHealingOrchestrator);
+    });
+
+    it('is ready immediately with inline YAML', () => {
+      expect(orchestrator.isReady()).toBe(true);
+    });
+
+    it('accepts config overrides', () => {
+      const { orchestrator: orch } = createTestOrchestrator();
+      expect(orch.isReady()).toBe(true);
+    });
+  });
+
+  // ==========================================================================
+  // feedTestOutput()
+  // ==========================================================================
+
+  describe('feedTestOutput()', () => {
+    it('processes clean output without detecting failures', () => {
+      orchestrator.feedTestOutput('All 42 tests passed.\nDone in 5.3s');
+      const stats = orchestrator.getStats();
+      expect(stats.totalObservations).toBe(1);
+      expect(stats.infraFailuresDetected).toBe(0);
+    });
+
+    it('detects postgres failure from test output', () => {
+      orchestrator.feedTestOutput('Error: connect ECONNREFUSED 127.0.0.1:5432');
+      const stats = orchestrator.getStats();
+      expect(stats.totalObservations).toBe(1);
+      expect(stats.infraFailuresDetected).toBe(1);
+      expect(stats.byService['postgres']?.failures).toBe(1);
+    });
+
+    it('detects multiple service failures', () => {
+      orchestrator.feedTestOutput(
+        'Error: connect ECONNREFUSED 127.0.0.1:5432\n' +
+        'Error: connect ECONNREFUSED 127.0.0.1:6379'
+      );
+      const stats = orchestrator.getStats();
+      expect(stats.infraFailuresDetected).toBe(2);
+      expect(stats.byService['postgres']?.failures).toBe(1);
+      expect(stats.byService['redis']?.failures).toBe(1);
+    });
+
+    it('accumulates observations across multiple calls', () => {
+      orchestrator.feedTestOutput('Error: connect ECONNREFUSED 127.0.0.1:5432');
+      orchestrator.feedTestOutput('Error: connect ECONNREFUSED 127.0.0.1:6379');
+      const stats = orchestrator.getStats();
+      expect(stats.totalObservations).toBe(2);
+      expect(stats.infraFailuresDetected).toBe(2);
+    });
+  });
+
+  // ==========================================================================
+  // runRecoveryCycle()
+  // ==========================================================================
+
+  describe('runRecoveryCycle()', () => {
+    it('returns empty results when no failures detected', async () => {
+      const results = await orchestrator.runRecoveryCycle();
+      expect(results).toHaveLength(0);
+    });
+
+    it('returns empty results after clean output', async () => {
+      orchestrator.feedTestOutput('All tests passed');
+      const results = await orchestrator.runRecoveryCycle();
+      expect(results).toHaveLength(0);
+    });
+
+    it('attempts recovery for detected failures', async () => {
+      orchestrator.feedTestOutput('Error: connect ECONNREFUSED 127.0.0.1:5432');
+      const results = await orchestrator.runRecoveryCycle();
+      expect(results).toHaveLength(1);
+      expect(results[0].serviceName).toBe('postgres');
+    });
+
+    it('recovers service when all commands succeed', async () => {
+      // By default NoOp returns exitCode=0 (service already healthy)
+      orchestrator.feedTestOutput('Error: connect ECONNREFUSED 127.0.0.1:5432');
+      const results = await orchestrator.runRecoveryCycle();
+      expect(results[0].recovered).toBe(true);
+    });
+
+    it('reports failure when recovery fails', async () => {
+      vi.spyOn(runner, 'run').mockResolvedValue({
+        exitCode: 1,
+        stdout: '',
+        stderr: 'still down',
+        durationMs: 10,
+        timedOut: false,
+      });
+
+      orchestrator.feedTestOutput('Error: connect ECONNREFUSED 127.0.0.1:5432');
+      const results = await orchestrator.runRecoveryCycle();
+      expect(results[0].recovered).toBe(false);
+      expect(results[0].escalated).toBe(true);
+    });
+
+    it('recovers multiple services in one cycle', async () => {
+      orchestrator.feedTestOutput(
+        'Error: connect ECONNREFUSED 127.0.0.1:5432\n' +
+        'Error: connect ECONNREFUSED 127.0.0.1:6379'
+      );
+      const results = await orchestrator.runRecoveryCycle();
+      expect(results).toHaveLength(2);
+      const serviceNames = results.map((r) => r.serviceName);
+      expect(serviceNames).toContain('postgres');
+      expect(serviceNames).toContain('redis');
+    });
+
+    it('respects maxConcurrentRecoveries config', async () => {
+      const { orchestrator: orch } = createTestOrchestrator(runner);
+
+      // Override with max 1 concurrent recovery
+      const limitedOrch = createInfraHealingOrchestratorSync({
+        commandRunner: new NoOpCommandRunner(),
+        playbook: TEST_PLAYBOOK,
+        config: { maxConcurrentRecoveries: 1 },
+      });
+
+      limitedOrch.feedTestOutput(
+        'Error: connect ECONNREFUSED 127.0.0.1:5432\n' +
+        'Error: connect ECONNREFUSED 127.0.0.1:6379'
+      );
+      const results = await limitedOrch.runRecoveryCycle();
+      expect(results).toHaveLength(1); // Only 1 due to limit
+    });
+  });
+
+  // ==========================================================================
+  // Full Pipeline: feed → detect → recover → stats
+  // ==========================================================================
+
+  describe('full pipeline', () => {
+    it('detects postgres failure and recovers it', async () => {
+      // 1. Feed test output with postgres error
+      orchestrator.feedTestOutput(
+        'Running test suite...\n' +
+        'Error: connect ECONNREFUSED 127.0.0.1:5432\n' +
+        'FAIL: test_user_creation\n'
+      );
+
+      // 2. Verify detection
+      const statsBefore = orchestrator.getStats();
+      expect(statsBefore.infraFailuresDetected).toBe(1);
+
+      // 3. Run recovery (NoOp returns success by default)
+      const results = await orchestrator.runRecoveryCycle();
+      expect(results).toHaveLength(1);
+      expect(results[0].recovered).toBe(true);
+
+      // 4. Verify stats updated
+      const statsAfter = orchestrator.getStats();
+      expect(statsAfter.recoveriesAttempted).toBe(1);
+      expect(statsAfter.recoveriesSucceeded).toBe(1);
+    });
+
+    it('handles multiple failures with mixed recovery results', async () => {
+      let callCount = 0;
+      vi.spyOn(runner, 'run').mockImplementation(async (cmd) => {
+        callCount++;
+        // postgres health check passes (service already healthy)
+        if (cmd === 'pg_isready') {
+          return { exitCode: 0, stdout: '', stderr: '', durationMs: 10, timedOut: false };
+        }
+        // redis health check fails, recovery fails
+        if (cmd.includes('redis')) {
+          return { exitCode: 1, stdout: '', stderr: 'failed', durationMs: 10, timedOut: false };
+        }
+        // Everything else fails
+        return { exitCode: 1, stdout: '', stderr: 'failed', durationMs: 10, timedOut: false };
+      });
+
+      orchestrator.feedTestOutput(
+        'Error: connect ECONNREFUSED 127.0.0.1:5432\n' +
+        'Error: connect ECONNREFUSED 127.0.0.1:6379'
+      );
+      const results = await orchestrator.runRecoveryCycle();
+
+      const postgresResult = results.find((r) => r.serviceName === 'postgres');
+      const redisResult = results.find((r) => r.serviceName === 'redis');
+
+      expect(postgresResult?.recovered).toBe(true);
+      expect(redisResult?.recovered).toBe(false);
+    });
+  });
+
+  // ==========================================================================
+  // Component Accessors
+  // ==========================================================================
+
+  describe('component accessors', () => {
+    it('exposes observer', () => {
+      expect(orchestrator.getObserver()).toBeDefined();
+    });
+
+    it('exposes playbook', () => {
+      expect(orchestrator.getPlaybook()).toBeDefined();
+      expect(orchestrator.getPlaybook().isLoaded()).toBe(true);
+    });
+
+    it('exposes lock', () => {
+      expect(orchestrator.getLock()).toBeDefined();
+    });
+
+    it('exposes executor', () => {
+      expect(orchestrator.getExecutor()).toBeDefined();
+    });
+  });
+
+  // ==========================================================================
+  // Statistics
+  // ==========================================================================
+
+  describe('getStats()', () => {
+    it('returns zeroed stats initially', () => {
+      const stats = orchestrator.getStats();
+      expect(stats.totalObservations).toBe(0);
+      expect(stats.infraFailuresDetected).toBe(0);
+      expect(stats.recoveriesAttempted).toBe(0);
+      expect(stats.recoveriesSucceeded).toBe(0);
+      expect(stats.recoveriesFailed).toBe(0);
+      expect(stats.lockContentionEvents).toBe(0);
+    });
+
+    it('merges executor stats into orchestrator stats', async () => {
+      orchestrator.feedTestOutput('Error: connect ECONNREFUSED 127.0.0.1:5432');
+      await orchestrator.runRecoveryCycle();
+
+      const stats = orchestrator.getStats();
+      expect(stats.totalObservations).toBe(1);
+      expect(stats.infraFailuresDetected).toBe(1);
+      expect(stats.recoveriesAttempted).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // ==========================================================================
+  // isReady()
+  // ==========================================================================
+
+  describe('isReady()', () => {
+    it('returns true when playbook is loaded', () => {
+      expect(orchestrator.isReady()).toBe(true);
+    });
+  });
+
+  // ==========================================================================
+  // Skips services without playbook entry
+  // ==========================================================================
+
+  describe('services without playbook entry', () => {
+    it('skips services not in playbook during recovery', async () => {
+      // DNS errors map to service 'dns' which is not in our test playbook
+      orchestrator.feedTestOutput('Error: getaddrinfo ENOTFOUND myservice.local');
+      const results = await orchestrator.runRecoveryCycle();
+      // 'dns' service is not in test playbook — should be skipped
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  // ==========================================================================
+  // Async factory: createInfraHealingOrchestrator (file-based)
+  // ==========================================================================
+
+  describe('createInfraHealingOrchestrator (async factory)', () => {
+    it('creates orchestrator from YAML file path', async () => {
+      const fs = await import('node:fs/promises');
+      const path = await import('node:path');
+      const os = await import('node:os');
+
+      const tmpFile = path.join(os.tmpdir(), `aqe-orch-test-${Date.now()}.yaml`);
+      await fs.writeFile(tmpFile, TEST_PLAYBOOK, 'utf-8');
+
+      try {
+        const runner = new NoOpCommandRunner();
+        const orch = await createInfraHealingOrchestrator({
+          commandRunner: runner,
+          playbook: tmpFile, // file path, not YAML string
+        });
+
+        expect(orch.isReady()).toBe(true);
+        expect(orch.getPlaybook().listServices()).toContain('postgres');
+        expect(orch.getPlaybook().listServices()).toContain('redis');
+      } finally {
+        await fs.unlink(tmpFile);
+      }
+    });
+
+    it('creates orchestrator from inline YAML when playbookIsFile is false', async () => {
+      const runner = new NoOpCommandRunner();
+      const orch = await createInfraHealingOrchestrator({
+        commandRunner: runner,
+        playbook: TEST_PLAYBOOK,
+        playbookIsFile: false,
+      });
+
+      expect(orch.isReady()).toBe(true);
+      expect(orch.getPlaybook().listServices()).toContain('postgres');
+    });
+
+    it('async factory produces working recovery cycle', async () => {
+      const fs = await import('node:fs/promises');
+      const path = await import('node:path');
+      const os = await import('node:os');
+
+      const tmpFile = path.join(os.tmpdir(), `aqe-orch-cycle-${Date.now()}.yaml`);
+      await fs.writeFile(tmpFile, TEST_PLAYBOOK, 'utf-8');
+
+      try {
+        const runner = new NoOpCommandRunner();
+        runner.setResponse('pg_isready', { exitCode: 1, stderr: 'no response', stdout: '' });
+        runner.setResponse('docker compose up -d postgres', { exitCode: 0, stdout: 'Starting...' });
+
+        const orch = await createInfraHealingOrchestrator({
+          commandRunner: runner,
+          playbook: tmpFile,
+        });
+
+        orch.feedTestOutput('Error: connect ECONNREFUSED 127.0.0.1:5432');
+        const results = await orch.runRecoveryCycle();
+
+        expect(results.length).toBeGreaterThan(0);
+        expect(results[0].serviceName).toBe('postgres');
+        expect(runner.getCalls().length).toBeGreaterThan(0);
+      } finally {
+        await fs.unlink(tmpFile);
+      }
+    });
+
+    it('rejects non-existent file path', async () => {
+      const runner = new NoOpCommandRunner();
+      await expect(createInfraHealingOrchestrator({
+        commandRunner: runner,
+        playbook: '/tmp/does-not-exist-aqe-playbook.yaml',
+      })).rejects.toThrow();
+    });
+  });
+});

--- a/v3/tests/unit/strange-loop/infra-healing/recovery-playbook.test.ts
+++ b/v3/tests/unit/strange-loop/infra-healing/recovery-playbook.test.ts
@@ -1,0 +1,338 @@
+/**
+ * Recovery Playbook Tests
+ * ADR-057: Infrastructure Self-Healing Extension
+ *
+ * Tests for YAML playbook loading, parsing, variable interpolation,
+ * and service recovery plan retrieval.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  RecoveryPlaybook,
+  createRecoveryPlaybook,
+} from '../../../../src/strange-loop/infra-healing/recovery-playbook.js';
+
+// ============================================================================
+// Test YAML Fixtures
+// ============================================================================
+
+const MINIMAL_PLAYBOOK = `
+version: "1.0.0"
+services:
+  postgres:
+    healthCheck:
+      command: "pg_isready"
+      timeoutMs: 5000
+    recover:
+      - command: "docker compose up -d postgres"
+        timeoutMs: 30000
+    verify:
+      command: "pg_isready"
+      timeoutMs: 5000
+`;
+
+const FULL_PLAYBOOK = `
+version: "2.0.0"
+defaults:
+  timeoutMs: 8000
+  maxRetries: 2
+  backoffMs: [1000, 3000]
+
+services:
+  postgres:
+    description: "PostgreSQL database"
+    healthCheck:
+      command: "pg_isready -h localhost -p 5432"
+      timeoutMs: 5000
+    recover:
+      - command: "docker compose up -d postgres"
+        timeoutMs: 30000
+      - command: "sleep 3"
+        timeoutMs: 5000
+        required: false
+    verify:
+      command: "pg_isready -h localhost -p 5432"
+      timeoutMs: 5000
+    maxRetries: 3
+    backoffMs: [2000, 5000, 10000]
+
+  redis:
+    description: "Redis cache"
+    healthCheck: "redis-cli ping"
+    recover:
+      - command: "docker compose up -d redis"
+        timeoutMs: 15000
+    verify: "redis-cli ping"
+`;
+
+const INTERPOLATION_PLAYBOOK = `
+version: "1.0.0"
+services:
+  postgres:
+    healthCheck:
+      command: "pg_isready -h \${PGHOST} -p \${PGPORT}"
+      timeoutMs: 5000
+    recover:
+      - command: "docker compose up -d \${DB_SERVICE}"
+        timeoutMs: 30000
+    verify:
+      command: "pg_isready -h \${PGHOST} -p \${PGPORT}"
+      timeoutMs: 5000
+`;
+
+// ============================================================================
+// Recovery Playbook Tests
+// ============================================================================
+
+describe('RecoveryPlaybook', () => {
+  let playbook: RecoveryPlaybook;
+
+  beforeEach(() => {
+    playbook = createRecoveryPlaybook();
+  });
+
+  // ==========================================================================
+  // Factory
+  // ==========================================================================
+
+  describe('createRecoveryPlaybook', () => {
+    it('creates a playbook instance', () => {
+      const pb = createRecoveryPlaybook();
+      expect(pb).toBeInstanceOf(RecoveryPlaybook);
+    });
+
+    it('accepts explicit variables', () => {
+      const pb = createRecoveryPlaybook({ PGHOST: 'db.example.com' });
+      expect(pb).toBeInstanceOf(RecoveryPlaybook);
+    });
+  });
+
+  // ==========================================================================
+  // Loading
+  // ==========================================================================
+
+  describe('loadFromString()', () => {
+    it('loads a minimal YAML playbook', () => {
+      playbook.loadFromString(MINIMAL_PLAYBOOK);
+      expect(playbook.isLoaded()).toBe(true);
+    });
+
+    it('loads a full YAML playbook with all fields', () => {
+      playbook.loadFromString(FULL_PLAYBOOK);
+      expect(playbook.isLoaded()).toBe(true);
+    });
+  });
+
+  describe('isLoaded()', () => {
+    it('returns false before loading', () => {
+      expect(playbook.isLoaded()).toBe(false);
+    });
+
+    it('returns true after loading', () => {
+      playbook.loadFromString(MINIMAL_PLAYBOOK);
+      expect(playbook.isLoaded()).toBe(true);
+    });
+  });
+
+  // ==========================================================================
+  // Service Listing
+  // ==========================================================================
+
+  describe('listServices()', () => {
+    it('returns empty array before loading', () => {
+      expect(playbook.listServices()).toHaveLength(0);
+    });
+
+    it('returns service names from playbook', () => {
+      playbook.loadFromString(FULL_PLAYBOOK);
+      const services = playbook.listServices();
+      expect(services).toContain('postgres');
+      expect(services).toContain('redis');
+      expect(services).toHaveLength(2);
+    });
+  });
+
+  // ==========================================================================
+  // Recovery Plan Retrieval
+  // ==========================================================================
+
+  describe('getRecoveryPlan()', () => {
+    it('returns undefined before loading', () => {
+      expect(playbook.getRecoveryPlan('postgres')).toBeUndefined();
+    });
+
+    it('returns undefined for unknown service', () => {
+      playbook.loadFromString(FULL_PLAYBOOK);
+      expect(playbook.getRecoveryPlan('nonexistent')).toBeUndefined();
+    });
+
+    it('returns recovery plan for known service', () => {
+      playbook.loadFromString(FULL_PLAYBOOK);
+      const plan = playbook.getRecoveryPlan('postgres');
+      expect(plan).toBeDefined();
+      expect(plan!.serviceName).toBe('postgres');
+      expect(plan!.description).toBe('PostgreSQL database');
+    });
+
+    it('parses healthCheck command correctly', () => {
+      playbook.loadFromString(FULL_PLAYBOOK);
+      const plan = playbook.getRecoveryPlan('postgres')!;
+      expect(plan.healthCheck.command).toBe('pg_isready -h localhost -p 5432');
+      expect(plan.healthCheck.timeoutMs).toBe(5000);
+      expect(plan.healthCheck.required).toBe(true);
+    });
+
+    it('parses recover commands in order', () => {
+      playbook.loadFromString(FULL_PLAYBOOK);
+      const plan = playbook.getRecoveryPlan('postgres')!;
+      expect(plan.recover).toHaveLength(2);
+      expect(plan.recover[0].command).toBe('docker compose up -d postgres');
+      expect(plan.recover[0].timeoutMs).toBe(30000);
+      expect(plan.recover[0].required).toBe(true);
+      expect(plan.recover[1].command).toBe('sleep 3');
+      expect(plan.recover[1].required).toBe(false);
+    });
+
+    it('parses verify command correctly', () => {
+      playbook.loadFromString(FULL_PLAYBOOK);
+      const plan = playbook.getRecoveryPlan('postgres')!;
+      expect(plan.verify.command).toBe('pg_isready -h localhost -p 5432');
+      expect(plan.verify.timeoutMs).toBe(5000);
+    });
+
+    it('uses per-service maxRetries and backoffMs', () => {
+      playbook.loadFromString(FULL_PLAYBOOK);
+      const plan = playbook.getRecoveryPlan('postgres')!;
+      expect(plan.maxRetries).toBe(3);
+      expect(plan.backoffMs).toEqual([2000, 5000, 10000]);
+    });
+
+    it('inherits defaults when per-service values not specified', () => {
+      playbook.loadFromString(FULL_PLAYBOOK);
+      const plan = playbook.getRecoveryPlan('redis')!;
+      expect(plan.maxRetries).toBe(2); // from defaults
+      expect(plan.backoffMs).toEqual([1000, 3000]); // from defaults
+    });
+
+    it('handles string-only command shorthand', () => {
+      playbook.loadFromString(FULL_PLAYBOOK);
+      const plan = playbook.getRecoveryPlan('redis')!;
+      // healthCheck was a bare string, should get default timeout
+      expect(plan.healthCheck.command).toBe('redis-cli ping');
+      expect(plan.healthCheck.timeoutMs).toBe(8000); // defaults.timeoutMs
+    });
+  });
+
+  // ==========================================================================
+  // Config Retrieval
+  // ==========================================================================
+
+  describe('getConfig()', () => {
+    it('returns null before loading', () => {
+      expect(playbook.getConfig()).toBeNull();
+    });
+
+    it('returns full config after loading', () => {
+      playbook.loadFromString(FULL_PLAYBOOK);
+      const config = playbook.getConfig()!;
+      expect(config.version).toBe('2.0.0');
+      expect(config.defaultTimeoutMs).toBe(8000);
+      expect(config.defaultMaxRetries).toBe(2);
+      expect(config.defaultBackoffMs).toEqual([1000, 3000]);
+    });
+  });
+
+  // ==========================================================================
+  // Variable Interpolation
+  // ==========================================================================
+
+  describe('variable interpolation', () => {
+    it('interpolates variables from constructor', () => {
+      const pb = createRecoveryPlaybook({
+        PGHOST: 'db.production.local',
+        PGPORT: '5433',
+        DB_SERVICE: 'my-postgres',
+      });
+      pb.loadFromString(INTERPOLATION_PLAYBOOK);
+
+      const plan = pb.getRecoveryPlan('postgres')!;
+      expect(plan.healthCheck.command).toBe('pg_isready -h db.production.local -p 5433');
+      expect(plan.recover[0].command).toBe('docker compose up -d my-postgres');
+      expect(plan.verify.command).toBe('pg_isready -h db.production.local -p 5433');
+    });
+
+    it('leaves unresolved variables as-is', () => {
+      const pb = createRecoveryPlaybook({ PGHOST: 'localhost' });
+      pb.loadFromString(INTERPOLATION_PLAYBOOK);
+
+      const plan = pb.getRecoveryPlan('postgres')!;
+      expect(plan.healthCheck.command).toBe('pg_isready -h localhost -p ${PGPORT}');
+    });
+  });
+
+  // ==========================================================================
+  // Defaults Fallback
+  // ==========================================================================
+
+  describe('defaults fallback', () => {
+    it('uses hardcoded defaults when no defaults section', () => {
+      playbook.loadFromString(MINIMAL_PLAYBOOK);
+      const plan = playbook.getRecoveryPlan('postgres')!;
+      expect(plan.maxRetries).toBe(3); // hardcoded default
+      expect(plan.backoffMs).toEqual([2000, 5000, 10000]); // hardcoded default
+    });
+  });
+
+  // ==========================================================================
+  // loadFromFile
+  // ==========================================================================
+
+  describe('loadFromFile', () => {
+    it('loads playbook from a real YAML file', async () => {
+      const fs = await import('node:fs/promises');
+      const path = await import('node:path');
+      const os = await import('node:os');
+
+      // Write a temp YAML file
+      const tmpDir = os.tmpdir();
+      const tmpFile = path.join(tmpDir, `aqe-playbook-test-${Date.now()}.yaml`);
+      await fs.writeFile(tmpFile, MINIMAL_PLAYBOOK, 'utf-8');
+
+      try {
+        await playbook.loadFromFile(tmpFile);
+        const services = playbook.listServices();
+        expect(services).toContain('postgres');
+        const plan = playbook.getRecoveryPlan('postgres')!;
+        expect(plan.healthCheck.command).toBe('pg_isready');
+        expect(plan.recover).toHaveLength(1);
+        expect(plan.recover[0].command).toBe('docker compose up -d postgres');
+      } finally {
+        await fs.unlink(tmpFile);
+      }
+    });
+
+    it('rejects non-existent file path', async () => {
+      await expect(playbook.loadFromFile('/tmp/does-not-exist-aqe.yaml'))
+        .rejects.toThrow();
+    });
+
+    it('getConfig returns parsed config after loadFromFile', async () => {
+      const fs = await import('node:fs/promises');
+      const path = await import('node:path');
+      const os = await import('node:os');
+
+      const tmpFile = path.join(os.tmpdir(), `aqe-playbook-config-${Date.now()}.yaml`);
+      await fs.writeFile(tmpFile, MINIMAL_PLAYBOOK, 'utf-8');
+
+      try {
+        await playbook.loadFromFile(tmpFile);
+        const config = playbook.getConfig();
+        expect(config).toBeDefined();
+        expect(config!.version).toBe('1.0.0');
+        expect(config!.services).toHaveProperty('postgres');
+      } finally {
+        await fs.unlink(tmpFile);
+      }
+    });
+  });
+});

--- a/v3/tests/unit/strange-loop/infra-healing/test-output-observer.test.ts
+++ b/v3/tests/unit/strange-loop/infra-healing/test-output-observer.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Test Output Observer Tests
+ * ADR-057: Infrastructure Self-Healing Extension
+ *
+ * Tests pattern matching for infrastructure error signatures,
+ * classification, deduplication, and vulnerability generation.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  TestOutputObserver,
+  createTestOutputObserver,
+  DEFAULT_ERROR_SIGNATURES,
+} from '../../../../src/strange-loop/infra-healing/test-output-observer.js';
+import type { InfraErrorSignature } from '../../../../src/strange-loop/infra-healing/types.js';
+
+// ============================================================================
+// Test Output Observer Tests
+// ============================================================================
+
+describe('TestOutputObserver', () => {
+  let observer: TestOutputObserver;
+
+  beforeEach(() => {
+    observer = createTestOutputObserver();
+  });
+
+  // ==========================================================================
+  // Factory
+  // ==========================================================================
+
+  describe('createTestOutputObserver', () => {
+    it('creates an observer with default signatures', () => {
+      const obs = createTestOutputObserver();
+      expect(obs).toBeInstanceOf(TestOutputObserver);
+    });
+
+    it('accepts custom signatures', () => {
+      const custom: InfraErrorSignature[] = [
+        {
+          pattern: /CUSTOM_ERROR/,
+          classification: 'infra_failure',
+          vulnerabilityType: 'service_unreachable',
+          serviceName: 'custom-service',
+          defaultSeverity: 0.9,
+          description: 'Custom error',
+        },
+      ];
+      const obs = createTestOutputObserver(custom);
+      const result = obs.observe('CUSTOM_ERROR occurred');
+      expect(result.infraFailures).toHaveLength(1);
+      expect(result.infraFailures[0].serviceName).toBe('custom-service');
+    });
+  });
+
+  // ==========================================================================
+  // Default Signatures Coverage
+  // ==========================================================================
+
+  describe('DEFAULT_ERROR_SIGNATURES', () => {
+    it('has at least 20 built-in signatures', () => {
+      expect(DEFAULT_ERROR_SIGNATURES.length).toBeGreaterThanOrEqual(20);
+    });
+
+    it('all signatures have required fields', () => {
+      for (const sig of DEFAULT_ERROR_SIGNATURES) {
+        expect(sig.pattern).toBeInstanceOf(RegExp);
+        expect(sig.classification).toBeTruthy();
+        expect(sig.vulnerabilityType).toBeTruthy();
+        expect(sig.serviceName).toBeTruthy();
+        expect(sig.defaultSeverity).toBeGreaterThan(0);
+        expect(sig.description).toBeTruthy();
+      }
+    });
+  });
+
+  // ==========================================================================
+  // Database Connection Errors
+  // ==========================================================================
+
+  describe('database connection errors', () => {
+    it('detects PostgreSQL ECONNREFUSED on port 5432', () => {
+      const result = observer.observe('Error: connect ECONNREFUSED 127.0.0.1:5432');
+      expect(result.infraFailures).toHaveLength(1);
+      expect(result.infraFailures[0].serviceName).toBe('postgres');
+      expect(result.infraFailures[0].classification).toBe('infra_failure');
+    });
+
+    it('detects MySQL ECONNREFUSED on port 3306', () => {
+      const result = observer.observe('Error: connect ECONNREFUSED 127.0.0.1:3306');
+      expect(result.infraFailures).toHaveLength(1);
+      expect(result.infraFailures[0].serviceName).toBe('mysql');
+    });
+
+    it('detects MongoDB ECONNREFUSED on port 27017', () => {
+      const result = observer.observe('Error: connect ECONNREFUSED 127.0.0.1:27017');
+      expect(result.infraFailures).toHaveLength(1);
+      expect(result.infraFailures[0].serviceName).toBe('mongodb');
+    });
+
+    it('detects psycopg2 connection errors', () => {
+      const result = observer.observe(
+        'psycopg2.OperationalError: could not connect to server: Connection refused'
+      );
+      expect(result.infraFailures).toHaveLength(1);
+      expect(result.infraFailures[0].serviceName).toBe('postgres');
+    });
+
+    it('detects Java JDBC connection failures', () => {
+      const result = observer.observe(
+        'java.sql.SQLException: Communications link failure - Connection refused'
+      );
+      expect(result.infraFailures).toHaveLength(1);
+      expect(result.infraFailures[0].serviceName).toBe('mysql');
+    });
+  });
+
+  // ==========================================================================
+  // Cache / Message Broker Errors
+  // ==========================================================================
+
+  describe('cache and message broker errors', () => {
+    it('detects Redis ECONNREFUSED on port 6379', () => {
+      const result = observer.observe('Error: connect ECONNREFUSED 127.0.0.1:6379');
+      expect(result.infraFailures).toHaveLength(1);
+      expect(result.infraFailures[0].serviceName).toBe('redis');
+    });
+
+    it('detects RabbitMQ ECONNREFUSED on port 5672', () => {
+      const result = observer.observe('Error: connect ECONNREFUSED 127.0.0.1:5672');
+      expect(result.infraFailures).toHaveLength(1);
+      expect(result.infraFailures[0].serviceName).toBe('rabbitmq');
+    });
+
+    it('detects Kafka ECONNREFUSED on port 9092', () => {
+      const result = observer.observe('Error: connect ECONNREFUSED 127.0.0.1:9092');
+      expect(result.infraFailures).toHaveLength(1);
+      expect(result.infraFailures[0].serviceName).toBe('kafka');
+    });
+
+    it('detects Elasticsearch ECONNREFUSED on port 9200', () => {
+      const result = observer.observe('Error: connect ECONNREFUSED 127.0.0.1:9200');
+      expect(result.infraFailures).toHaveLength(1);
+      expect(result.infraFailures[0].serviceName).toBe('elasticsearch');
+    });
+  });
+
+  // ==========================================================================
+  // Network Errors
+  // ==========================================================================
+
+  describe('network errors', () => {
+    it('detects ETIMEDOUT', () => {
+      const result = observer.observe('Error: connect ETIMEDOUT 10.0.0.1:443');
+      expect(result.infraFailures).toHaveLength(1);
+      expect(result.infraFailures[0].matchedSignature?.vulnerabilityType).toBe('infra_timeout');
+    });
+
+    it('detects ESOCKETTIMEDOUT', () => {
+      const result = observer.observe('Error: ESOCKETTIMEDOUT');
+      expect(result.infraFailures).toHaveLength(1);
+    });
+
+    it('detects ECONNRESET', () => {
+      const result = observer.observe('Error: read ECONNRESET');
+      expect(result.infraFailures).toHaveLength(1);
+      expect(result.infraFailures[0].matchedSignature?.vulnerabilityType).toBe('service_unreachable');
+    });
+
+    it('detects DNS ENOTFOUND', () => {
+      const result = observer.observe('Error: getaddrinfo ENOTFOUND myservice.local');
+      expect(result.infraFailures).toHaveLength(1);
+      expect(result.infraFailures[0].matchedSignature?.vulnerabilityType).toBe('dns_resolution_failure');
+    });
+
+    it('detects DNS EAI_AGAIN', () => {
+      const result = observer.observe('Error: getaddrinfo EAI_AGAIN myservice.local');
+      expect(result.infraFailures).toHaveLength(1);
+      expect(result.infraFailures[0].matchedSignature?.vulnerabilityType).toBe('dns_resolution_failure');
+    });
+  });
+
+  // ==========================================================================
+  // Resource Exhaustion Errors
+  // ==========================================================================
+
+  describe('resource exhaustion errors', () => {
+    it('detects ENOMEM', () => {
+      const result = observer.observe('Error: ENOMEM: not enough memory');
+      expect(result.infraFailures).toHaveLength(1);
+      expect(result.infraFailures[0].matchedSignature?.vulnerabilityType).toBe('out_of_memory');
+    });
+
+    it('detects Java OutOfMemoryError', () => {
+      const result = observer.observe('java.lang.OutOfMemoryError: Heap space');
+      expect(result.infraFailures).toHaveLength(1);
+      expect(result.infraFailures[0].matchedSignature?.vulnerabilityType).toBe('out_of_memory');
+    });
+
+    it('detects ENOSPC (disk full)', () => {
+      const result = observer.observe('Error: ENOSPC: No space left on device');
+      expect(result.infraFailures).toHaveLength(1);
+      expect(result.infraFailures[0].matchedSignature?.vulnerabilityType).toBe('disk_full');
+    });
+
+    it('detects EADDRINUSE (port conflict)', () => {
+      const result = observer.observe('Error: listen EADDRINUSE: address already in use');
+      expect(result.infraFailures).toHaveLength(1);
+      expect(result.infraFailures[0].matchedSignature?.vulnerabilityType).toBe('port_bind_failure');
+    });
+  });
+
+  // ==========================================================================
+  // TLS / Certificate Errors
+  // ==========================================================================
+
+  describe('TLS and certificate errors', () => {
+    it('detects expired certificate', () => {
+      const result = observer.observe('Error: certificate has expired');
+      expect(result.infraFailures).toHaveLength(1);
+      expect(result.infraFailures[0].matchedSignature?.vulnerabilityType).toBe('certificate_expired');
+    });
+
+    it('detects CERT_HAS_EXPIRED', () => {
+      const result = observer.observe('Error: CERT_HAS_EXPIRED');
+      expect(result.infraFailures).toHaveLength(1);
+    });
+
+    it('detects UNABLE_TO_VERIFY_LEAF_SIGNATURE', () => {
+      const result = observer.observe('Error: UNABLE_TO_VERIFY_LEAF_SIGNATURE');
+      expect(result.infraFailures).toHaveLength(1);
+    });
+
+    it('detects self-signed certificate', () => {
+      const result = observer.observe('Error: certificate is self signed');
+      expect(result.infraFailures).toHaveLength(1);
+    });
+  });
+
+  // ==========================================================================
+  // Connection Pool and Docker Errors
+  // ==========================================================================
+
+  describe('pool and container errors', () => {
+    it('detects connection pool exhaustion', () => {
+      const result = observer.observe('Error: pool exhausted, no connections available');
+      expect(result.infraFailures).toHaveLength(1);
+    });
+
+    it('detects too many connections', () => {
+      const result = observer.observe('FATAL: too many connections for role "app"');
+      expect(result.infraFailures).toHaveLength(1);
+    });
+
+    it('detects Docker daemon unreachable', () => {
+      const result = observer.observe('Cannot connect to the Docker daemon at unix:///var/run/docker.sock');
+      expect(result.infraFailures).toHaveLength(1);
+      expect(result.infraFailures[0].serviceName).toBe('docker');
+    });
+
+    it('detects Selenium Grid unreachable', () => {
+      const result = observer.observe('WebDriverError: session not created: Could not start browser');
+      expect(result.infraFailures).toHaveLength(1);
+      expect(result.infraFailures[0].serviceName).toBe('selenium-grid');
+    });
+  });
+
+  // ==========================================================================
+  // Multi-line Output and Deduplication
+  // ==========================================================================
+
+  describe('observe()', () => {
+    it('parses multiple lines and finds multiple errors', () => {
+      const output = [
+        'Running test suite...',
+        'Error: connect ECONNREFUSED 127.0.0.1:5432',
+        'PASS: test_login',
+        'Error: connect ECONNREFUSED 127.0.0.1:6379',
+        'FAIL: test_cache_lookup',
+      ].join('\n');
+
+      const result = observer.observe(output);
+      expect(result.totalLinesParsed).toBe(5);
+      expect(result.infraFailures).toHaveLength(2);
+      expect(result.classifiedErrors).toHaveLength(2);
+    });
+
+    it('deduplicates vulnerabilities by service name', () => {
+      const output = [
+        'Error: connect ECONNREFUSED 127.0.0.1:5432',
+        'Error: connect ECONNREFUSED 127.0.0.1:5432 postgres',
+      ].join('\n');
+
+      const result = observer.observe(output);
+      // Two classified errors but only one vulnerability (deduped by service)
+      expect(result.infraFailures).toHaveLength(2);
+      expect(result.vulnerabilities).toHaveLength(1);
+      expect(result.vulnerabilities[0].affectedAgents).toContain('infra-postgres');
+    });
+
+    it('generates vulnerabilities with correct fields', () => {
+      const result = observer.observe('Error: connect ECONNREFUSED 127.0.0.1:5432');
+      expect(result.vulnerabilities).toHaveLength(1);
+
+      const vuln = result.vulnerabilities[0];
+      expect(vuln.type).toBe('db_connection_failure');
+      expect(vuln.severity).toBeGreaterThan(0);
+      expect(vuln.affectedAgents).toContain('infra-postgres');
+      expect(vuln.suggestedAction).toBe('restart_service');
+      expect(vuln.detectedAt).toBeGreaterThan(0);
+    });
+
+    it('returns empty results for clean output', () => {
+      const result = observer.observe('All 42 tests passed.\nDone in 12.3s');
+      expect(result.infraFailures).toHaveLength(0);
+      expect(result.classifiedErrors).toHaveLength(0);
+      expect(result.vulnerabilities).toHaveLength(0);
+    });
+
+    it('records observation metadata', () => {
+      const result = observer.observe('some output');
+      expect(result.id).toBeTruthy();
+      expect(result.observedAt).toBeGreaterThan(0);
+      expect(result.parsingDurationMs).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  // ==========================================================================
+  // State Management
+  // ==========================================================================
+
+  describe('getFailingServices()', () => {
+    it('returns empty set before any observation', () => {
+      expect(observer.getFailingServices().size).toBe(0);
+    });
+
+    it('returns failing service names after observation', () => {
+      observer.observe('Error: connect ECONNREFUSED 127.0.0.1:5432');
+      const failing = observer.getFailingServices();
+      expect(failing.has('postgres')).toBe(true);
+    });
+
+    it('returns multiple failing services', () => {
+      observer.observe(
+        'Error: connect ECONNREFUSED 127.0.0.1:5432\nError: connect ECONNREFUSED 127.0.0.1:6379'
+      );
+      const failing = observer.getFailingServices();
+      expect(failing.has('postgres')).toBe(true);
+      expect(failing.has('redis')).toBe(true);
+    });
+  });
+
+  describe('getLastObservation()', () => {
+    it('returns null before any observation', () => {
+      expect(observer.getLastObservation()).toBeNull();
+    });
+
+    it('returns the most recent observation', () => {
+      observer.observe('Error: connect ECONNREFUSED 127.0.0.1:5432');
+      const obs = observer.getLastObservation();
+      expect(obs).not.toBeNull();
+      expect(obs!.infraFailures).toHaveLength(1);
+    });
+  });
+
+  describe('clearObservation()', () => {
+    it('clears the last observation', () => {
+      observer.observe('Error: connect ECONNREFUSED 127.0.0.1:5432');
+      expect(observer.getLastObservation()).not.toBeNull();
+
+      observer.clearObservation();
+      expect(observer.getLastObservation()).toBeNull();
+      expect(observer.getFailingServices().size).toBe(0);
+    });
+  });
+
+  // ==========================================================================
+  // classifyLine()
+  // ==========================================================================
+
+  describe('classifyLine()', () => {
+    it('returns null for non-matching lines', () => {
+      expect(observer.classifyLine('All tests passed')).toBeNull();
+    });
+
+    it('returns ClassifiedError for matching lines', () => {
+      const result = observer.classifyLine('Error: connect ECONNREFUSED 127.0.0.1:5432', 5);
+      expect(result).not.toBeNull();
+      expect(result!.classification).toBe('infra_failure');
+      expect(result!.lineNumber).toBe(5);
+      expect(result!.confidence).toBeGreaterThan(0);
+      expect(result!.classifiedAt).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Clean PR addressing review feedback on #223:
- **Scope reduced**: 73 files → 24 files (only infra-healing changes)
- **ADR-056 → ADR-057**: Renamed to avoid conflict with existing ADR-056 (Skill Validation System)
- **ADR index updated**: ADR-057 entry added to `v3-adrs.md`

No code logic changes — same feature, clean branch, correct ADR number.

## What's included

| Category | Details |
|----------|---------|
| **New components** (10 files) | TestOutputObserver, RecoveryPlaybook, CoordinationLock, InfraActionExecutor, CompositeActionExecutor, InfraAwareAgentProvider, InfraHealingOrchestrator, types, barrel exports, default playbook |
| **Modified files** (4 files) | `types.ts` (+8 vulnerability types, +1 action type), `healing-controller.ts` (infra routing), `strange-loop.ts` (factory functions), `index.ts` (re-exports) |
| **ADR** | ADR-057 in standard WH(Y) format + index entry |
| **Unit tests** | 245 passing (151 new + 94 existing, zero regressions) |
| **Integration tests** | 5 real Docker tests (stops PostgreSQL, recovers via playbook) |
| **Demo script** | `scripts/demo-infra-healing.ts` |

## Verification

- [x] `npx tsc --noEmit` — clean compile
- [x] `npx vitest run tests/unit/strange-loop/` — 245/245 passing
- [x] Zero ADR-056 references in infra-healing files (all renamed to ADR-057)
- [x] Existing ADR-056 (Skill Validation) references in validation/ files untouched
- [x] No unrelated files (no e2e tests, QCSD agents, worker configs, n8n validator)

Closes #223

## Test plan

- [x] Unit tests: 245/245 passing
- [x] TypeScript: clean compile
- [ ] Review: no regressions in existing Strange Loop behavior
- [ ] Review: YAML playbook format is reasonable for operators

🤖 Generated with [Claude Code](https://claude.com/claude-code)