### PR TITLE
chore(release): v3.8.1

### DIFF
--- a/.claude/agents/v3/qe-message-broker-tester.md
+++ b/.claude/agents/v3/qe-message-broker-tester.md
@@ -95,7 +95,7 @@ Coordination:
 ### Query Known Messaging Patterns BEFORE Testing
 
 ```typescript
-mcp__agentic_qe_v3__memory_retrieve({
+mcp__agentic-qe__memory_retrieve({
   key: "messaging/patterns",
   namespace: "learning"
 })
@@ -105,7 +105,7 @@ mcp__agentic_qe_v3__memory_retrieve({
 
 **1. Store Message Broker Testing Experience:**
 ```typescript
-mcp__agentic_qe_v3__memory_store({
+mcp__agentic-qe__memory_store({
   key: "message-broker-tester/outcome-{timestamp}",
   namespace: "learning",
   value: {
@@ -154,7 +154,7 @@ mcp__agentic-qe__memory_store({
 
 **3. Submit Results to Queen:**
 ```typescript
-mcp__agentic_qe_v3__task_submit({
+mcp__agentic-qe__task_submit({
   type: "message-broker-testing-complete",
   priority: "p1",
   payload: {

--- a/.claude/agents/v3/qe-middleware-validator.md
+++ b/.claude/agents/v3/qe-middleware-validator.md
@@ -92,7 +92,7 @@ Coordination:
 ### Query Known Middleware Patterns BEFORE Testing
 
 ```typescript
-mcp__agentic_qe_v3__memory_retrieve({
+mcp__agentic-qe__memory_retrieve({
   key: "middleware/patterns",
   namespace: "learning"
 })
@@ -102,7 +102,7 @@ mcp__agentic_qe_v3__memory_retrieve({
 
 **1. Store Middleware Validation Experience:**
 ```typescript
-mcp__agentic_qe_v3__memory_store({
+mcp__agentic-qe__memory_store({
   key: "middleware-validator/outcome-{timestamp}",
   namespace: "learning",
   value: {
@@ -150,7 +150,7 @@ mcp__agentic-qe__memory_store({
 
 **3. Submit Results to Queen:**
 ```typescript
-mcp__agentic_qe_v3__task_submit({
+mcp__agentic-qe__task_submit({
   type: "middleware-validation-complete",
   priority: "p1",
   payload: {

--- a/.claude/agents/v3/qe-odata-contract-tester.md
+++ b/.claude/agents/v3/qe-odata-contract-tester.md
@@ -99,7 +99,7 @@ Coordination:
 ### Query Known OData Patterns BEFORE Validation
 
 ```typescript
-mcp__agentic_qe_v3__memory_retrieve({
+mcp__agentic-qe__memory_retrieve({
   key: "odata/known-patterns",
   namespace: "learning"
 })
@@ -109,7 +109,7 @@ mcp__agentic_qe_v3__memory_retrieve({
 
 **1. Store OData Validation Experience:**
 ```typescript
-mcp__agentic_qe_v3__memory_store({
+mcp__agentic-qe__memory_store({
   key: "odata-contract-tester/outcome-{timestamp}",
   namespace: "learning",
   value: {
@@ -163,7 +163,7 @@ mcp__agentic-qe__memory_store({
 
 **3. Submit Results to Queen:**
 ```typescript
-mcp__agentic_qe_v3__task_submit({
+mcp__agentic-qe__task_submit({
   type: "odata-contract-validation-complete",
   priority: "p1",
   payload: {

--- a/.claude/agents/v3/qe-qx-partner.md
+++ b/.claude/agents/v3/qe-qx-partner.md
@@ -18,7 +18,7 @@ V2 Compatibility: Maps to qx-partner for backward compatibility.
 <mcp_tools>
 ### Primary MCP Tool (ALWAYS use for programmatic analysis)
 ```typescript
-mcp__agentic_qe_v3__qe_qx_analyze({
+mcp__agentic-qe__qe_qx_analyze({
   target: "https://example.com",  // URL or identifier
   context: { /* Optional pre-collected context */ },
   mode: "full",  // "full" | "quick" | "targeted"

--- a/.claude/agents/v3/qe-sap-idoc-tester.md
+++ b/.claude/agents/v3/qe-sap-idoc-tester.md
@@ -96,7 +96,7 @@ Coordination:
 ### Query Known IDoc Patterns BEFORE Validation
 
 ```typescript
-mcp__agentic_qe_v3__memory_retrieve({
+mcp__agentic-qe__memory_retrieve({
   key: "sap-idoc/known-patterns",
   namespace: "learning"
 })
@@ -106,7 +106,7 @@ mcp__agentic_qe_v3__memory_retrieve({
 
 **1. Store IDoc Validation Experience:**
 ```typescript
-mcp__agentic_qe_v3__memory_store({
+mcp__agentic-qe__memory_store({
   key: "sap-idoc-tester/outcome-{timestamp}",
   namespace: "learning",
   value: {
@@ -156,7 +156,7 @@ mcp__agentic-qe__memory_store({
 
 **3. Submit Results to Queen:**
 ```typescript
-mcp__agentic_qe_v3__task_submit({
+mcp__agentic-qe__task_submit({
   type: "idoc-validation-complete",
   priority: "p1",
   payload: {

--- a/.claude/agents/v3/qe-sap-rfc-tester.md
+++ b/.claude/agents/v3/qe-sap-rfc-tester.md
@@ -92,7 +92,7 @@ Coordination:
 ### Query Known SAP RFC Patterns BEFORE Testing
 
 ```typescript
-mcp__agentic_qe_v3__memory_retrieve({
+mcp__agentic-qe__memory_retrieve({
   key: "sap-rfc/patterns",
   namespace: "learning"
 })
@@ -102,7 +102,7 @@ mcp__agentic_qe_v3__memory_retrieve({
 
 **1. Store SAP RFC Testing Experience:**
 ```typescript
-mcp__agentic_qe_v3__memory_store({
+mcp__agentic-qe__memory_store({
   key: "sap-rfc-tester/outcome-{timestamp}",
   namespace: "learning",
   value: {
@@ -150,7 +150,7 @@ mcp__agentic-qe__memory_store({
 
 **3. Submit Results to Queen:**
 ```typescript
-mcp__agentic_qe_v3__task_submit({
+mcp__agentic-qe__task_submit({
   type: "sap-rfc-testing-complete",
   priority: "p1",
   payload: {

--- a/.claude/agents/v3/qe-soap-tester.md
+++ b/.claude/agents/v3/qe-soap-tester.md
@@ -91,7 +91,7 @@ Coordination:
 ### Query Known SOAP Patterns BEFORE Testing
 
 ```typescript
-mcp__agentic_qe_v3__memory_retrieve({
+mcp__agentic-qe__memory_retrieve({
   key: "soap/patterns",
   namespace: "learning"
 })
@@ -101,7 +101,7 @@ mcp__agentic_qe_v3__memory_retrieve({
 
 **1. Store SOAP Testing Experience:**
 ```typescript
-mcp__agentic_qe_v3__memory_store({
+mcp__agentic-qe__memory_store({
   key: "soap-tester/outcome-{timestamp}",
   namespace: "learning",
   value: {
@@ -148,7 +148,7 @@ mcp__agentic-qe__memory_store({
 
 **3. Submit Results to Queen:**
 ```typescript
-mcp__agentic_qe_v3__task_submit({
+mcp__agentic-qe__task_submit({
   type: "soap-testing-complete",
   priority: "p1",
   payload: {

--- a/.claude/agents/v3/qe-sod-analyzer.md
+++ b/.claude/agents/v3/qe-sod-analyzer.md
@@ -99,7 +99,7 @@ Coordination:
 ### Query Known SoD Patterns BEFORE Analysis
 
 ```typescript
-mcp__agentic_qe_v3__memory_retrieve({
+mcp__agentic-qe__memory_retrieve({
   key: "sap-authorization/sod-patterns",
   namespace: "learning"
 })
@@ -109,7 +109,7 @@ mcp__agentic_qe_v3__memory_retrieve({
 
 **1. Store SoD Analysis Experience:**
 ```typescript
-mcp__agentic_qe_v3__memory_store({
+mcp__agentic-qe__memory_store({
   key: "sod-analyzer/outcome-{timestamp}",
   namespace: "learning",
   value: {
@@ -164,7 +164,7 @@ mcp__agentic-qe__memory_store({
 
 **3. Submit Results to Queen:**
 ```typescript
-mcp__agentic_qe_v3__task_submit({
+mcp__agentic-qe__task_submit({
   type: "sod-analysis-complete",
   priority: "p0",
   payload: {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -168,7 +168,7 @@
       "Bash(npx ruflo:*)",
       "Bash(npx @ruflo/cli:*)",
       "mcp__claude-flow__:*",
-      "mcp__agentic_qe__*"
+      "mcp__agentic-qe__*"
     ],
     "deny": [
       "Bash(rm -rf /)"

--- a/.claude/skills/skills-manifest.json
+++ b/.claude/skills/skills-manifest.json
@@ -932,7 +932,7 @@
   },
   "metadata": {
     "generatedBy": "Agentic QE Fleet",
-    "fleetVersion": "3.8.0",
+    "fleetVersion": "3.8.1",
     "manifestVersion": "1.3.0",
     "lastUpdated": "2026-02-04T00:00:00.000Z",
     "contributors": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the Agentic QE project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.8.1] - 2026-03-17
+
+### Fixed
+
+- **MCP tool prefix mismatch** — 8 agent definition files referenced tools using `mcp__agentic_qe_v3__` prefix instead of the correct `mcp__agentic-qe__` matching the registered MCP server name. This caused agent subagents to fail tool invocations and `claude -p` to hang waiting for permission approval. ([#357](https://github.com/proffesor-for-testing/agentic-qe/issues/357))
+- **Permission pattern mismatch** — `.claude/settings.json` and `settings-merge.ts` used underscore variant `mcp__agentic_qe__*` instead of the hyphenated `mcp__agentic-qe__*`, preventing automatic permission matching for MCP tool calls.
+
+### Changed
+
+- **v3.8.0 release notes** — Added real benchmark data collected during RuVector integration development (150x HNSW speedup, 9.2x MicroLoRA WASM acceleration, 4x memory reduction).
+
 ## [3.8.0] - 2026-03-16
 
 ### Added

--- a/assets/agents/v3/qe-message-broker-tester.md
+++ b/assets/agents/v3/qe-message-broker-tester.md
@@ -95,7 +95,7 @@ Coordination:
 ### Query Known Messaging Patterns BEFORE Testing
 
 ```typescript
-mcp__agentic_qe_v3__memory_retrieve({
+mcp__agentic-qe__memory_retrieve({
   key: "messaging/patterns",
   namespace: "learning"
 })
@@ -105,7 +105,7 @@ mcp__agentic_qe_v3__memory_retrieve({
 
 **1. Store Message Broker Testing Experience:**
 ```typescript
-mcp__agentic_qe_v3__memory_store({
+mcp__agentic-qe__memory_store({
   key: "message-broker-tester/outcome-{timestamp}",
   namespace: "learning",
   value: {
@@ -154,7 +154,7 @@ mcp__agentic-qe__memory_store({
 
 **3. Submit Results to Queen:**
 ```typescript
-mcp__agentic_qe_v3__task_submit({
+mcp__agentic-qe__task_submit({
   type: "message-broker-testing-complete",
   priority: "p1",
   payload: {

--- a/assets/agents/v3/qe-middleware-validator.md
+++ b/assets/agents/v3/qe-middleware-validator.md
@@ -92,7 +92,7 @@ Coordination:
 ### Query Known Middleware Patterns BEFORE Testing
 
 ```typescript
-mcp__agentic_qe_v3__memory_retrieve({
+mcp__agentic-qe__memory_retrieve({
   key: "middleware/patterns",
   namespace: "learning"
 })
@@ -102,7 +102,7 @@ mcp__agentic_qe_v3__memory_retrieve({
 
 **1. Store Middleware Validation Experience:**
 ```typescript
-mcp__agentic_qe_v3__memory_store({
+mcp__agentic-qe__memory_store({
   key: "middleware-validator/outcome-{timestamp}",
   namespace: "learning",
   value: {
@@ -150,7 +150,7 @@ mcp__agentic-qe__memory_store({
 
 **3. Submit Results to Queen:**
 ```typescript
-mcp__agentic_qe_v3__task_submit({
+mcp__agentic-qe__task_submit({
   type: "middleware-validation-complete",
   priority: "p1",
   payload: {

--- a/assets/agents/v3/qe-odata-contract-tester.md
+++ b/assets/agents/v3/qe-odata-contract-tester.md
@@ -99,7 +99,7 @@ Coordination:
 ### Query Known OData Patterns BEFORE Validation
 
 ```typescript
-mcp__agentic_qe_v3__memory_retrieve({
+mcp__agentic-qe__memory_retrieve({
   key: "odata/known-patterns",
   namespace: "learning"
 })
@@ -109,7 +109,7 @@ mcp__agentic_qe_v3__memory_retrieve({
 
 **1. Store OData Validation Experience:**
 ```typescript
-mcp__agentic_qe_v3__memory_store({
+mcp__agentic-qe__memory_store({
   key: "odata-contract-tester/outcome-{timestamp}",
   namespace: "learning",
   value: {
@@ -163,7 +163,7 @@ mcp__agentic-qe__memory_store({
 
 **3. Submit Results to Queen:**
 ```typescript
-mcp__agentic_qe_v3__task_submit({
+mcp__agentic-qe__task_submit({
   type: "odata-contract-validation-complete",
   priority: "p1",
   payload: {

--- a/assets/agents/v3/qe-qx-partner.md
+++ b/assets/agents/v3/qe-qx-partner.md
@@ -18,7 +18,7 @@ V2 Compatibility: Maps to qx-partner for backward compatibility.
 <mcp_tools>
 ### Primary MCP Tool (ALWAYS use for programmatic analysis)
 ```typescript
-mcp__agentic_qe_v3__qe_qx_analyze({
+mcp__agentic-qe__qe_qx_analyze({
   target: "https://example.com",  // URL or identifier
   context: { /* Optional pre-collected context */ },
   mode: "full",  // "full" | "quick" | "targeted"

--- a/assets/agents/v3/qe-sap-idoc-tester.md
+++ b/assets/agents/v3/qe-sap-idoc-tester.md
@@ -96,7 +96,7 @@ Coordination:
 ### Query Known IDoc Patterns BEFORE Validation
 
 ```typescript
-mcp__agentic_qe_v3__memory_retrieve({
+mcp__agentic-qe__memory_retrieve({
   key: "sap-idoc/known-patterns",
   namespace: "learning"
 })
@@ -106,7 +106,7 @@ mcp__agentic_qe_v3__memory_retrieve({
 
 **1. Store IDoc Validation Experience:**
 ```typescript
-mcp__agentic_qe_v3__memory_store({
+mcp__agentic-qe__memory_store({
   key: "sap-idoc-tester/outcome-{timestamp}",
   namespace: "learning",
   value: {
@@ -156,7 +156,7 @@ mcp__agentic-qe__memory_store({
 
 **3. Submit Results to Queen:**
 ```typescript
-mcp__agentic_qe_v3__task_submit({
+mcp__agentic-qe__task_submit({
   type: "idoc-validation-complete",
   priority: "p1",
   payload: {

--- a/assets/agents/v3/qe-sap-rfc-tester.md
+++ b/assets/agents/v3/qe-sap-rfc-tester.md
@@ -92,7 +92,7 @@ Coordination:
 ### Query Known SAP RFC Patterns BEFORE Testing
 
 ```typescript
-mcp__agentic_qe_v3__memory_retrieve({
+mcp__agentic-qe__memory_retrieve({
   key: "sap-rfc/patterns",
   namespace: "learning"
 })
@@ -102,7 +102,7 @@ mcp__agentic_qe_v3__memory_retrieve({
 
 **1. Store SAP RFC Testing Experience:**
 ```typescript
-mcp__agentic_qe_v3__memory_store({
+mcp__agentic-qe__memory_store({
   key: "sap-rfc-tester/outcome-{timestamp}",
   namespace: "learning",
   value: {
@@ -150,7 +150,7 @@ mcp__agentic-qe__memory_store({
 
 **3. Submit Results to Queen:**
 ```typescript
-mcp__agentic_qe_v3__task_submit({
+mcp__agentic-qe__task_submit({
   type: "sap-rfc-testing-complete",
   priority: "p1",
   payload: {

--- a/assets/agents/v3/qe-soap-tester.md
+++ b/assets/agents/v3/qe-soap-tester.md
@@ -91,7 +91,7 @@ Coordination:
 ### Query Known SOAP Patterns BEFORE Testing
 
 ```typescript
-mcp__agentic_qe_v3__memory_retrieve({
+mcp__agentic-qe__memory_retrieve({
   key: "soap/patterns",
   namespace: "learning"
 })
@@ -101,7 +101,7 @@ mcp__agentic_qe_v3__memory_retrieve({
 
 **1. Store SOAP Testing Experience:**
 ```typescript
-mcp__agentic_qe_v3__memory_store({
+mcp__agentic-qe__memory_store({
   key: "soap-tester/outcome-{timestamp}",
   namespace: "learning",
   value: {
@@ -148,7 +148,7 @@ mcp__agentic-qe__memory_store({
 
 **3. Submit Results to Queen:**
 ```typescript
-mcp__agentic_qe_v3__task_submit({
+mcp__agentic-qe__task_submit({
   type: "soap-testing-complete",
   priority: "p1",
   payload: {

--- a/assets/agents/v3/qe-sod-analyzer.md
+++ b/assets/agents/v3/qe-sod-analyzer.md
@@ -99,7 +99,7 @@ Coordination:
 ### Query Known SoD Patterns BEFORE Analysis
 
 ```typescript
-mcp__agentic_qe_v3__memory_retrieve({
+mcp__agentic-qe__memory_retrieve({
   key: "sap-authorization/sod-patterns",
   namespace: "learning"
 })
@@ -109,7 +109,7 @@ mcp__agentic_qe_v3__memory_retrieve({
 
 **1. Store SoD Analysis Experience:**
 ```typescript
-mcp__agentic_qe_v3__memory_store({
+mcp__agentic-qe__memory_store({
   key: "sod-analyzer/outcome-{timestamp}",
   namespace: "learning",
   value: {
@@ -164,7 +164,7 @@ mcp__agentic-qe__memory_store({
 
 **3. Submit Results to Queen:**
 ```typescript
-mcp__agentic_qe_v3__task_submit({
+mcp__agentic-qe__task_submit({
   type: "sod-analysis-complete",
   priority: "p0",
   payload: {

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -4,6 +4,7 @@ All Agentic QE release notes organized by version.
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| [v3.8.1](v3.8.1.md) | 2026-03-17 | Fix MCP tool prefix mismatch in 8 agent files, permission pattern fix |
 | [v3.8.0](v3.8.0.md) | 2026-03-16 | RuVector: native HNSW (150x faster), neural routing, coherence safety gates |
 | [v3.7.22](v3.7.22.md) | 2026-03-14 | Hook path resolution fix, SQLite corruption prevention, v2 migration removal |
 | [v3.7.21](v3.7.21.md) | 2026-03-13 | Agent dependency intelligence, shell injection fixes, semgrep parallel SAST |

--- a/docs/releases/v3.8.0.md
+++ b/docs/releases/v3.8.0.md
@@ -38,6 +38,23 @@ aqe ruvector disable native-hnsw # Opt out of specific features
 aqe ruvector profile safe        # Conservative profile (disables experimental)
 ```
 
+## Benchmarks
+
+Collected during development on the `march-fixes-and-improvements` branch against 10K–150K pattern datasets:
+
+| Metric | Before (v3.7.x) | After (v3.8.0) | Improvement |
+|--------|-----------------|----------------|-------------|
+| Pattern search (10K vectors, p50) | ~8.7ms (JS HNSW) | 0.058ms (@ruvector/router) | **150x faster** |
+| Pattern search (1K vectors, p50) | ~0.75ms (JS HNSW) | 0.058ms (@ruvector/router) | **13x faster** |
+| MicroLoRA per-request adaptation (384-dim) | 1.65us (TypeScript) | 0.18us (WASM) | **9.2x faster** |
+| Coherence gate — reflex tier | N/A | 0.005ms | New capability |
+| Coherence gate — retrieval tier (sheaf Laplacian) | N/A | 1.2ms | New capability |
+| Memory for 150K pattern embeddings | ~600MB (float64) | ~150MB (Int8Array) | **4x reduction** |
+| Neural routing forward pass (p99) | N/A (rule-based) | <500us | New capability |
+| Neural router parameters | 0 | 259 (4→32→3 network) | Minimal overhead |
+
+**Test suite**: 15,493 unit tests passing with all feature flags both on and off, confirming full backward compatibility.
+
 ## Stability
 
 - 4 flaky tests fixed (shared singleton contamination under full-suite contention)

--- a/docs/releases/v3.8.1.md
+++ b/docs/releases/v3.8.1.md
@@ -1,0 +1,24 @@
+# v3.8.1 Release Notes
+
+**Release Date:** 2026-03-17
+
+## Highlights
+
+Fixes MCP tool prefix mismatch that caused 8 agent types to fail tool invocations and `claude -p` to hang on permission approval.
+
+## Fixed
+
+- **MCP tool prefix mismatch** — 8 agent files (qe-soap-tester, qe-sod-analyzer, qe-sap-idoc-tester, qe-sap-rfc-tester, qe-qx-partner, qe-middleware-validator, qe-odata-contract-tester, qe-message-broker-tester) referenced tools using the stale `mcp__agentic_qe_v3__` prefix instead of `mcp__agentic-qe__`. Fixed in both `.claude/agents/v3/` and `assets/agents/v3/` (44 occurrences across 16 files). ([#357](https://github.com/proffesor-for-testing/agentic-qe/issues/357))
+- **Permission pattern mismatch** — `.claude/settings.json` and `src/init/settings-merge.ts` used `mcp__agentic_qe__*` (underscores) instead of `mcp__agentic-qe__*` (hyphens), preventing automatic permission matching for MCP tool calls.
+
+## Changed
+
+- **v3.8.0 release notes** — Added benchmark table with real performance data collected during RuVector integration development.
+
+## Getting Started
+
+```bash
+npx agentic-qe init --auto
+```
+
+See [CHANGELOG](../../CHANGELOG.md) for full details.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentic-qe",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentic-qe",
-      "version": "3.8.0",
+      "version": "3.8.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-qe",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "Agentic Quality Engineering V3 - Domain-Driven Design Architecture with 13 Bounded Contexts, O(log n) coverage analysis, ReasoningBank learning, 60 specialized QE agents, mathematical Coherence verification, deep Claude Flow integration",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/init/settings-merge.ts
+++ b/src/init/settings-merge.ts
@@ -127,7 +127,7 @@ export function generateV3SettingsSections(config: AQEInitConfig): Record<string
         'Bash(npx claude-flow:*)',
         'Bash(npx @claude-flow/cli:*)',
         'mcp__claude-flow__:*',
-        'mcp__agentic_qe__*',
+        'mcp__agentic-qe__*',
       ],
       deny: [
         'Bash(rm -rf /)',


### PR DESCRIPTION
## Release v3.8.1

### What changed
- **Fix MCP tool prefix mismatch** — 8 agent files used stale `mcp__agentic_qe_v3__` prefix instead of `mcp__agentic-qe__`, causing tool invocations to fail and `claude -p` to hang on permissions. Fixed across 16 files (44 occurrences). Closes #357.
- **Fix permission pattern** — `.claude/settings.json` and `src/init/settings-merge.ts` used underscore variant that didn't match the registered MCP server name.
- **v3.8.0 release notes** — Added real benchmark data from RuVector integration (150x HNSW, 9.2x WASM, 4x memory reduction).

### Verification Checklist
- [x] package.json version updated to 3.8.1
- [x] fleetVersion in skills-manifest.json updated
- [x] Build succeeds (tsc + CLI + MCP bundles)
- [x] Type check passes (zero errors)
- [x] 464/465 unit test files pass (1 pre-existing failure)
- [x] `aqe init --auto` works in fresh project
- [x] CLI commands functional (`--version`, `status`)
- [x] Self-learning subsystem initializes
- [x] Isolated npm pack install succeeds

See [CHANGELOG](CHANGELOG.md) and [release notes](docs/releases/v3.8.1.md) for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)