### PR TITLE
fix: CLI crash on global install (v3.7.12)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -195,7 +195,23 @@ node /workspaces/agentic-qe-new/dist/cli/bundle.js health 2>&1 | head -10
 ```
 These should respond (even if empty results) without errors, confirming the subsystems initialize properly.
 
-#### 8e. Cleanup
+#### 8e. Isolated Dependency Check (catches missing externals)
+```bash
+# Pack and install in a clean temp directory to simulate real user install
+CLEAN_DIR=$(mktemp -d)
+npm pack --pack-destination "$CLEAN_DIR" 2>&1 | tail -2
+cd "$CLEAN_DIR"
+npm init -y > /dev/null 2>&1
+npm install ./agentic-qe-<version>.tgz 2>&1 | tail -3
+node node_modules/.bin/aqe --version 2>&1
+EXIT=$?
+echo "Exit code: $EXIT"
+cd /workspaces/agentic-qe-new
+rm -rf "$CLEAN_DIR"
+```
+Must exit 0 and print the correct version. If it crashes with `ERR_MODULE_NOT_FOUND`, a dependency is marked as external in the build scripts but not listed in `dependencies`. Fix by either bundling it, lazy-loading it, or adding it to dependencies.
+
+#### 8f. Cleanup
 ```bash
 rm -rf /tmp/aqe-release-test
 ```
@@ -328,10 +344,36 @@ gh run view <run-id> --log-failed
 ```bash
 npm view agentic-qe@<version> name version
 ```
-Confirm the published version matches. Test install:
+Confirm the published version matches. Test install in local environment:
 ```bash
 npx agentic-qe@<version> --version
 ```
+
+### 15. Isolated Install Verification (CRITICAL)
+
+This step catches missing/external dependency issues that only manifest in clean environments (e.g., `typescript` not being available when installed globally). This MUST pass before declaring the release successful.
+
+```bash
+# Create a completely isolated install — no access to project node_modules
+CLEAN_DIR=$(mktemp -d)
+npm install --prefix "$CLEAN_DIR" agentic-qe@<version> 2>&1 | tail -5
+
+# Test CLI commands using ONLY the isolated install's dependencies
+NODE_PATH="$CLEAN_DIR/node_modules" node "$CLEAN_DIR/node_modules/.bin/aqe" --version
+NODE_PATH="$CLEAN_DIR/node_modules" node "$CLEAN_DIR/node_modules/.bin/aqe" --help 2>&1 | head -5
+
+# Cleanup
+rm -rf "$CLEAN_DIR"
+```
+
+If `--version` crashes (e.g., `ERR_MODULE_NOT_FOUND`), the release has a broken dependency. Diagnose whether the missing package should be:
+- **Bundled** into the CLI (add to build script, remove from externals)
+- **Added to `dependencies`** in package.json (if it's a real runtime dep)
+- **Lazy-loaded** with try/catch (if only needed for optional features)
+
+Fix, rebuild, and re-release if this step fails. Never ship a CLI that crashes on `--version`.
+
+**STOP — confirm isolated install works.**
 
 ## Rules
 

--- a/.claude/skills/skills-manifest.json
+++ b/.claude/skills/skills-manifest.json
@@ -904,7 +904,7 @@
   },
   "metadata": {
     "generatedBy": "Agentic QE Fleet",
-    "fleetVersion": "3.7.11",
+    "fleetVersion": "3.7.12",
     "manifestVersion": "1.3.0",
     "lastUpdated": "2026-02-04T00:00:00.000Z",
     "contributors": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Agentic QE project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.7.12] - 2026-03-06
+
+### Fixed
+
+- **CLI crash on global install** — `aqe --version` crashed with `ERR_MODULE_NOT_FOUND: Cannot find package 'typescript'` when installed globally (`npm i -g agentic-qe`). TypeScript was marked as an external ESM dependency in the build but is only a devDependency, so it's absent in clean environments. Now lazy-loaded via `createRequire` Proxy — only loads when AST parsing features are actually used.
+- **Release skill missing isolated install check** — Added pre-release step 8e (isolated dependency check) and post-publish step 15 (clean-environment install verification) to catch missing external dependencies before they reach users.
+
 ## [3.7.11] - 2026-03-06
 
 ### Added

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -4,6 +4,7 @@ All Agentic QE release notes organized by version.
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| [v3.7.12](v3.7.12.md) | 2026-03-06 | Fix CLI crash on global install (lazy-load typescript), release verification hardening |
 | [v3.7.11](v3.7.11.md) | 2026-03-06 | Full @claude-flow/guidance governance integration across all 8 modules |
 | [v3.7.10](v3.7.10.md) | 2026-03-05 | Fix MCP path resolution, CRLF skill parsing, stale v3/ refs; README rewrite |
 | [v3.7.9](v3.7.9.md) | 2026-03-05 | Multi-language test gen (8 langs), 384-dim embedding standardization, trust tier evals |

--- a/docs/releases/v3.7.12.md
+++ b/docs/releases/v3.7.12.md
@@ -1,0 +1,12 @@
+# v3.7.12 Release Notes
+
+**Release Date:** 2026-03-06
+
+## Highlights
+
+Hotfix for CLI crash when installed globally (`npm i -g agentic-qe`). The `aqe --version` command no longer requires TypeScript to be installed. Also adds isolated install verification to the release process to prevent similar issues.
+
+## Fixed
+
+- **CLI crash on global install** — `aqe --version` crashed with `ERR_MODULE_NOT_FOUND: Cannot find package 'typescript'` in clean environments. TypeScript's compiler API (used for AST parsing in test generation) was loaded eagerly at bundle startup via a top-level ESM import, even for commands that don't need it. Now lazy-loaded through a `createRequire` Proxy that only triggers when code analysis features are actually invoked.
+- **Release skill missing isolation gate** — Added step 8e (pre-release isolated dependency check with `node_modules` hidden) and step 15 (post-publish clean-environment install verification) to the `/release` skill. These catch external dependency issues before they reach users.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentic-qe",
-  "version": "3.7.11",
+  "version": "3.7.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentic-qe",
-      "version": "3.7.11",
+      "version": "3.7.12",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-qe",
-  "version": "3.7.11",
+  "version": "3.7.12",
   "description": "Agentic Quality Engineering V3 - Domain-Driven Design Architecture with 13 Bounded Contexts, O(log n) coverage analysis, ReasoningBank learning, 60 specialized QE agents, mathematical Coherence verification, deep Claude Flow integration",
   "type": "module",
   "main": "./dist/index.js",

--- a/scripts/build-cli.mjs
+++ b/scripts/build-cli.mjs
@@ -52,7 +52,6 @@ const nativeModules = [
 
 // Pure JS externals that work fine with ESM import
 const esmExternals = [
-  'typescript',
   'fast-glob',
   'yaml',
   'commander',
@@ -63,19 +62,71 @@ const esmExternals = [
 ];
 
 /**
- * esbuild plugin: Rewrite bare "typescript" import to explicit subpath.
+ * esbuild plugin: Lazy-load typescript via createRequire().
  *
- * TypeScript's package.json has no "exports" field — only "main": "./lib/typescript.js".
- * Node.js 22+ ESM legacyMainResolve fails to resolve the bare specifier in some
- * environments (devcontainers, NVM-managed Node). Rewriting to the explicit subpath
- * bypasses legacyMainResolve entirely (see issue #267).
+ * typescript is a devDependency — it won't be available when users install
+ * agentic-qe globally. A top-level ESM `import` would crash the entire CLI
+ * (even `aqe --version`). This plugin replaces the static import with a
+ * lazy createRequire() call that only executes when the TypeScript parser
+ * is actually used, and throws a helpful error if typescript is missing.
  */
-const typescriptResolvePlugin = {
-  name: 'typescript-resolve',
+/**
+ * esbuild plugin: Lazy-load typescript via createRequire().
+ *
+ * typescript is a devDependency — it won't be available when users install
+ * agentic-qe globally. A top-level ESM `import` would crash the entire CLI
+ * (even `aqe --version`). This plugin replaces the static import with a
+ * lazy createRequire() call that only executes when the TypeScript parser
+ * is actually used, and throws a helpful error if typescript is missing.
+ *
+ * The source code uses `import * as ts from 'typescript'` (namespace import),
+ * so we keep typescript external but rewrite the import sites in the output
+ * bundle to use a lazy-loading wrapper instead of a top-level import.
+ */
+const typescriptLazyPlugin = {
+  name: 'typescript-lazy',
   setup(build) {
+    // Keep typescript external so it's not bundled (~9MB)
     build.onResolve({ filter: /^typescript$/ }, () => ({
-      path: 'typescript/lib/typescript.js',
-      external: true,
+      path: 'typescript',
+      namespace: 'typescript-lazy',
+    }));
+
+    // Generate a virtual module that lazy-loads via createRequire on first use
+    build.onLoad({ filter: /.*/, namespace: 'typescript-lazy' }, () => ({
+      contents: [
+        'import { createRequire } from "module";',
+        'let _ts;',
+        'function _load() {',
+        '  if (!_ts) {',
+        '    const req = createRequire(import.meta.url);',
+        '    try { _ts = req("typescript"); }',
+        '    catch {',
+        '      try { _ts = req("typescript/lib/typescript.js"); }',
+        '      catch {',
+        '        _ts = new Proxy({}, { get(_, p) {',
+        '          if (p === "__esModule" || typeof p === "symbol") return undefined;',
+        '          throw new Error("TypeScript is required for code analysis. Install it: npm install -g typescript");',
+        '        }});',
+        '      }',
+        '    }',
+        '  }',
+        '  return _ts;',
+        '}',
+        // Use a Proxy as the default export so `import * as ts` works.
+        // When esbuild bundles `import * as ts from "typescript"` with this
+        // virtual module, it accesses properties on the default export.
+        'export default new Proxy({}, {',
+        '  get(_, p) { return _load()[p]; },',
+        '  has(_, p) { return p in _load(); },',
+        '  ownKeys() { return Object.keys(_load()); },',
+        '  getOwnPropertyDescriptor(_, p) {',
+        '    const v = _load()[p];',
+        '    if (v !== undefined) return { configurable: true, enumerable: true, value: v };',
+        '  },',
+        '});',
+      ].join('\n'),
+      loader: 'js',
     }));
   },
 };
@@ -134,7 +185,7 @@ try {
     platform: 'node',
     format: 'esm',
     external: esmExternals,
-    plugins: [typescriptResolvePlugin, nativeRequirePlugin],
+    plugins: [typescriptLazyPlugin, nativeRequirePlugin],
     outfile: join(__dirname, '..', 'dist/cli/bundle.js'),
     define: {
       '__CLI_VERSION__': JSON.stringify(version),

--- a/scripts/build-mcp.mjs
+++ b/scripts/build-mcp.mjs
@@ -52,7 +52,6 @@ const nativeModules = [
 
 // Pure JS externals that work fine with ESM import
 const esmExternals = [
-  'typescript',
   'fast-glob',
   'fast-json-patch',
   'yaml',
@@ -64,19 +63,62 @@ const esmExternals = [
 ];
 
 /**
- * esbuild plugin: Rewrite bare "typescript" import to explicit subpath.
+ * esbuild plugin: Lazy-load typescript via createRequire().
  *
- * TypeScript's package.json has no "exports" field — only "main": "./lib/typescript.js".
- * Node.js 22+ ESM legacyMainResolve fails to resolve the bare specifier in some
- * environments (devcontainers, NVM-managed Node). Rewriting to the explicit subpath
- * bypasses legacyMainResolve entirely (see issue #267).
+ * typescript is a devDependency — it won't be available when users install
+ * agentic-qe globally. A top-level ESM `import` would crash the entire CLI
+ * (even `aqe --version`). This plugin replaces the static import with a
+ * lazy createRequire() call that only executes when the TypeScript parser
+ * is actually used, and throws a helpful error if typescript is missing.
  */
-const typescriptResolvePlugin = {
-  name: 'typescript-resolve',
+/**
+ * esbuild plugin: Lazy-load typescript via createRequire().
+ *
+ * typescript is a devDependency — it won't be available when users install
+ * agentic-qe globally. A top-level ESM `import` would crash the entire CLI
+ * (even `aqe --version`). This plugin replaces the static import with a
+ * lazy createRequire() call that only executes when the TypeScript parser
+ * is actually used, and throws a helpful error if typescript is missing.
+ */
+const typescriptLazyPlugin = {
+  name: 'typescript-lazy',
   setup(build) {
     build.onResolve({ filter: /^typescript$/ }, () => ({
-      path: 'typescript/lib/typescript.js',
-      external: true,
+      path: 'typescript',
+      namespace: 'typescript-lazy',
+    }));
+
+    build.onLoad({ filter: /.*/, namespace: 'typescript-lazy' }, () => ({
+      contents: [
+        'import { createRequire } from "module";',
+        'let _ts;',
+        'function _load() {',
+        '  if (!_ts) {',
+        '    const req = createRequire(import.meta.url);',
+        '    try { _ts = req("typescript"); }',
+        '    catch {',
+        '      try { _ts = req("typescript/lib/typescript.js"); }',
+        '      catch {',
+        '        _ts = new Proxy({}, { get(_, p) {',
+        '          if (p === "__esModule" || typeof p === "symbol") return undefined;',
+        '          throw new Error("TypeScript is required for code analysis. Install it: npm install -g typescript");',
+        '        }});',
+        '      }',
+        '    }',
+        '  }',
+        '  return _ts;',
+        '}',
+        'export default new Proxy({}, {',
+        '  get(_, p) { return _load()[p]; },',
+        '  has(_, p) { return p in _load(); },',
+        '  ownKeys() { return Object.keys(_load()); },',
+        '  getOwnPropertyDescriptor(_, p) {',
+        '    const v = _load()[p];',
+        '    if (v !== undefined) return { configurable: true, enumerable: true, value: v };',
+        '  },',
+        '});',
+      ].join('\n'),
+      loader: 'js',
     }));
   },
 };
@@ -124,7 +166,7 @@ try {
     platform: 'node',
     format: 'esm',
     external: esmExternals,
-    plugins: [typescriptResolvePlugin, nativeRequirePlugin],
+    plugins: [typescriptLazyPlugin, nativeRequirePlugin],
     outfile: join(__dirname, '..', 'dist/mcp/bundle.js'),
     define: {
       '__CLI_VERSION__': JSON.stringify(version),

--- a/src/domains/test-generation/services/pattern-matcher.ts
+++ b/src/domains/test-generation/services/pattern-matcher.ts
@@ -7,7 +7,7 @@
  */
 
 import { v4 as uuidv4 } from 'uuid';
-import * as ts from 'typescript';
+import ts from 'typescript';
 import * as fs from 'fs';
 import * as path from 'path';
 import { Result, ok, err } from '../../../shared/types';

--- a/src/domains/test-generation/services/test-generator.ts
+++ b/src/domains/test-generation/services/test-generator.ts
@@ -10,7 +10,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as ts from 'typescript';
+import ts from 'typescript';
 import { Result, ok, err } from '../../../shared/types';
 import { MemoryBackend } from '../../../kernel/interfaces';
 import {

--- a/src/shared/parsers/typescript-parser.ts
+++ b/src/shared/parsers/typescript-parser.ts
@@ -3,7 +3,7 @@
  * Wrapper around TypeScript Compiler API for code analysis
  */
 
-import * as ts from 'typescript';
+import ts from 'typescript';
 import type { ILanguageParser, ParsedFile, UniversalFunctionInfo, UniversalClassInfo, UniversalImportInfo, UniversalPropertyInfo } from './interfaces.js';
 import type { SupportedLanguage } from '../types/test-frameworks.js';
 


### PR DESCRIPTION
## Summary

- **Fix CLI crash on global install** — `aqe --version` crashed with `ERR_MODULE_NOT_FOUND: Cannot find package 'typescript'` when installed via `npm i -g agentic-qe`. TypeScript was marked as an external ESM dependency but is only a devDependency, absent in clean environments. Now lazy-loaded via `createRequire` Proxy — only loads when AST parsing is actually needed.
- **Add isolated install check to `/release` skill** — New step 8e (pre-release `npm pack` + install in temp dir) and step 15 (post-publish clean-env verification) catch missing externals before they ship.

## Verification

- [x] Build succeeds (tsc + CLI + MCP bundles) 
- [x] Type check passes
- [x] Unit tests pass (2 pre-existing failures only)
- [x] Isolated install test passes (`npm pack` → install in clean dir → `aqe --version` → 3.7.12)
- [x] Bundle size unchanged (9.6MB CLI, 11MB MCP)

## Test plan

- [ ] CI passes
- [ ] After merge + publish: `npm i -g agentic-qe@3.7.12 && aqe --version` in a clean environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)