### PR TITLE
fix(init): agents not installed during upgrade

### DIFF
--- a/.claude/skills/skills-manifest.json
+++ b/.claude/skills/skills-manifest.json
@@ -904,7 +904,7 @@
   },
   "metadata": {
     "generatedBy": "Agentic QE Fleet",
-    "fleetVersion": "3.7.17",
+    "fleetVersion": "3.7.18",
     "manifestVersion": "1.3.0",
     "lastUpdated": "2026-02-04T00:00:00.000Z",
     "contributors": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Agentic QE project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.7.18] - 2026-03-11
+
+### Fixed
+
+- **Critical: `aqe init --auto` not installing agents on upgrade** — `preserveOverridesDir()` used `__dirname` (unavailable in ESM bundles), causing a TypeError that crashed the agents installer. Skills were silently installed but agents were skipped, and the phase reported 0/0. Fixed by using `import.meta.url` path resolution with fallback.
+- **Assets phase error isolation** — Agents installer errors no longer crash the entire assets phase. Skills and agents install independently, so a failure in one doesn't prevent the other from completing and reporting counts.
+
 ## [3.7.17] - 2026-03-11
 
 ### Added

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -4,6 +4,7 @@ All Agentic QE release notes organized by version.
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| [v3.7.18](v3.7.18.md) | 2026-03-11 | Hotfix: agents not installed on `aqe init --auto` upgrade |
 | [v3.7.17](v3.7.17.md) | 2026-03-11 | BMAD-inspired: adversarial review, agent overlays, validation pipelines, branch enumerator |
 | [v3.7.16](v3.7.16.md) | 2026-03-10 | Critical: test DB isolation fix, Tier 3 baselines, MCP persistence pipeline |
 | [v3.7.15](v3.7.15.md) | 2026-03-09 | Six Hats learning improvements, Proof-of-Quality CLI, MCP tool scoping, test stability |

--- a/docs/releases/v3.7.18.md
+++ b/docs/releases/v3.7.18.md
@@ -1,0 +1,12 @@
+# v3.7.18 Release Notes
+
+**Release Date:** 2026-03-11
+
+## Highlights
+
+Hotfix for `aqe init --auto` not installing agents during version upgrades.
+
+## Fixed
+
+- **Critical: agents not installed on upgrade** — `preserveOverridesDir()` in the agents installer used `__dirname` which is undefined in ESM bundles. This caused a silent crash that prevented all agents from being installed during `aqe init --auto` upgrades. Skills were installed but agents were not, and the phase reported "Skills installed: 0, Agents installed: 0".
+- **Assets phase error isolation** — The agents installer error no longer crashes the entire assets phase, allowing skills to complete and report correctly even if agents fail.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentic-qe",
-  "version": "3.7.17",
+  "version": "3.7.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentic-qe",
-      "version": "3.7.17",
+      "version": "3.7.18",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-qe",
-  "version": "3.7.17",
+  "version": "3.7.18",
   "description": "Agentic Quality Engineering V3 - Domain-Driven Design Architecture with 13 Bounded Contexts, O(log n) coverage analysis, ReasoningBank learning, 60 specialized QE agents, mathematical Coherence verification, deep Claude Flow integration",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/init/agents-installer.ts
+++ b/src/init/agents-installer.ts
@@ -257,15 +257,21 @@ export class AgentsInstaller {
     // Copy the example overlay template if not already present
     const exampleDest = join(overridesDir, '_example.yaml');
     if (!existsSync(exampleDest)) {
-      const templateSources = [
-        join(__dirname, '..', '..', 'assets', 'templates', 'agent-override-example.yaml'),
-        join(__dirname, '..', 'assets', 'templates', 'agent-override-example.yaml'),
-      ];
-      for (const src of templateSources) {
-        if (existsSync(src)) {
-          copyFileSync(src, exampleDest);
-          break;
+      try {
+        const moduleDir = dirname(fileURLToPath(import.meta.url));
+        const templateSources = [
+          join(moduleDir, '..', '..', 'assets', 'templates', 'agent-override-example.yaml'),
+          join(moduleDir, '..', 'assets', 'templates', 'agent-override-example.yaml'),
+          join(this.projectRoot, 'node_modules', 'agentic-qe', 'assets', 'templates', 'agent-override-example.yaml'),
+        ];
+        for (const src of templateSources) {
+          if (existsSync(src)) {
+            copyFileSync(src, exampleDest);
+            break;
+          }
         }
+      } catch {
+        // Template copy is non-critical — skip silently
       }
     }
   }

--- a/src/init/phases/09-assets.ts
+++ b/src/init/phases/09-assets.ts
@@ -83,18 +83,22 @@ export class AssetsPhase extends BasePhase<AssetsResult> {
     }
 
     // Install agents
-    const agentsInstaller = createAgentsInstaller({
-      projectRoot,
-      installQEAgents: true,
-      installSubagents: true,
-      overwrite: shouldOverwrite,
-    });
+    try {
+      const agentsInstaller = createAgentsInstaller({
+        projectRoot,
+        installQEAgents: true,
+        installSubagents: true,
+        overwrite: shouldOverwrite,
+      });
 
-    const agentsResult = await agentsInstaller.install();
-    agentsInstalled = agentsResult.installed.length;
+      const agentsResult = await agentsInstaller.install();
+      agentsInstalled = agentsResult.installed.length;
 
-    if (agentsResult.errors.length > 0) {
-      context.services.warn(`Agents warnings: ${agentsResult.errors.join(', ')}`);
+      if (agentsResult.errors.length > 0) {
+        context.services.warn(`Agents warnings: ${agentsResult.errors.join(', ')}`);
+      }
+    } catch (error) {
+      context.services.warn(`Agents install error: ${error instanceof Error ? error.message : error}`);
     }
 
     // Initialize overlay configs in agent registry for runtime use


### PR DESCRIPTION
## Summary

- **Critical fix**: `aqe init --auto` was not installing agents during version upgrades due to `__dirname` being undefined in ESM bundles
- **Root cause**: `preserveOverridesDir()` in agents-installer.ts used `__dirname` (CJS-only), which threw TypeError in the ESM CLI bundle, crashing the entire agents installer
- **Impact**: Skills were installed but all 60 agents were silently skipped. Phase reported "Skills: 0, Agents: 0"
- **Fix**: Replaced `__dirname` with `import.meta.url` resolution, added try/catch fallback, and isolated agents installer errors in the assets phase

## Verification
- [x] Tested upgrade from 3.7.16 → 3.7.18: Skills=77, Agents=60
- [x] Steps directories (44 step files) properly installed
- [x] Agent overrides directory created with example template
- [x] Build passes, type check passes

## Test plan
- [ ] CI passes
- [ ] After merge, create GitHub release v3.7.18 to trigger npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)