### PR TITLE
fix(init): use dynamic package version for upgrade detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-qe",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "description": "Agentic Quality Engineering V3 - Domain-Driven Design Architecture with 12 Bounded Contexts, O(log n) coverage analysis, ReasoningBank learning, 51 specialized QE agents, mathematical Coherence verification, deep Claude Flow integration",
   "main": "./v3/dist/index.js",
   "types": "./v3/dist/index.d.ts",

--- a/v3/package.json
+++ b/v3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentic-qe/v3",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "description": "Agentic QE v3 - Domain-Driven Design Architecture with 12 Bounded Contexts, O(log n) coverage analysis, ReasoningBank learning, 51 specialized QE agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/v3/src/init/init-wizard.ts
+++ b/v3/src/init/init-wizard.ts
@@ -20,7 +20,7 @@ import type {
   WizardState,
   PretrainedLibrary,
 } from './types.js';
-import { createDefaultConfig, DEFAULT_SKILLS_CONFIG } from './types.js';
+import { createDefaultConfig, DEFAULT_SKILLS_CONFIG, getAQEVersion } from './types.js';
 import { ProjectAnalyzer, createProjectAnalyzer } from './project-analyzer.js';
 import { SelfConfigurator, createSelfConfigurator } from './self-configurator.js';
 import { SkillsInstaller, createSkillsInstaller, type SkillsInstallResult } from './skills-installer.js';
@@ -714,7 +714,7 @@ export class InitOrchestrator {
 
       // Convert to v3 format
       const v3Config = {
-        version: '3.0.0',
+        version: getAQEVersion(),
         migratedFrom: v2Detection.version || '2.x.x',
         migratedAt: new Date().toISOString(),
         project: {

--- a/v3/src/init/migration/config-migrator.ts
+++ b/v3/src/init/migration/config-migrator.ts
@@ -5,6 +5,7 @@
 
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
+import { getAQEVersion } from '../types.js';
 
 /**
  * V2 Config Migrator
@@ -74,7 +75,7 @@ ${yaml.stringify(v3Config)}`;
     codeIntelConfig: Record<string, unknown> | null
   ): Record<string, unknown> {
     return {
-      version: '3.0.0',
+      version: getAQEVersion(),
       migratedFrom: '2.x.x',
       migratedAt: new Date().toISOString(),
       project: {

--- a/v3/src/init/phases/04-database.ts
+++ b/v3/src/init/phases/04-database.ts
@@ -21,6 +21,7 @@ import {
   BasePhase,
   type InitContext,
 } from './phase-interface.js';
+import { getAQEVersion } from '../types.js';
 
 export interface DatabaseResult {
   dbPath: string;
@@ -82,7 +83,7 @@ export class DatabasePhase extends BasePhase<DatabaseResult> {
       await unifiedMemory.kvSet('_init_marker', {
         initialized: new Date().toISOString(),
         projectRoot,
-        version: '3.0.0',
+        version: getAQEVersion(),
       }, '_system');
 
       // Get schema version

--- a/v3/src/init/phases/05-learning.ts
+++ b/v3/src/init/phases/05-learning.ts
@@ -11,6 +11,7 @@ import {
   type InitContext,
 } from './phase-interface.js';
 import type { AQEInitConfig } from '../types.js';
+import { getAQEVersion } from '../types.js';
 
 export interface LearningResult {
   enabled: boolean;
@@ -110,7 +111,7 @@ export class LearningPhase extends BasePhase<LearningResult> {
       const indexPath = join(patternsDir, 'index.json');
       if (!existsSync(indexPath)) {
         writeFileSync(indexPath, JSON.stringify({
-          version: '3.0.0',
+          version: getAQEVersion(),
           domains: [],
           loadedAt: new Date().toISOString(),
         }, null, 2), 'utf-8');

--- a/v3/src/init/self-configurator.ts
+++ b/v3/src/init/self-configurator.ts
@@ -25,6 +25,7 @@ import {
   DEFAULT_AUTO_TUNING_CONFIG,
   DEFAULT_SKILLS_CONFIG,
   ALL_DOMAINS,
+  getAQEVersion,
 } from './types.js';
 
 // ============================================================================
@@ -243,7 +244,7 @@ export class SelfConfigurator {
   recommend(analysis: ProjectAnalysis): AQEInitConfig {
     // Start with base configuration
     const config: AQEInitConfig = {
-      version: '3.0.0',
+      version: getAQEVersion(),
       project: {
         name: analysis.projectName,
         root: analysis.projectRoot,

--- a/v3/src/init/types.ts
+++ b/v3/src/init/types.ts
@@ -444,11 +444,18 @@ export const ALL_DOMAINS = [
 ];
 
 /**
+ * Get the current AQE version from build-time constant
+ */
+export function getAQEVersion(): string {
+  return typeof __CLI_VERSION__ !== 'undefined' ? __CLI_VERSION__ : '3.0.0';
+}
+
+/**
  * Create default AQE init configuration
  */
 export function createDefaultConfig(projectName: string, projectRoot: string): AQEInitConfig {
   return {
-    version: '3.0.0',
+    version: getAQEVersion(),
     project: {
       name: projectName,
       root: projectRoot,


### PR DESCRIPTION
## Summary

Fixes the root cause of `aqe init --auto` not upgrading skills/agents.

## Problem

The version upgrade detection wasn't working because `context.config.version` was always hardcoded to `"3.0.0"` instead of the actual package version (e.g., `"3.5.3"`).

When comparing:
- Existing config: `"3.5.0"` (from user's project)
- New config version: `"3.0.0"` (hardcoded)

The comparison was meaningless and didn't reflect actual version changes.

## Solution

- Added `getAQEVersion()` helper that reads `__CLI_VERSION__` (injected at build time by esbuild)
- Updated all places that hardcoded `version: '3.0.0'`:
  - `self-configurator.ts`
  - `init-wizard.ts`
  - `config-migrator.ts`
  - `04-database.ts`
  - `05-learning.ts`
  - `types.ts`

## Test plan

- [x] All 142 init tests pass
- [x] Build shows correct version (v3.5.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)