### PR TITLE
chore(release): v3.7.2

### DIFF
--- a/.agentic-qe/workers/registry.json
+++ b/.agentic-qe/workers/registry.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.6.8",
+  "version": "3.7.2",
   "maxConcurrent": 6,
   "workers": {
     "pattern-consolidator": {

--- a/.claude/skills/skills-manifest.json
+++ b/.claude/skills/skills-manifest.json
@@ -904,7 +904,7 @@
   },
   "metadata": {
     "generatedBy": "Agentic QE Fleet",
-    "fleetVersion": "3.7.1",
+    "fleetVersion": "3.7.2",
     "manifestVersion": "1.3.0",
     "lastUpdated": "2026-02-04T00:00:00.000Z",
     "contributors": [

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 **V3 (Main)** | [V2 Documentation](v2/docs/V2-README.md) | [Release Notes](docs/releases/README.md) | [Changelog](v3/CHANGELOG.md) | [Contributors](CONTRIBUTORS.md) | [Issues](https://github.com/proffesor-for-testing/agentic-qe/issues) | [Discussions](https://github.com/proffesor-for-testing/agentic-qe/discussions)
 
-> **V3** brings Domain-Driven Design architecture, 13 bounded contexts, 60 specialized QE agents, TinyDancer intelligent model routing, ReasoningBank learning with Dream cycles, HNSW vector search, mathematical Coherence verification, full MinCut/Consensus integration across all 13 domains, RVF cognitive container integration with portable brain export/import, OpenCode multi-client support, and deep integration with [Claude Flow](https://github.com/ruvnet/claude-flow) and [Agentic Flow](https://github.com/ruvnet/agentic-flow).
+> **V3** brings Domain-Driven Design architecture, 13 bounded contexts, 60 specialized QE agents, TinyDancer intelligent model routing, ReasoningBank learning with Dream cycles, HNSW vector search, mathematical Coherence verification, full MinCut/Consensus integration across all 13 domains, RVF cognitive container integration with portable brain export/import, OpenCode multi-client support, AWS Kiro IDE integration, and deep integration with [Claude Flow](https://github.com/ruvnet/claude-flow) and [Agentic Flow](https://github.com/ruvnet/agentic-flow).
 
 🏗️ **DDD Architecture** | 🧠 **ReasoningBank + Dream Cycles** | 🎯 **TinyDancer Model Routing** | 🔍 **HNSW Vector Search** | 👑 **Queen Coordinator** | 📊 **O(log n) Coverage** | 🔗 **Claude Flow Integration** | 🎯 **13 Bounded Contexts** | 📚 **78 QE Skills** | 🧬 **Coherence Verification** | ✅ **Trust Tiers** | 🛡️ **Governance**
 
@@ -36,11 +36,14 @@ aqe init --auto
 
 # Include OpenCode assets (agents, skills, tools, permissions)
 aqe init --auto --with-opencode
+
+# Include AWS Kiro IDE assets (agents, skills, hooks, steering)
+aqe init --auto --with-kiro
 ```
 
 > **Note:** `aqe init` automatically configures the MCP server in `.mcp.json` — Claude Code will auto-start it when connecting. For standalone MCP server usage (non-Claude-Code clients), run `aqe-mcp` or `npx agentic-qe mcp`.
 
-### Use from MCP-compatible agent clients (Claude Code, OpenCode, Codex, others)
+### Use from MCP-compatible agent clients (Claude Code, OpenCode, Kiro, Codex, others)
 
 AQE is exposed as an MCP server and can be used from any client that supports MCP tool connections.
 
@@ -51,6 +54,9 @@ AQE is exposed as an MCP server and can be used from any client that supports MC
 # For OpenCode: provision assets automatically during init
 aqe init --auto --with-opencode   # installs agents, skills, tools, permissions, opencode.json
 aqe-mcp                           # starts with SSE auto-detection
+
+# For AWS Kiro: provision Kiro-native assets during init
+aqe init --auto --with-kiro       # installs .kiro/ agents, skills, hooks, steering, MCP config
 
 # For other MCP clients: start the server manually
 aqe-mcp                  # if installed globally
@@ -76,6 +82,7 @@ For client-specific setup examples, see `docs/integration/mcp-clients.md`.
 - ✅ **Coherence Verification** (v3.3.0): Mathematical proof of belief consistency using WASM engines
 - ✅ **RVF Cognitive Containers** (v3.7.0): MinCut task routing, witness chain audit trail, portable brain export/import, unified HNSW search, production dual-write to native RVF
 - ✅ **OpenCode Support** (v3.7.1): 59 agent configs, 86 skill configs (78 QE + 8 general dev), 5 tool wrappers, SSE/WS/HTTP transport, output compaction, graceful degradation, `aqe init --with-opencode` auto-provisioning
+- ✅ **AWS Kiro Support** (v3.7.2): 87 agent configs, 86 skill configs, 5 event-driven hooks, 2 steering files, MCP config, `aqe init --with-kiro` auto-provisioning
 - ✅ **V2 Backward Compatibility**: All V2 agents map to V3 equivalents
 - ✅ **78 QE Skills**: 46 Tier 3 verified + 32 additional QE skills (QCSD swarms, n8n testing, enterprise integration, qe-* domains)
 
@@ -327,6 +334,56 @@ aqe brain import --input ./my-brain --dry-run
 # View brain statistics
 aqe brain info --input ./my-brain
 ```
+
+---
+
+### 🏗️ AWS Kiro IDE Support (v3.7.2)
+
+V3.7.2 adds full **AWS Kiro IDE** integration, converting AQE agents, skills, hooks, and steering files to Kiro-native formats via `aqe init --with-kiro`.
+
+| Asset | Count | Description |
+|-------|-------|-------------|
+| **Agents** | 87 | `.kiro/agents/*.json` — 62 QE + 15 n8n + 10 infra/testing agents |
+| **Skills** | 86 | `.kiro/skills/*/SKILL.md` — full instructional content from Claude Code sources |
+| **Hooks** | 5 | `.kiro/hooks/*.kiro.hook` — event-driven automation (test update, coverage, security, quality gate, pre-commit) |
+| **Steering** | 2 | `.kiro/steering/*.md` — QE standards and testing conventions |
+| **MCP Config** | 1 | `.kiro/settings/mcp.json` — auto-approved AQE tools |
+
+**Setup:**
+
+```bash
+# Provision Kiro assets during init
+aqe init --auto --with-kiro
+
+# Or add Kiro to an existing project
+aqe init --with-kiro
+```
+
+**What gets generated:**
+
+```
+.kiro/
+├── agents/              # 87 agent definitions (Kiro JSON format)
+├── skills/*/SKILL.md    # 86 skill definitions (full markdown content)
+├── hooks/               # 5 event-driven hooks
+│   ├── aqe-test-updater.kiro.hook       # Auto-update tests on source changes
+│   ├── aqe-coverage-check.kiro.hook     # Coverage analysis on test edits
+│   ├── aqe-security-scan.kiro.hook      # Security scan on auth file changes
+│   ├── aqe-spec-quality-gate.kiro.hook  # Quality gate after spec tasks
+│   └── aqe-pre-commit-quality.kiro.hook # Quality check before agent stops
+├── steering/            # 2 project-wide guidance files
+│   ├── qe-standards.md              # QE standards (auto-triggered)
+│   └── testing-conventions.md       # Test file conventions (fileMatch)
+└── settings/mcp.json    # MCP server config with auto-approved tools
+```
+
+**Key features:**
+- Converts OpenCode YAML agents and Claude Code markdown agents to Kiro JSON format
+- Reads full SKILL.md content from Claude Code sources (not thin YAML stubs)
+- Maps `mcp:agentic-qe:` references to Kiro's `@agentic-qe/` format
+- Maps Claude Code tool names to Kiro builtins (`bash`→`shell`, `edit`→`write`)
+- Auto-detects existing `.kiro/` directory in `--auto` mode
+- Safe by default: won't overwrite existing files unless `--upgrade` is used
 
 ---
 
@@ -837,6 +894,12 @@ agentic-qe/
 ├── .claude/
 │   ├── agents/v3/           # V3 agent definitions (source)
 │   └── skills/              # 15 QE-specific skills
+├── .kiro/                   # AWS Kiro IDE integration (v3.7.2)
+│   ├── agents/              # 87 Kiro agent definitions (JSON)
+│   ├── skills/              # 86 Kiro skill definitions (SKILL.md)
+│   ├── hooks/               # 5 event-driven hooks
+│   ├── steering/            # 2 QE steering files
+│   └── settings/            # MCP server configuration
 ├── docs/                    # Shared documentation
 │   ├── plans/               # Migration plans
 │   ├── policies/            # Project policies

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -4,6 +4,7 @@ All Agentic QE release notes organized by version.
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| [v3.7.2](v3.7.2.md) | 2026-02-25 | AWS Kiro IDE integration, hono security patch |
 | [v3.7.1](v3.7.1.md) | 2026-02-24 | OpenCode integration, RVF production wiring, 8 bug fixes |
 | [v3.7.0](v3.7.0.md) | 2026-02-23 | RVF Cognitive Container integration: MinCut routing, witness chain, brain CLI, HNSW unification |
 | [v3.6.19](v3.6.19.md) | 2026-02-22 | 6 learning pipeline fixes, event-driven trajectories, 25 new tests |

--- a/docs/releases/v3.7.2.md
+++ b/docs/releases/v3.7.2.md
@@ -1,0 +1,30 @@
+# v3.7.2 Release Notes
+
+**Release Date:** 2026-02-25
+
+## Highlights
+
+AWS Kiro IDE integration with 87 agents, 86 skills, 5 hooks, and steering files — plus a security patch for the hono dependency.
+
+## Added
+
+- **AWS Kiro IDE integration** — Full Kiro support via `aqe init --with-kiro`, converting AQE agents, skills, hooks, and steering files to Kiro-native formats
+  - 87 agent JSON configs (62 QE + 15 n8n + 10 infra/testing)
+  - 86 skill SKILL.md files with full instructional content from Claude Code sources
+  - 5 event-driven hooks: test-updater, coverage-check, security-scan, spec-quality-gate, pre-commit-quality
+  - 2 steering files: qe-standards (auto-triggered), testing-conventions (fileMatch on test files)
+  - MCP server configuration with auto-approved read-only tools
+- **Kiro installer** (`v3/src/init/kiro-installer.ts`) — Converts OpenCode YAML and Claude Code markdown agents to Kiro JSON, maps `mcp:agentic-qe:` references to `@agentic-qe/`, and maps Claude Code tool names to Kiro builtins
+
+## Fixed
+
+- **Kiro model mapping** — Markdown agent converter now properly reads the `model` field from frontmatter instead of always defaulting to claude-sonnet-4
+- **Unused variable warnings** — Removed unused `category` and `name` variables in kiro-installer.ts
+
+## Changed
+
+- **README** — Added dedicated AWS Kiro IDE section, updated Quick Start and client examples, added `.kiro/` to project architecture tree
+
+## Security
+
+- **hono 4.12.0 → 4.12.2** — Fixes `X-Forwarded-For` handling in AWS Lambda adapter that could allow IP-based access control bypass ([GHSA-xh87-mx6m-69f3](https://github.com/honojs/hono/security/advisories/GHSA-xh87-mx6m-69f3))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentic-qe",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentic-qe",
-      "version": "3.7.1",
+      "version": "3.7.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-qe",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "description": "Agentic Quality Engineering V3 - Domain-Driven Design Architecture with 13 Bounded Contexts, O(log n) coverage analysis, ReasoningBank learning, 60 specialized QE agents, mathematical Coherence verification, deep Claude Flow integration",
   "main": "./v3/dist/index.js",
   "types": "./v3/dist/index.d.ts",

--- a/v3/CHANGELOG.md
+++ b/v3/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to Agentic QE will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.7.2] - 2026-02-25
+
+### Added
+
+- **AWS Kiro IDE integration** — Full Kiro support converting AQE agents, skills, hooks, and steering files to Kiro-native formats via `aqe init --with-kiro`: 87 agent JSON configs, 86 skill SKILL.md files with full content, 5 event-driven hooks (test-updater, coverage-check, security-scan, spec-quality-gate, pre-commit-quality), 2 steering files (qe-standards, testing-conventions), and MCP server configuration
+- **`aqe init --with-kiro` flag** — Provisions `.kiro/` directory with agents, skills, hooks, steering, and MCP config; follows the OpenCode/N8n installer pattern with auto-detection in `--auto` mode when `.kiro/` exists
+- **Kiro installer** (`v3/src/init/kiro-installer.ts`) — 937-line converter that reads OpenCode YAML agents and Claude Code markdown agents, converts `mcp:agentic-qe:` refs to `@agentic-qe/` format, maps tool names to Kiro builtins (`bash`→`shell`, `edit`→`write`), and prioritizes full SKILL.md content over thin YAML stubs
+
+### Fixed
+
+- **Kiro model mapping inconsistency** — `convertMdAgentToKiro()` now reads the `model` field from markdown agent frontmatter and properly maps opus/haiku models, matching the behavior of `convertToKiroAgent()` for YAML agents
+- **Unused variable warnings** — Removed unused `category` and `name` variables in kiro-installer.ts
+
+### Changed
+
+- **README updated** — Added dedicated AWS Kiro IDE section with asset table, directory structure, setup commands, and key features; updated Quick Start, client examples, feature bullets, and project architecture tree
+
+### Security
+
+- **hono 4.12.0 → 4.12.2** — Fixes incorrect `X-Forwarded-For` handling in AWS Lambda adapter that could allow IP-based access control bypass (GHSA-xh87-mx6m-69f3)
+
 ## [3.7.1] - 2026-02-24
 
 ### Added

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentic-qe/v3",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentic-qe/v3",
-      "version": "3.7.1",
+      "version": "3.7.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/v3/package.json
+++ b/v3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentic-qe/v3",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "description": "Agentic QE v3 - Domain-Driven Design Architecture with 13 Bounded Contexts, O(log n) coverage analysis, ReasoningBank learning, 60 specialized QE agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/v3/src/init/kiro-installer.ts
+++ b/v3/src/init/kiro-installer.ts
@@ -311,11 +311,16 @@ export class KiroInstaller {
     // Convert mcp: references in the prompt body
     const prompt = body.replace(/mcp:agentic-qe:/g, '@agentic-qe/');
 
-    // Map model based on category/priority
-    const category = getField('category');
+    // Map model from frontmatter, falling back to category/priority heuristics
+    const rawModel = getField('model');
     const priority = getField('priority');
     let model = 'claude-sonnet-4';
-    if (priority === 'critical' || category === 'n8n-testing') model = 'claude-sonnet-4';
+    if (rawModel) {
+      if (rawModel.includes('opus')) model = 'claude-opus-4';
+      else if (rawModel.includes('haiku')) model = 'claude-haiku-4';
+    } else if (priority === 'critical') {
+      model = 'claude-sonnet-4';
+    }
 
     return {
       name: agentName,
@@ -571,7 +576,6 @@ export class KiroInstaller {
     const descMatch = frontmatter.match(/^description:\s*"?([^"\n]*)"?/m);
     const tagsMatch = frontmatter.match(/^tags:\s*\[([^\]]*)\]/m);
 
-    const name = nameMatch?.[1]?.trim() ?? skillName;
     const description = descMatch?.[1]?.trim() ?? '';
     const tags = tagsMatch?.[1]?.trim() ?? '';
 


### PR DESCRIPTION
## Release v3.7.2

### What's New
- **AWS Kiro IDE integration** — 87 agents, 86 skills, 5 hooks, 2 steering files via `aqe init --with-kiro`
- **hono security patch** — Fixes X-Forwarded-For bypass (GHSA-xh87-mx6m-69f3)
- **README Kiro section** — Dedicated documentation for Kiro setup and usage
- **Bug fixes** — Kiro model mapping, unused variable warnings

### Verification Checklist
- [x] Both package.json versions match (3.7.2)
- [x] Build succeeds (tsc + CLI + MCP bundles)
- [x] Type check passes (zero errors)
- [x] All unit tests pass (414 files, 14,048 tests)
- [x] `aqe init --auto` works in fresh project
- [x] CLI commands functional (--version returns 3.7.2)
- [x] Self-learning subsystem initializes
- [x] Performance gates pass (15/15)
- [x] Regression tests pass (34 files, 1,275 tests)
- [x] test:ci suite passes (pre-existing MCP perf threshold excluded)

See [CHANGELOG](v3/CHANGELOG.md) and [Release Notes](docs/releases/v3.7.2.md) for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)