### PR TITLE
chore(release): v3.9.16

### DIFF
--- a/.claude/skills/skills-manifest.json
+++ b/.claude/skills/skills-manifest.json
@@ -939,7 +939,7 @@
   },
   "metadata": {
     "generatedBy": "Agentic QE Fleet",
-    "fleetVersion": "3.9.15",
+    "fleetVersion": "3.9.16",
     "manifestVersion": "1.4.0",
     "lastUpdated": "2026-04-13T00:00:00.000Z",
     "contributors": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to the Agentic QE project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.16] - 2026-04-24
+
+**Brain-export tooling + native-binding advisor.** Three new CLI commands that make the QE brain snapshot easier to inspect and make optional native deps visible. Closes the last actionable items on issue #332 (brain export improvements) and item 2 of issue #383 (upgrade advisor).
+
+### Added
+
+- **`aqe brain diff <a> <b>`** — Compare two brain exports. Always compares manifests (version, checksum, per-table record counts, domain list delta) across any mix of JSONL and `.rvf` files. When both sides are JSONL it also reports record-level **added / removed / changed** IDs per table — identity comes from the primary key on keyed tables and from dedup columns on append-only tables (witness_chain, qe_pattern_usage). Flags: `--table <name>`, `--verbose`, `--json`. Exit 0 when identical, 1 on any difference.
+- **`aqe brain search -i <export>`** — Offline filtered search over a JSONL brain export. Defaults to `qe_patterns`; `--table <name>` targets any of the 25 tables. Filters: `--domain` (repeatable, combines with AND), `--pattern-type`, `--since`/`--until` (ISO dates against `updated_at` → `created_at` → `timestamp`), `-q/--query` (case-insensitive substring over name + description), `-l/--limit` (default 20), `--json`.
+- **`aqe upgrade`** — Read-only advisor that detects which optional native bindings load on this platform (`@ruvector/rvf-node`, `@ruvector/solver-node`, `@ruvector/attention`, `@ruvector/gnn`, `hnswlib-node`), shows the current `useRVFPatternStore` / `useSublinearSolver` / `useNativeHNSW` / `useGraphMAEEmbeddings` / `useQEFlashAttention` flag state after `RUVECTOR_*` env overrides, and prints install hints for anything missing. Does **not** mutate feature flags, env, or config. Flags: `--json`, `--strict` (exits 1 when an optional is missing). Exit 2 when a required native fails to load.
+- **Shell completions for `brain` and `upgrade`** — bash/zsh/fish/PowerShell tab-completion scripts now cover both new commands and all six `brain` subcommands (`export`, `import`, `info`, `diff`, `search`, `witness-backfill`). For `brain search --domain`, bash completion sources the canonical AQE domain list.
+
+### Fixed
+
+- **Stale issue-tracker drift** — Issue #355 ("RuVector Integration: Remaining Work Tracker") and issue #332 ("Brain Export LOW-priority improvements") had diverged from reality. Delivered items from #355 (RVF export/import CLI, manifest-with-checksums, witness-integrity validation) were still shown as TODO. Consolidated the overlap with #383 into a single comment on #355, split long-horizon RuVector work into the new #432 backlog issue, and closed #355 + #332 with explicit delivered / won't-fix rationale for each remaining item.
+
+### Changed
+
+- **22 pre-existing `no-useless-escape` lint errors in `src/cli/completions/index.ts`** cleaned up during the completions work (`\$foo` → `$foo` inside the JS template literal for the generated bash script; `\${files[@]}` preserved because `${` triggers template interpolation). Generator output is byte-identical after the cleanup, verified via `bash -n`.
+
+### Upgrade Notes
+
+- No breaking changes. Three new CLI commands; existing commands unchanged.
+- `aqe upgrade` is the recommended first-run diagnostic for users reporting "HNSW is slow" or "why is my router doing power iteration" — it tells them which native deps are missing and exactly what to `npm install`.
+- If you've built tooling that parses `aqe brain`'s help output, note that two new subcommands (`diff`, `search`) are now listed.
+
 ## [3.9.15] - 2026-04-22
 
 **qe-browser skill promoted to Implemented (ADR-091).** Closes the final gaps from the v3.9.9 introduction: the skill's eval file is now a runnable evaluation via a new `aqe eval run --skill qe-browser` command, a CI workflow gates changes with both unit and smoke tests, a getting-started guide walks new users through install and the five primitives, and Linux ARM64 users get a copy-paste `VIBIUM_BROWSER_PATH` hint after `aqe init --auto` detects their system chromium. Trust tier 3.

--- a/assets/skills/skills-manifest.json
+++ b/assets/skills/skills-manifest.json
@@ -939,7 +939,7 @@
   },
   "metadata": {
     "generatedBy": "Agentic QE Fleet",
-    "fleetVersion": "3.9.15",
+    "fleetVersion": "3.9.16",
     "manifestVersion": "1.4.0",
     "lastUpdated": "2026-04-13T00:00:00.000Z",
     "contributors": [

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -4,6 +4,7 @@ All Agentic QE release notes organized by version.
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| [v3.9.16](v3.9.16.md) | 2026-04-24 | Brain-export tooling: `aqe brain diff`/`search`, native-binding advisor `aqe upgrade` |
 | [v3.9.15](v3.9.15.md) | 2026-04-22 | qe-browser Implemented (ADR-091): `aqe eval run` CLI, CI gate, Linux ARM64 browser hint |
 | [v3.9.14](v3.9.14.md) | 2026-04-20 | Security + supply-chain: 15 critical vulns fixed, tarball -52%, command injection patched |
 | [v3.9.13](v3.9.13.md) | 2026-04-17 | Opus 4.7 migration (ADR-093): Sonnet 4.6 default, `xhigh` fleet-wide, cyber agents pinned |

--- a/docs/releases/v3.9.16.md
+++ b/docs/releases/v3.9.16.md
@@ -1,0 +1,34 @@
+# v3.9.16 Release Notes
+
+**Release Date:** 2026-04-24
+
+## Highlights
+
+Three new CLI commands that make the QE brain snapshot easier to inspect and make optional native deps visible: `aqe brain diff`, `aqe brain search`, and `aqe upgrade`. Closes the last actionable items on issue #332 and item 2 of issue #383.
+
+## Added
+
+- **`aqe brain diff <a> <b>`** — Compare two brain exports. Always compares manifests (version, checksum, per-table record counts, domain list delta) across any mix of JSONL and `.rvf` files. When both sides are JSONL it also reports record-level **added / removed / changed** IDs per table — identity comes from the primary key on keyed tables and from dedup columns on append-only tables (witness_chain, qe_pattern_usage). Flags: `--table <name>`, `--verbose`, `--json`. Exit 0 when identical, 1 on any difference.
+- **`aqe brain search -i <export>`** — Offline filtered search over a JSONL brain export. Defaults to `qe_patterns`; `--table <name>` targets any of the 25 tables. Filters: `--domain` (repeatable, combines with AND), `--pattern-type`, `--since`/`--until` (ISO dates against `updated_at` → `created_at` → `timestamp`), `-q/--query` (case-insensitive substring over name + description), `-l/--limit` (default 20), `--json`.
+- **`aqe upgrade`** — Read-only advisor that detects which optional native bindings load on this platform (`@ruvector/rvf-node`, `@ruvector/solver-node`, `@ruvector/attention`, `@ruvector/gnn`, `hnswlib-node`), shows the current flag state after `RUVECTOR_*` env overrides, and prints install hints for anything missing. Does **not** mutate feature flags, env, or config. Flags: `--json`, `--strict` (exits 1 when an optional is missing). Exit 2 when a required native fails to load.
+- **Shell completions for `brain` and `upgrade`** — bash/zsh/fish/PowerShell tab-completion scripts now cover both new commands and all six `brain` subcommands (`export`, `import`, `info`, `diff`, `search`, `witness-backfill`). For `brain search --domain`, bash completion sources the canonical AQE domain list.
+
+## Fixed
+
+- **Stale issue-tracker drift** — Issues #355 and #332 had diverged from reality. Delivered items from #355 (RVF export/import CLI, manifest-with-checksums, witness-integrity validation) were still shown as TODO. Consolidated the overlap with #383 into a single comment on #355, split long-horizon RuVector work into the new #432 backlog issue, and closed #355 + #332 with explicit delivered / won't-fix rationale for each remaining item.
+
+## Changed
+
+- **22 pre-existing `no-useless-escape` lint errors in `src/cli/completions/index.ts`** cleaned up during the completions work. Generator output is byte-identical after the cleanup, verified via `bash -n`.
+
+## Upgrade Notes
+
+- No breaking changes. Three new CLI commands; existing commands unchanged.
+- `aqe upgrade` is the recommended first-run diagnostic for users reporting "HNSW is slow" or "why is my router doing power iteration" — it tells them which native deps are missing and exactly what to `npm install`.
+- If you've built tooling that parses `aqe brain`'s help output, note that two new subcommands (`diff`, `search`) are now listed.
+
+## Links
+
+- Issue #332 (closed): Brain Export LOW-priority improvements
+- Issue #383 item 2 (delivered): `aqe upgrade` standalone command
+- Issue #432 (new backlog): RuVector stretch goals

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentic-qe",
-  "version": "3.9.15",
+  "version": "3.9.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentic-qe",
-      "version": "3.9.15",
+      "version": "3.9.16",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-qe",
-  "version": "3.9.15",
+  "version": "3.9.16",
   "description": "Agentic Quality Engineering V3 - Domain-Driven Design Architecture with 13 Bounded Contexts, O(log n) coverage analysis, ReasoningBank learning, 60 specialized QE agents, mathematical Coherence verification, deep Claude Flow integration",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/cli/brain-commands.ts
+++ b/src/cli/brain-commands.ts
@@ -28,6 +28,16 @@ import {
   type RvfBrainManifest,
   type RvfBrainImportResult,
 } from '../integrations/ruvector/brain-rvf-exporter.js';
+import {
+  diffBrains,
+  type BrainDiffOptions,
+  type BrainDiffResult,
+} from '../integrations/ruvector/brain-diff.js';
+import {
+  searchBrain,
+  type BrainSearchOptions,
+  type BrainSearchResult,
+} from '../integrations/ruvector/brain-search.js';
 import { createWitnessChain } from '../audit/witness-chain.js';
 import { backfillWitnessChain } from '../audit/witness-backfill.js';
 
@@ -122,6 +132,39 @@ export async function brainInfo(
   }
 
   return coreBrainInfo(containerPath);
+}
+
+// ============================================================================
+// Diff
+// ============================================================================
+
+/**
+ * Compare two brain exports and return a structured diff.
+ *
+ * Works for both JSONL and RVF exports at the manifest level; record-level
+ * added/removed/changed is only available when both sides are JSONL.
+ */
+export async function brainDiff(
+  pathA: string,
+  pathB: string,
+  options: BrainDiffOptions = {},
+): Promise<BrainDiffResult> {
+  return diffBrains(pathA, pathB, options);
+}
+
+// ============================================================================
+// Search
+// ============================================================================
+
+/**
+ * Filtered search over a JSONL brain export. Domain/pattern-type/date-range
+ * filters plus an optional substring query on name + description.
+ */
+export async function brainSearch(
+  inputPath: string,
+  options: BrainSearchOptions = {},
+): Promise<BrainSearchResult> {
+  return searchBrain(inputPath, options);
 }
 
 // ============================================================================

--- a/src/cli/commands/upgrade.ts
+++ b/src/cli/commands/upgrade.ts
@@ -1,0 +1,479 @@
+/**
+ * `aqe upgrade` — read-only advisory
+ *
+ * Detects which optional native bindings load on this platform and prints a
+ * report with recommendations. Does NOT modify feature flags, env vars, or
+ * config files — it only tells the user what they'd gain by installing the
+ * missing optional deps.
+ *
+ * Related: issue #383 item 2.
+ */
+
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { createRequire } from 'node:module';
+import { platform, arch } from 'node:os';
+
+import { getRuVectorFeatureFlags } from '../../integrations/ruvector/feature-flags.js';
+
+// ============================================================================
+// Public types
+// ============================================================================
+
+export type LoadStatus = 'loaded' | 'missing' | 'required-missing';
+
+export interface NativeCheck {
+  /** npm package name as it appears in package.json */
+  readonly packageName: string;
+  /** Human-readable role */
+  readonly role: string;
+  /** What the fallback looks like when missing (not applicable for required deps) */
+  readonly fallback: string;
+  /** Feature flag(s) this native affects (informational) */
+  readonly affectsFlags: readonly string[];
+  /** Whether missing is fatal or just degrades performance */
+  readonly required: boolean;
+}
+
+export interface NativeResult extends NativeCheck {
+  readonly status: LoadStatus;
+  /** Error message if the load failed (missing means MODULE_NOT_FOUND; other errors get surfaced). */
+  readonly loadError?: string;
+}
+
+export interface EnvOverride {
+  readonly envVar: string;
+  readonly value: string;
+  readonly flagName: string;
+}
+
+export interface Recommendation {
+  readonly severity: 'info' | 'warn' | 'error';
+  readonly message: string;
+  /** Copy-paste install command, when relevant. */
+  readonly action?: string;
+}
+
+export interface UpgradeReport {
+  readonly aqeVersion: string;
+  readonly platform: {
+    readonly os: string;
+    readonly arch: string;
+    readonly node: string;
+  };
+  readonly natives: readonly NativeResult[];
+  readonly flags: {
+    readonly useRVFPatternStore: boolean;
+    readonly useSublinearSolver: boolean;
+    readonly useNativeHNSW: boolean;
+    readonly useGraphMAEEmbeddings: boolean;
+    readonly useQEFlashAttention: boolean;
+  };
+  readonly envOverrides: readonly EnvOverride[];
+  readonly recommendations: readonly Recommendation[];
+  readonly summary: {
+    readonly requiredOk: boolean;
+    readonly optionalMissingCount: number;
+    readonly optionalLoadedCount: number;
+  };
+}
+
+// ============================================================================
+// Native catalog
+// ============================================================================
+
+/**
+ * The set of packages `aqe upgrade` inspects. Order controls the report
+ * rendering order.
+ */
+export const NATIVE_CATALOG: readonly NativeCheck[] = [
+  {
+    packageName: 'better-sqlite3',
+    role: 'SQLite storage (required — memory.db, patterns, audit)',
+    fallback: 'n/a — required',
+    affectsFlags: [],
+    required: true,
+  },
+  {
+    packageName: 'web-tree-sitter',
+    role: 'Tree-sitter WASM parser runtime (required — code intelligence)',
+    fallback: 'n/a — required',
+    affectsFlags: [],
+    required: true,
+  },
+  {
+    packageName: 'hnswlib-node',
+    role: 'Canonical HNSW vector index (default since ADR-090)',
+    fallback: 'ProgressiveHnswBackend (JS) — correct but slower on large codebases',
+    affectsFlags: ['useNativeHNSW'],
+    required: false,
+  },
+  {
+    packageName: '@ruvector/rvf-node',
+    role: 'Persistent HNSW pattern store + RVF brain export format',
+    fallback: 'SQLite-backed HNSW + JSONL brain export',
+    affectsFlags: ['useRVFPatternStore'],
+    required: false,
+  },
+  {
+    packageName: '@ruvector/solver-node',
+    role: 'Sublinear PageRank on the pattern citation graph',
+    fallback: 'TypeScript power iteration — O(n·m) (practical cap ≈ 50K nodes)',
+    affectsFlags: ['useSublinearSolver'],
+    required: false,
+  },
+  {
+    packageName: '@ruvector/attention',
+    role: 'Flash Attention with SIMD acceleration',
+    fallback: 'Plain attention — 2.5–7× slower on large sequences',
+    affectsFlags: ['useQEFlashAttention'],
+    required: false,
+  },
+  {
+    packageName: '@ruvector/gnn',
+    role: 'GraphMAE native acceleration',
+    fallback: 'TypeScript GraphMAE — correct but slower',
+    affectsFlags: ['useGraphMAEEmbeddings'],
+    required: false,
+  },
+];
+
+// ============================================================================
+// Detection
+// ============================================================================
+
+export type LoadProbe = (packageName: string) => { ok: true } | { ok: false; error: Error };
+
+/** Default probe — uses a CJS require relative to this module's location. */
+export function createDefaultLoadProbe(): LoadProbe {
+  const req = createRequire(import.meta.url);
+  return (packageName: string) => {
+    try {
+      req(packageName);
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err : new Error(String(err)) };
+    }
+  };
+}
+
+export function detectNatives(
+  catalog: readonly NativeCheck[],
+  probe: LoadProbe,
+): NativeResult[] {
+  return catalog.map<NativeResult>((check) => {
+    const result = probe(check.packageName);
+    if (result.ok) {
+      return { ...check, status: 'loaded' };
+    }
+    const missingModule = isModuleNotFound(result.error);
+    const status: LoadStatus = check.required
+      ? 'required-missing'
+      : missingModule
+        ? 'missing'
+        : 'missing';
+    return { ...check, status, loadError: result.error.message };
+  });
+}
+
+function isModuleNotFound(err: Error): boolean {
+  return (err as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND';
+}
+
+// ============================================================================
+// Environment overrides
+// ============================================================================
+
+/**
+ * Map of RUVECTOR_* env vars → feature flag names that aqe upgrade cares about.
+ * Only includes flags tied to optional natives — the full list is in
+ * feature-flags.ts.
+ */
+const ENV_VAR_TO_FLAG: Record<string, string> = {
+  RUVECTOR_USE_RVF_PATTERN_STORE: 'useRVFPatternStore',
+  RUVECTOR_USE_SUBLINEAR_SOLVER: 'useSublinearSolver',
+  RUVECTOR_USE_NATIVE_HNSW: 'useNativeHNSW',
+  RUVECTOR_USE_GNN_INDEX: 'useQEGNNIndex',
+  RUVECTOR_USE_FLASH_ATTENTION: 'useQEFlashAttention',
+  RUVECTOR_USE_GRAPH_MAE_EMBEDDINGS: 'useGraphMAEEmbeddings',
+};
+
+export function readEnvOverrides(env: NodeJS.ProcessEnv): EnvOverride[] {
+  const out: EnvOverride[] = [];
+  for (const [envVar, flagName] of Object.entries(ENV_VAR_TO_FLAG)) {
+    const v = env[envVar];
+    if (v !== undefined) out.push({ envVar, value: v, flagName });
+  }
+  return out;
+}
+
+// ============================================================================
+// Recommendation rules
+// ============================================================================
+
+interface RecommendationInput {
+  readonly natives: readonly NativeResult[];
+  readonly flags: UpgradeReport['flags'];
+  readonly envOverrides: readonly EnvOverride[];
+}
+
+export function buildRecommendations(input: RecommendationInput): Recommendation[] {
+  const recs: Recommendation[] = [];
+  const nativeByName = new Map(input.natives.map((n) => [n.packageName, n]));
+
+  // Missing required deps are a hard error.
+  for (const n of input.natives) {
+    if (n.status === 'required-missing') {
+      recs.push({
+        severity: 'error',
+        message: `Required dependency missing: ${n.packageName} — ${n.role}`,
+        action: `npm install ${n.packageName}`,
+      });
+    }
+  }
+
+  // Missing optional deps: suggest install, note fallback.
+  for (const n of input.natives) {
+    if (n.status === 'missing' && !n.required) {
+      recs.push({
+        severity: 'warn',
+        message: `Optional native missing: ${n.packageName} — falls back to ${n.fallback}`,
+        action: `npm install ${n.packageName}`,
+      });
+    }
+  }
+
+  // Env override conflicts: user forced a flag ON but the native isn't loadable.
+  const flagByName: Record<string, boolean | undefined> = { ...input.flags };
+  for (const override of input.envOverrides) {
+    const natives = input.natives.filter((n) => n.affectsFlags.includes(override.flagName));
+    const anyLoaded = natives.some((n) => n.status === 'loaded');
+    const wantsOn = override.value === 'true' || override.value === '1';
+
+    if (wantsOn && natives.length > 0 && !anyLoaded) {
+      const missing = natives.map((n) => n.packageName).join(', ');
+      recs.push({
+        severity: 'warn',
+        message:
+          `${override.envVar}=${override.value} requests flag ${override.flagName}=true, ` +
+          `but required native(s) not loaded: ${missing}. The flag will silently fall back.`,
+        action: natives[0] ? `npm install ${natives[0].packageName}` : undefined,
+      });
+    }
+  }
+  void flagByName; // reserved for future rules
+  void nativeByName;
+
+  // All optionals loaded → positive-confirmation info line.
+  const optionalMissing = input.natives.filter(
+    (n) => !n.required && n.status === 'missing',
+  );
+  if (optionalMissing.length === 0 && input.natives.every((n) => n.status !== 'required-missing')) {
+    recs.push({
+      severity: 'info',
+      message: 'All recommended native bindings are loaded — no action required.',
+    });
+  }
+
+  return recs;
+}
+
+// ============================================================================
+// Report builder
+// ============================================================================
+
+export interface BuildReportInput {
+  readonly aqeVersion: string;
+  readonly probe: LoadProbe;
+  readonly env: NodeJS.ProcessEnv;
+  readonly flags: UpgradeReport['flags'];
+}
+
+export function buildReport(input: BuildReportInput): UpgradeReport {
+  const natives = detectNatives(NATIVE_CATALOG, input.probe);
+  const envOverrides = readEnvOverrides(input.env);
+  const recommendations = buildRecommendations({
+    natives,
+    flags: input.flags,
+    envOverrides,
+  });
+
+  const optionalLoadedCount = natives.filter((n) => !n.required && n.status === 'loaded').length;
+  const optionalMissingCount = natives.filter((n) => !n.required && n.status === 'missing').length;
+  const requiredOk = natives.filter((n) => n.required).every((n) => n.status === 'loaded');
+
+  return {
+    aqeVersion: input.aqeVersion,
+    platform: {
+      os: platform(),
+      arch: arch(),
+      node: process.version,
+    },
+    natives,
+    flags: input.flags,
+    envOverrides,
+    recommendations,
+    summary: {
+      requiredOk,
+      optionalMissingCount,
+      optionalLoadedCount,
+    },
+  };
+}
+
+// ============================================================================
+// Exit-code policy
+// ============================================================================
+
+export function exitCodeFor(report: UpgradeReport, strict: boolean): number {
+  if (!report.summary.requiredOk) return 2;
+  if (strict && report.summary.optionalMissingCount > 0) return 1;
+  return 0;
+}
+
+// ============================================================================
+// Rendering
+// ============================================================================
+
+export function renderReportHuman(report: UpgradeReport): string {
+  const lines: string[] = [];
+  const push = (s = '') => lines.push(s);
+
+  push('');
+  push(chalk.bold.blue('  aqe upgrade — native binding report'));
+  push(chalk.gray('  ──────────────────────────────────────'));
+  push('');
+  push(`  AQE:       ${chalk.cyan(report.aqeVersion)}`);
+  push(`  Platform:  ${chalk.cyan(`${report.platform.os} ${report.platform.arch}`)}`);
+  push(`  Node:      ${chalk.cyan(report.platform.node)}`);
+
+  push('');
+  push(chalk.blue('  Native bindings:'));
+  for (const n of report.natives) {
+    const status = statusBadge(n.status);
+    push(`    ${status} ${chalk.bold(n.packageName.padEnd(28))} ${chalk.gray(n.role)}`);
+    if (n.status !== 'loaded' && n.loadError) {
+      // Node's MODULE_NOT_FOUND error message carries a multi-line "Require
+      // stack:" trailer that adds no signal here — keep the first line only.
+      push(`        ${chalk.gray(n.loadError.split('\n')[0])}`);
+    }
+  }
+
+  push('');
+  push(chalk.blue('  Flag state (after env overrides):'));
+  const flagEntries = Object.entries(report.flags);
+  for (const [name, value] of flagEntries) {
+    const badge = value ? chalk.green('on ') : chalk.yellow('off');
+    push(`    ${badge}  ${name}`);
+  }
+
+  if (report.envOverrides.length > 0) {
+    push('');
+    push(chalk.blue('  Env overrides in effect:'));
+    for (const o of report.envOverrides) {
+      push(`    ${chalk.cyan(o.envVar)}=${chalk.cyan(o.value)}  ${chalk.gray(`→ ${o.flagName}`)}`);
+    }
+  }
+
+  push('');
+  push(chalk.blue('  Recommendations:'));
+  if (report.recommendations.length === 0) {
+    push(chalk.gray('    (none)'));
+  } else {
+    for (const rec of report.recommendations) {
+      const prefix = recommendationPrefix(rec.severity);
+      push(`    ${prefix} ${rec.message}`);
+      if (rec.action) push(`        ${chalk.gray('→')} ${chalk.cyan(rec.action)}`);
+    }
+  }
+
+  push('');
+  const okBadge = report.summary.requiredOk ? chalk.green('OK') : chalk.red('FAIL');
+  push(
+    `  Summary:   required ${okBadge}    ` +
+      `optional loaded ${chalk.cyan(report.summary.optionalLoadedCount)} / ` +
+      `${chalk.cyan(report.summary.optionalLoadedCount + report.summary.optionalMissingCount)}`,
+  );
+  push('');
+
+  return lines.join('\n');
+}
+
+function statusBadge(status: LoadStatus): string {
+  switch (status) {
+    case 'loaded':
+      return chalk.green('✓');
+    case 'missing':
+      return chalk.yellow('…');
+    case 'required-missing':
+      return chalk.red('✗');
+  }
+}
+
+function recommendationPrefix(severity: Recommendation['severity']): string {
+  switch (severity) {
+    case 'info':
+      return chalk.green('✓');
+    case 'warn':
+      return chalk.yellow('!');
+    case 'error':
+      return chalk.red('✗');
+  }
+}
+
+// ============================================================================
+// Commander wiring
+// ============================================================================
+
+interface UpgradeCliOptions {
+  json?: boolean;
+  strict?: boolean;
+}
+
+export function createUpgradeCommand(cleanupAndExit: (code: number) => Promise<never>): Command {
+  const cmd = new Command('upgrade')
+    .description('Detect optional native bindings and recommend install / flag changes (read-only)')
+    .option('--json', 'Emit the report as JSON to stdout', false)
+    .option('--strict', 'Exit non-zero if any recommended optional native is missing', false)
+    .action(async (options: UpgradeCliOptions) => {
+      const aqeVersion = resolveAqeVersion();
+      const rvFlags = getRuVectorFeatureFlags();
+
+      const report = buildReport({
+        aqeVersion,
+        probe: createDefaultLoadProbe(),
+        env: process.env,
+        flags: {
+          useRVFPatternStore: rvFlags.useRVFPatternStore,
+          useSublinearSolver: rvFlags.useSublinearSolver,
+          useNativeHNSW: rvFlags.useNativeHNSW,
+          useGraphMAEEmbeddings: rvFlags.useGraphMAEEmbeddings,
+          useQEFlashAttention: rvFlags.useQEFlashAttention,
+        },
+      });
+
+      if (options.json) {
+        process.stdout.write(JSON.stringify(report, null, 2) + '\n');
+      } else {
+        process.stdout.write(renderReportHuman(report));
+      }
+
+      await cleanupAndExit(exitCodeFor(report, options.strict === true));
+    });
+
+  return cmd;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function resolveAqeVersion(): string {
+  try {
+    const req = createRequire(import.meta.url);
+    const pkg = req('../../../package.json') as { version?: string };
+    return pkg.version ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}

--- a/src/cli/completions/index.ts
+++ b/src/cli/completions/index.ts
@@ -237,6 +237,23 @@ export const COMMANDS = {
       install: { options: ['--shell'] },
     },
   },
+  // Brain export/import/diff/search
+  brain: {
+    description: 'Export, import, and inspect QE brain state',
+    subcommands: {
+      export: { options: ['-o', '--output', '--format', '--db'] },
+      import: { options: ['-i', '--input', '--strategy', '--dry-run', '--db'] },
+      info: { options: ['-i', '--input'] },
+      diff: { options: ['--table', '--verbose', '--json'] },
+      search: { options: ['-i', '--input', '--table', '--domain', '--pattern-type', '--since', '--until', '-q', '--query', '-l', '--limit', '--json'] },
+      'witness-backfill': { options: ['--db'] },
+    },
+  },
+  // Native binding advisor
+  upgrade: {
+    description: 'Detect optional native bindings and recommend install / flag changes',
+    options: ['--json', '--strict'],
+  },
 } as const;
 
 /**
@@ -298,40 +315,40 @@ export function generateBashCompletion(): string {
 
 # Helper function to complete test files (*.test.ts, *.spec.ts, *.test.js, etc.)
 _aqe_complete_test_files() {
-    local cur="\$1"
+    local cur="$1"
     local IFS=$'\\n'
     local files=()
 
     # Complete test files with common test file patterns
     # Use find for more reliable glob matching across directories
-    if [[ -z "\$cur" || "\$cur" == "." ]]; then
+    if [[ -z "$cur" || "$cur" == "." ]]; then
         # No prefix - search from current directory
         while IFS= read -r file; do
-            files+=("\$file")
+            files+=("$file")
         done < <(find . -maxdepth 3 -type f \\( -name "*.test.ts" -o -name "*.spec.ts" -o -name "*.test.js" -o -name "*.spec.js" -o -name "*.test.tsx" -o -name "*.spec.tsx" \\) 2>/dev/null | head -30)
     else
         # Has prefix - use compgen with glob patterns
-        files+=(\$(compgen -f -X '!*.test.ts' -- "\$cur" 2>/dev/null))
-        files+=(\$(compgen -f -X '!*.spec.ts' -- "\$cur" 2>/dev/null))
-        files+=(\$(compgen -f -X '!*.test.js' -- "\$cur" 2>/dev/null))
-        files+=(\$(compgen -f -X '!*.spec.js' -- "\$cur" 2>/dev/null))
-        files+=(\$(compgen -f -X '!*.test.tsx' -- "\$cur" 2>/dev/null))
-        files+=(\$(compgen -f -X '!*.spec.tsx' -- "\$cur" 2>/dev/null))
+        files+=($(compgen -f -X '!*.test.ts' -- "$cur" 2>/dev/null))
+        files+=($(compgen -f -X '!*.spec.ts' -- "$cur" 2>/dev/null))
+        files+=($(compgen -f -X '!*.test.js' -- "$cur" 2>/dev/null))
+        files+=($(compgen -f -X '!*.spec.js' -- "$cur" 2>/dev/null))
+        files+=($(compgen -f -X '!*.test.tsx' -- "$cur" 2>/dev/null))
+        files+=($(compgen -f -X '!*.spec.tsx' -- "$cur" 2>/dev/null))
     fi
 
     # Also include directories for navigation
-    COMPREPLY=(\$(compgen -d -- "\$cur"))
+    COMPREPLY=($(compgen -d -- "$cur"))
 
     # Add test files to completions
     for file in "\${files[@]}"; do
-        [[ -n "\$file" ]] && COMPREPLY+=("\$file")
+        [[ -n "$file" ]] && COMPREPLY+=("$file")
     done
 }
 
 # Helper function to complete directories
 _aqe_complete_directories() {
-    local cur="\$1"
-    COMPREPLY=( \$(compgen -d -- "$cur") )
+    local cur="$1"
+    COMPREPLY=( $(compgen -d -- "$cur") )
 }
 
 # Main completion function (version-agnostic name per ADR-042)
@@ -339,12 +356,13 @@ _aqe_completions() {
     local cur prev words cword
     _init_completion || return
 
-    local commands="init status health task agent domain protocol test coverage quality security code migrate hypergraph completions"
+    local commands="init status health task agent domain protocol test coverage quality security code migrate hypergraph completions brain upgrade"
     local task_subcmds="submit list cancel status"
     local agent_subcmds="list spawn"
     local domain_subcmds="list health"
     local protocol_subcmds="run"
     local completions_subcmds="bash zsh fish powershell install"
+    local brain_subcmds="export import info diff search witness-backfill"
     local code_actions="index search impact deps"
     local test_actions="generate execute"
 
@@ -677,6 +695,48 @@ _aqe_completions() {
                     ;;
             esac
             ;;
+        brain)
+            case "\${words[2]}" in
+                export)
+                    COMPREPLY=( $(compgen -W "-o --output --format --db" -- "$cur") )
+                    return
+                    ;;
+                import)
+                    COMPREPLY=( $(compgen -W "-i --input --strategy --dry-run --db" -- "$cur") )
+                    return
+                    ;;
+                info)
+                    COMPREPLY=( $(compgen -W "-i --input" -- "$cur") )
+                    return
+                    ;;
+                diff)
+                    COMPREPLY=( $(compgen -W "--table --verbose --json" -- "$cur") )
+                    return
+                    ;;
+                search)
+                    case "$prev" in
+                        --domain)
+                            COMPREPLY=( $(compgen -W "$domains" -- "$cur") )
+                            return
+                            ;;
+                    esac
+                    COMPREPLY=( $(compgen -W "-i --input --table --domain --pattern-type --since --until -q --query -l --limit --json" -- "$cur") )
+                    return
+                    ;;
+                witness-backfill)
+                    COMPREPLY=( $(compgen -W "--db" -- "$cur") )
+                    return
+                    ;;
+                *)
+                    COMPREPLY=( $(compgen -W "$brain_subcmds" -- "$cur") )
+                    return
+                    ;;
+            esac
+            ;;
+        upgrade)
+            COMPREPLY=( $(compgen -W "--json --strict" -- "$cur") )
+            return
+            ;;
         *)
             COMPREPLY=( $(compgen -W "$commands" -- "$cur") )
             return
@@ -739,6 +799,8 @@ _aqe() {
         'hypergraph:Query the code knowledge hypergraph'
         'migrate:V2 to V3 migration'
         'completions:Generate shell completions'
+        'brain:Export, import, and inspect QE brain state'
+        'upgrade:Detect optional native bindings and recommend flags'
     )
 
     domains=(
@@ -1033,6 +1095,30 @@ _aqe() {
                             ;;
                     esac
                     ;;
+                brain)
+                    local -a brain_commands
+                    brain_commands=(
+                        'export:Export brain state to a portable file/directory'
+                        'import:Import a brain export into the local database'
+                        'info:Show manifest metadata for a brain export'
+                        'diff:Compare two brain exports'
+                        'search:Filtered search over a JSONL brain export'
+                        'witness-backfill:Create witness chain entries for legacy patterns'
+                    )
+                    _arguments -C \\
+                        '1:brain subcommand:->brain_cmd' \\
+                        '*::arg:->brain_args'
+                    case "$state" in
+                        brain_cmd)
+                            _describe -t commands 'brain subcommands' brain_commands
+                            ;;
+                    esac
+                    ;;
+                upgrade)
+                    _arguments \\
+                        '--json[Emit the report as JSON]' \\
+                        '--strict[Exit non-zero if any optional native is missing]'
+                    ;;
             esac
             ;;
     esac
@@ -1083,6 +1169,16 @@ complete -c aqe -n "__fish_seen_subcommand_from hypergraph; and not __fish_seen_
 complete -c aqe -n "__fish_seen_subcommand_from hypergraph; and not __fish_seen_subcommand_from stats untested impacted gaps" -a "impacted" -d "Find impacted tests"
 complete -c aqe -n "__fish_seen_subcommand_from hypergraph; and not __fish_seen_subcommand_from stats untested impacted gaps" -a "gaps" -d "Find coverage gaps"
 complete -c aqe -n "__fish_use_subcommand" -a "migrate" -d "V2 to V3 migration"
+complete -c aqe -n "__fish_use_subcommand" -a "brain" -d "Export, import, and inspect QE brain state"
+complete -c aqe -n "__fish_seen_subcommand_from brain; and not __fish_seen_subcommand_from export import info diff search witness-backfill" -a "export" -d "Export brain state"
+complete -c aqe -n "__fish_seen_subcommand_from brain; and not __fish_seen_subcommand_from export import info diff search witness-backfill" -a "import" -d "Import a brain export"
+complete -c aqe -n "__fish_seen_subcommand_from brain; and not __fish_seen_subcommand_from export import info diff search witness-backfill" -a "info" -d "Show manifest info"
+complete -c aqe -n "__fish_seen_subcommand_from brain; and not __fish_seen_subcommand_from export import info diff search witness-backfill" -a "diff" -d "Compare two brain exports"
+complete -c aqe -n "__fish_seen_subcommand_from brain; and not __fish_seen_subcommand_from export import info diff search witness-backfill" -a "search" -d "Filtered search over a JSONL brain export"
+complete -c aqe -n "__fish_seen_subcommand_from brain; and not __fish_seen_subcommand_from export import info diff search witness-backfill" -a "witness-backfill" -d "Backfill witness chain entries"
+complete -c aqe -n "__fish_use_subcommand" -a "upgrade" -d "Detect optional native bindings and recommend install / flag changes"
+complete -c aqe -n "__fish_seen_subcommand_from upgrade" -l json -d "Emit the report as JSON"
+complete -c aqe -n "__fish_seen_subcommand_from upgrade" -l strict -d "Exit non-zero if any optional native is missing"
 complete -c aqe -n "__fish_use_subcommand" -a "completions" -d "Generate shell completions"
 
 # Domains list
@@ -1290,6 +1386,8 @@ $script:AQE_COMMANDS = @{
     'hypergraph' = 'Query the code knowledge hypergraph'
     'migrate' = 'V2 to V3 migration'
     'completions' = 'Generate shell completions'
+    'brain' = 'Export, import, and inspect QE brain state'
+    'upgrade' = 'Detect optional native bindings and recommend flags'
 }
 
 Register-ArgumentCompleter -Native -CommandName 'aqe' -ScriptBlock {

--- a/src/cli/handlers/brain-handler.ts
+++ b/src/cli/handlers/brain-handler.ts
@@ -13,9 +13,16 @@ import {
   exportBrain,
   importBrain,
   brainInfo,
+  brainDiff,
+  brainSearch,
   witnessBackfill,
   type BrainManifest,
 } from '../brain-commands.js';
+import type {
+  BrainDiffResult,
+  TableDiff,
+} from '../../integrations/ruvector/brain-diff.js';
+import type { BrainSearchResult } from '../../integrations/ruvector/brain-search.js';
 
 // ============================================================================
 // Brain Handler
@@ -76,6 +83,34 @@ export class BrainHandler implements ICommandHandler {
       .option('--db <path>', 'Database path')
       .action(async (options: { db: string }) => {
         await this.executeWitnessBackfill(options);
+      });
+
+    brain
+      .command('diff')
+      .description('Compare two brain exports (JSONL directory or .rvf file)')
+      .argument('<a>', 'Path to first brain export')
+      .argument('<b>', 'Path to second brain export')
+      .option('--table <name>', 'Restrict comparison to a single table')
+      .option('--verbose', 'Show the IDs of added/removed/changed records', false)
+      .option('--json', 'Emit the diff as JSON to stdout', false)
+      .action(async (a: string, b: string, options: DiffOptions) => {
+        await this.executeDiff(a, b, options);
+      });
+
+    brain
+      .command('search')
+      .description('Search a JSONL brain export with filters')
+      .requiredOption('-i, --input <path>', 'Path to brain export directory (JSONL)')
+      .option('--table <name>', 'Table to search (default: qe_patterns)')
+      .option('--domain <name...>', 'Restrict to one or more domains')
+      .option('--pattern-type <type>', 'Restrict to a specific pattern_type (qe_patterns only)')
+      .option('--since <iso>', 'Include rows with timestamp ≥ <iso>')
+      .option('--until <iso>', 'Include rows with timestamp ≤ <iso>')
+      .option('-q, --query <text>', 'Substring match across name + description (case-insensitive)')
+      .option('-l, --limit <n>', 'Maximum results to return', '20')
+      .option('--json', 'Emit results as JSON to stdout', false)
+      .action(async (options: SearchOptions) => {
+        await this.executeSearch(options);
       });
   }
 
@@ -267,6 +302,57 @@ export class BrainHandler implements ICommandHandler {
     }
   }
 
+  private async executeDiff(a: string, b: string, options: DiffOptions): Promise<void> {
+    try {
+      const result = await brainDiff(path.resolve(a), path.resolve(b), {
+        tableFilter: options.table,
+      });
+
+      if (options.json) {
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+        await this.cleanupAndExit(result.identical ? 0 : 1);
+        return;
+      }
+
+      renderDiff(result, options.verbose);
+
+      // Exit code convention: 0 when identical, 1 when differences exist.
+      await this.cleanupAndExit(result.identical ? 0 : 1);
+    } catch (error) {
+      console.error(chalk.red('\n  Brain diff failed:'), error);
+      await this.cleanupAndExit(2);
+    }
+  }
+
+  private async executeSearch(options: SearchOptions): Promise<void> {
+    try {
+      const limit = parseLimit(options.limit);
+      const domains = normalizeDomainOption(options.domain);
+
+      const result = await brainSearch(path.resolve(options.input), {
+        table: options.table,
+        domains,
+        patternType: options.patternType,
+        since: options.since,
+        until: options.until,
+        query: options.query,
+        limit,
+      });
+
+      if (options.json) {
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+        await this.cleanupAndExit(result.totalMatched > 0 ? 0 : 3);
+        return;
+      }
+
+      renderSearch(result);
+      await this.cleanupAndExit(result.totalMatched > 0 ? 0 : 3);
+    } catch (error) {
+      console.error(chalk.red('\n  Brain search failed:'), error);
+      await this.cleanupAndExit(2);
+    }
+  }
+
   private async executeWitnessBackfill(options: { db: string }): Promise<void> {
     try {
       console.log(chalk.blue('\n  Running witness chain backfill...\n'));
@@ -304,6 +390,8 @@ Subcommands:
   export    Export brain state to a portable .rvf file or JSONL directory
   import    Import a brain export into the local database
   info      Show manifest metadata for an existing brain export
+  diff      Compare two brain exports (manifest always; record-level for JSONL)
+  search    Filtered search over a JSONL brain export
 
 Examples:
   aqe brain export -o .agentic-qe/brain.rvf
@@ -312,6 +400,9 @@ Examples:
   aqe brain import -i .agentic-qe/brain.rvf --strategy latest-wins
   aqe brain import -i .agentic-qe/brain.rvf --dry-run
   aqe brain info -i .agentic-qe/brain.rvf
+  aqe brain diff ./brain-a ./brain-b --verbose
+  aqe brain search -i ./brain-export --query oauth --domain test-generation
+  aqe brain search -i ./brain-export --since 2026-03-01 --limit 50 --json
 `;
   }
 }
@@ -337,6 +428,24 @@ interface InfoOptions {
   input: string;
 }
 
+interface DiffOptions {
+  table?: string;
+  verbose: boolean;
+  json: boolean;
+}
+
+interface SearchOptions {
+  input: string;
+  table?: string;
+  domain?: string | string[];
+  patternType?: string;
+  since?: string;
+  until?: string;
+  query?: string;
+  limit: string;
+  json: boolean;
+}
+
 // ============================================================================
 // Helpers
 // ============================================================================
@@ -351,6 +460,160 @@ function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function parseLimit(raw: string): number {
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 1) return 20;
+  return n;
+}
+
+function normalizeDomainOption(value: string | string[] | undefined): readonly string[] | undefined {
+  if (value === undefined) return undefined;
+  const arr = Array.isArray(value) ? value : [value];
+  const out: string[] = [];
+  for (const raw of arr) {
+    for (const part of raw.split(',')) {
+      const trimmed = part.trim();
+      if (trimmed) out.push(trimmed);
+    }
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+function renderDiff(result: BrainDiffResult, verbose: boolean): void {
+  console.log(chalk.blue('\n  Brain Diff\n'));
+  console.log(`  A:            ${chalk.cyan(result.pathA)}  (${result.formatA})`);
+  console.log(`  B:            ${chalk.cyan(result.pathB)}  (${result.formatB})`);
+  console.log(
+    `  Versions:     ${chalk.cyan(result.manifestA.version)} → ${chalk.cyan(result.manifestB.version)}` +
+      (result.versionMatch ? chalk.gray(' (match)') : chalk.yellow(' (differ)')),
+  );
+  console.log(
+    `  Checksums:    ${chalk.gray(result.manifestA.checksum.slice(0, 12))}… → ` +
+      `${chalk.gray(result.manifestB.checksum.slice(0, 12))}…` +
+      (result.checksumMatch ? chalk.gray(' (match)') : chalk.yellow(' (differ)')),
+  );
+  console.log(
+    `  Exported:     ${chalk.gray(result.manifestA.exportedAt)} → ${chalk.gray(result.manifestB.exportedAt)}`,
+  );
+  console.log(
+    `  Records:      ${chalk.cyan(result.manifestA.totalRecords)} → ${chalk.cyan(result.manifestB.totalRecords)} ` +
+      formatDelta(result.manifestB.totalRecords - result.manifestA.totalRecords),
+  );
+
+  if (result.domainsOnlyInA.length > 0 || result.domainsOnlyInB.length > 0) {
+    console.log(chalk.blue('\n  Domains:'));
+    if (result.domainsOnlyInA.length > 0) {
+      console.log(`    Only in A: ${chalk.yellow(result.domainsOnlyInA.join(', '))}`);
+    }
+    if (result.domainsOnlyInB.length > 0) {
+      console.log(`    Only in B: ${chalk.yellow(result.domainsOnlyInB.join(', '))}`);
+    }
+  }
+
+  if (!result.recordLevel) {
+    console.log(
+      chalk.gray(
+        '\n  Note: record-level diff is only available when both sides are JSONL exports.\n' +
+          '        Per-table counts shown below; re-export with --format jsonl for added/removed/changed IDs.',
+      ),
+    );
+  }
+
+  console.log(chalk.blue('\n  Tables:'));
+  const changed = result.tableDiffs.filter(tableHasChange);
+  if (changed.length === 0) {
+    console.log(chalk.gray('    (no differences)'));
+  } else {
+    for (const t of changed) {
+      console.log(
+        `    ${t.tableName.padEnd(28)} ${chalk.cyan(String(t.countA).padStart(7))} → ` +
+          `${chalk.cyan(String(t.countB).padStart(7))} ${formatDelta(t.delta)}` +
+          formatRecordBuckets(t, verbose),
+      );
+      if (verbose) {
+        if (t.added && t.added.length > 0) printIdBucket('added', t.added);
+        if (t.removed && t.removed.length > 0) printIdBucket('removed', t.removed);
+        if (t.changed && t.changed.length > 0) printIdBucket('changed', t.changed);
+      }
+    }
+  }
+
+  console.log('');
+  if (result.identical) {
+    console.log(chalk.green('  Result: identical\n'));
+  } else {
+    console.log(chalk.yellow('  Result: differences found\n'));
+  }
+}
+
+function tableHasChange(t: TableDiff): boolean {
+  if (t.delta !== 0) return true;
+  if (t.added && t.added.length > 0) return true;
+  if (t.removed && t.removed.length > 0) return true;
+  if (t.changed && t.changed.length > 0) return true;
+  return false;
+}
+
+function formatDelta(delta: number): string {
+  if (delta === 0) return chalk.gray('(±0)');
+  if (delta > 0) return chalk.green(`(+${delta})`);
+  return chalk.red(`(${delta})`);
+}
+
+function formatRecordBuckets(t: TableDiff, verbose: boolean): string {
+  const parts: string[] = [];
+  if (t.added && t.added.length > 0) parts.push(chalk.green(`+${t.added.length}`));
+  if (t.removed && t.removed.length > 0) parts.push(chalk.red(`-${t.removed.length}`));
+  if (t.changed && t.changed.length > 0) parts.push(chalk.yellow(`~${t.changed.length}`));
+  if (parts.length === 0) return '';
+  if (verbose) return '  ' + parts.join(' ');
+  return '  ' + chalk.gray('[') + parts.join(' ') + chalk.gray(']');
+}
+
+function printIdBucket(label: string, ids: readonly string[]): void {
+  const preview = ids.slice(0, 10).join(', ');
+  const suffix = ids.length > 10 ? chalk.gray(` …(+${ids.length - 10} more)`) : '';
+  console.log(`      ${chalk.gray(label + ':')} ${preview}${suffix}`);
+}
+
+function renderSearch(result: BrainSearchResult): void {
+  console.log(chalk.blue('\n  Brain Search\n'));
+  console.log(`  Input:      ${chalk.cyan(result.inputPath)}`);
+  console.log(`  Table:      ${chalk.cyan(result.table)}`);
+  console.log(
+    `  Scanned:    ${chalk.cyan(result.totalScanned)}    ` +
+      `Matched: ${chalk.cyan(result.totalMatched)}    ` +
+      `Shown: ${chalk.cyan(result.hits.length)}` +
+      (result.truncated ? chalk.yellow(` (truncated to limit ${result.limit})`) : ''),
+  );
+
+  if (result.hits.length === 0) {
+    console.log(chalk.yellow('\n  No matching rows.\n'));
+    return;
+  }
+
+  console.log('');
+  for (const hit of result.hits) {
+    const header =
+      chalk.cyan(hit.id) +
+      (hit.display.patternType ? chalk.gray(`  ${hit.display.patternType}`) : '') +
+      (hit.display.domain ? chalk.gray(`  [${hit.display.domain}]`) : '') +
+      (hit.display.confidence !== undefined
+        ? chalk.gray(`  conf=${hit.display.confidence.toFixed(2)}`)
+        : '');
+    console.log(`  ${header}`);
+    if (hit.display.name) console.log(`    ${chalk.bold(hit.display.name)}`);
+    if (hit.display.description) {
+      const desc = hit.display.description.length > 200
+        ? hit.display.description.slice(0, 200) + '…'
+        : hit.display.description;
+      console.log(`    ${chalk.gray(desc)}`);
+    }
+    if (hit.display.updatedAt) console.log(`    ${chalk.gray(hit.display.updatedAt)}`);
+    console.log('');
+  }
 }
 
 // ============================================================================

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -63,7 +63,6 @@ console.log = (...args: unknown[]) => {
 };
 
 // Also redirect timestamped INFO/WARN/ERROR log lines (e.g. "[07:12:24.372] [INFO ]")
-const originalConsoleInfo = console.info.bind(console);
 console.info = (...args: unknown[]) => {
   process.stderr.write(args.map(String).join(' ') + '\n');
 };
@@ -336,6 +335,11 @@ registerLazyCommand(program, {
   name: 'completions',
   description: 'Generate shell completions for aqe',
   factory: () => import('./commands/completions.js').then(m => m.createCompletionsCommand(cleanupAndExit)),
+});
+registerLazyCommand(program, {
+  name: 'upgrade',
+  description: 'Detect optional native bindings and recommend install / flag changes',
+  factory: () => import('./commands/upgrade.js').then(m => m.createUpgradeCommand(cleanupAndExit)),
 });
 registerLazyCommand(program, {
   name: 'fleet',

--- a/src/integrations/ruvector/brain-diff.ts
+++ b/src/integrations/ruvector/brain-diff.ts
@@ -1,0 +1,432 @@
+/**
+ * Brain Export Diff
+ *
+ * Compares two brain exports (JSONL directory or RVF file) and returns a
+ * structured diff.
+ *
+ * Two levels of comparison:
+ *   - Manifest-level (always available): version, checksum, per-table record
+ *     counts, exported_at, domain list delta.
+ *   - Record-level (JSONL exports only): for each table with a PK, the set of
+ *     added / removed / changed record IDs. For append-only tables only counts
+ *     are reported.
+ *
+ * For RVF exports, record-level diff is not supported by this module (the
+ * kernel is opaque without @ruvector/rvf-node). Export as JSONL for full diff.
+ */
+
+import { existsSync, readFileSync, statSync } from 'fs';
+import { join, resolve } from 'path';
+import { safeJsonParse } from '../../shared/safe-json.js';
+import { brainInfoFromRvf } from './brain-rvf-exporter.js';
+import {
+  readJsonl,
+  sha256,
+  TABLE_CONFIGS,
+  PK_COLUMNS,
+  type TableExportConfig,
+} from './brain-shared.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type ExportFormat = 'rvf' | 'jsonl';
+
+export interface ManifestSummary {
+  readonly format: ExportFormat;
+  readonly version: string;
+  readonly exportedAt: string;
+  readonly sourceDb: string;
+  readonly checksum: string;
+  readonly totalRecords: number;
+  readonly domains: readonly string[];
+  readonly tableRecordCounts: Record<string, number>;
+}
+
+export interface TableDiff {
+  readonly tableName: string;
+  readonly countA: number;
+  readonly countB: number;
+  readonly delta: number;
+  /** Only populated for JSONL↔JSONL record-level diffs on PK tables. */
+  readonly added?: readonly string[];
+  readonly removed?: readonly string[];
+  readonly changed?: readonly string[];
+}
+
+export interface BrainDiffResult {
+  readonly pathA: string;
+  readonly pathB: string;
+  readonly formatA: ExportFormat;
+  readonly formatB: ExportFormat;
+  readonly manifestA: ManifestSummary;
+  readonly manifestB: ManifestSummary;
+  readonly checksumMatch: boolean;
+  readonly versionMatch: boolean;
+  readonly identical: boolean;
+  readonly recordLevel: boolean;
+  readonly tableDiffs: readonly TableDiff[];
+  readonly domainsOnlyInA: readonly string[];
+  readonly domainsOnlyInB: readonly string[];
+}
+
+export interface BrainDiffOptions {
+  /** Restrict comparison to a single table (by table name). */
+  readonly tableFilter?: string;
+  /** Cap on the number of IDs retained per added/removed/changed list. */
+  readonly maxIdsPerBucket?: number;
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Compute the diff between two brain exports.
+ *
+ * Both paths may be JSONL directories or `.rvf` files. Record-level diff is
+ * only available when both sides are JSONL.
+ */
+export function diffBrains(
+  pathA: string,
+  pathB: string,
+  options: BrainDiffOptions = {},
+): BrainDiffResult {
+  const resolvedA = resolve(pathA);
+  const resolvedB = resolve(pathB);
+
+  const formatA = detectFormat(resolvedA);
+  const formatB = detectFormat(resolvedB);
+
+  const manifestA = readManifestSummary(resolvedA, formatA);
+  const manifestB = readManifestSummary(resolvedB, formatB);
+
+  const recordLevel = formatA === 'jsonl' && formatB === 'jsonl';
+
+  const tableDiffs = computeTableDiffs({
+    pathA: resolvedA,
+    pathB: resolvedB,
+    manifestA,
+    manifestB,
+    recordLevel,
+    tableFilter: options.tableFilter,
+    maxIdsPerBucket: options.maxIdsPerBucket ?? 500,
+  });
+
+  const domainsA = new Set(manifestA.domains);
+  const domainsB = new Set(manifestB.domains);
+  const domainsOnlyInA = manifestA.domains.filter((d) => !domainsB.has(d));
+  const domainsOnlyInB = manifestB.domains.filter((d) => !domainsA.has(d));
+
+  const checksumMatch = manifestA.checksum === manifestB.checksum;
+  const versionMatch = manifestA.version === manifestB.version;
+
+  const identical =
+    checksumMatch &&
+    versionMatch &&
+    tableDiffs.every(
+      (t) =>
+        t.delta === 0 &&
+        (t.added?.length ?? 0) === 0 &&
+        (t.removed?.length ?? 0) === 0 &&
+        (t.changed?.length ?? 0) === 0,
+    );
+
+  return {
+    pathA: resolvedA,
+    pathB: resolvedB,
+    formatA,
+    formatB,
+    manifestA,
+    manifestB,
+    checksumMatch,
+    versionMatch,
+    identical,
+    recordLevel,
+    tableDiffs,
+    domainsOnlyInA,
+    domainsOnlyInB,
+  };
+}
+
+// ============================================================================
+// Format detection + manifest reading
+// ============================================================================
+
+function detectFormat(path: string): ExportFormat {
+  if (!existsSync(path)) {
+    throw new Error(`Path not found: ${path}`);
+  }
+  if (path.endsWith('.rvf')) return 'rvf';
+  const s = statSync(path);
+  if (s.isFile()) {
+    // Any single file that isn't .rvf is treated as an error — JSONL exports
+    // are directories.
+    throw new Error(
+      `Unsupported brain export: ${path} (expected a .rvf file or a JSONL directory)`,
+    );
+  }
+  // Directory: assume JSONL
+  return 'jsonl';
+}
+
+function readManifestSummary(path: string, format: ExportFormat): ManifestSummary {
+  if (format === 'rvf') {
+    return readRvfManifestSummary(path);
+  }
+  return readJsonlManifestSummary(path);
+}
+
+interface RawManifest {
+  version?: string;
+  exportedAt?: string;
+  sourceDb?: string;
+  checksum?: string;
+  stats?: { totalRecords?: number };
+  domains?: readonly string[];
+  tableRecordCounts?: Record<string, number>;
+}
+
+function readJsonlManifestSummary(dir: string): ManifestSummary {
+  const manifestPath = join(dir, 'manifest.json');
+  if (!existsSync(manifestPath)) {
+    throw new Error(`Manifest not found at ${manifestPath}`);
+  }
+  const raw = safeJsonParse<RawManifest>(readFileSync(manifestPath, 'utf-8'));
+  return toManifestSummary(raw, 'jsonl');
+}
+
+function readRvfManifestSummary(rvfPath: string): ManifestSummary {
+  // Delegate to the RVF exporter's info path so we honour its format handling.
+  const raw = brainInfoFromRvf(rvfPath) as unknown as RawManifest;
+  return toManifestSummary(raw, 'rvf');
+}
+
+function toManifestSummary(raw: RawManifest, format: ExportFormat): ManifestSummary {
+  return {
+    format,
+    version: raw.version ?? 'unknown',
+    exportedAt: raw.exportedAt ?? 'unknown',
+    sourceDb: raw.sourceDb ?? 'unknown',
+    checksum: raw.checksum ?? '',
+    totalRecords: raw.stats?.totalRecords ?? 0,
+    domains: raw.domains ?? [],
+    tableRecordCounts: raw.tableRecordCounts ?? {},
+  };
+}
+
+// ============================================================================
+// Table-level diff
+// ============================================================================
+
+interface TableDiffInput {
+  readonly pathA: string;
+  readonly pathB: string;
+  readonly manifestA: ManifestSummary;
+  readonly manifestB: ManifestSummary;
+  readonly recordLevel: boolean;
+  readonly tableFilter?: string;
+  readonly maxIdsPerBucket: number;
+}
+
+function computeTableDiffs(input: TableDiffInput): TableDiff[] {
+  const configs = input.tableFilter
+    ? TABLE_CONFIGS.filter((c) => c.tableName === input.tableFilter)
+    : TABLE_CONFIGS;
+
+  if (input.tableFilter && configs.length === 0) {
+    throw new Error(`Unknown table: ${input.tableFilter}`);
+  }
+
+  const diffs: TableDiff[] = [];
+  for (const config of configs) {
+    const countA = input.manifestA.tableRecordCounts[config.tableName] ?? 0;
+    const countB = input.manifestB.tableRecordCounts[config.tableName] ?? 0;
+    const delta = countB - countA;
+
+    let added: readonly string[] | undefined;
+    let removed: readonly string[] | undefined;
+    let changed: readonly string[] | undefined;
+
+    if (input.recordLevel && hasIdentity(config)) {
+      const recordDiff = recordLevelDiff(
+        join(input.pathA, config.fileName),
+        join(input.pathB, config.fileName),
+        config,
+        input.maxIdsPerBucket,
+      );
+      added = recordDiff.added;
+      removed = recordDiff.removed;
+      changed = recordDiff.changed;
+    }
+
+    diffs.push({
+      tableName: config.tableName,
+      countA,
+      countB,
+      delta,
+      ...(added !== undefined ? { added } : {}),
+      ...(removed !== undefined ? { removed } : {}),
+      ...(changed !== undefined ? { changed } : {}),
+    });
+  }
+
+  return diffs;
+}
+
+function hasIdentity(_config: TableExportConfig): boolean {
+  // PK tables always have identity; append-only tables can be deduped via
+  // their dedup columns, which is good enough to compute added/removed.
+  return true;
+}
+
+function pkFor(config: TableExportConfig): string {
+  if (config.dedupColumns && config.dedupColumns.length > 0) {
+    // Composite identity — joined with a separator unlikely to occur in values.
+    return config.dedupColumns.join('');
+  }
+  return PK_COLUMNS[config.tableName] ?? 'id';
+}
+
+interface RecordDiff {
+  added: string[];
+  removed: string[];
+  changed: string[];
+}
+
+function recordLevelDiff(
+  fileA: string,
+  fileB: string,
+  config: TableExportConfig,
+  maxIdsPerBucket: number,
+): RecordDiff {
+  const mapA = buildIdentityMap(fileA, config);
+  const mapB = buildIdentityMap(fileB, config);
+
+  const added: string[] = [];
+  const removed: string[] = [];
+  const changed: string[] = [];
+
+  // In A but not in B → removed.
+  for (const [id, hashA] of mapA) {
+    const hashB = mapB.get(id);
+    if (hashB === undefined) {
+      if (removed.length < maxIdsPerBucket) removed.push(id);
+    } else if (hashB !== hashA) {
+      // Append-only tables use dedup columns as identity, so if the identity
+      // matches the record IS the same — guard via dedup flag.
+      if (config.dedupColumns && config.dedupColumns.length > 0) continue;
+      if (changed.length < maxIdsPerBucket) changed.push(id);
+    }
+  }
+  // In B but not in A → added.
+  for (const id of mapB.keys()) {
+    if (!mapA.has(id)) {
+      if (added.length < maxIdsPerBucket) added.push(id);
+    }
+  }
+
+  added.sort();
+  removed.sort();
+  changed.sort();
+
+  return { added, removed, changed };
+}
+
+/**
+ * Read a JSONL file and build a Map<identity, contentHash>.
+ *
+ * For PK tables the identity is the PK column value. For append-only tables
+ * the identity is a concatenation of the dedup columns (collisions are
+ * treated as "same record").
+ */
+function buildIdentityMap(
+  filePath: string,
+  config: TableExportConfig,
+): Map<string, string> {
+  const map = new Map<string, string>();
+  if (!existsSync(filePath)) return map;
+
+  const rows = readJsonl<Record<string, unknown>>(filePath, safeJsonParse);
+  for (const row of rows) {
+    const id = identityOf(row, config);
+    if (id === undefined) continue;
+    // Stable content hash: JSON-stringify with sorted keys.
+    const content = stableStringify(row);
+    map.set(id, sha256Hex(content));
+  }
+  return map;
+}
+
+function identityOf(
+  row: Record<string, unknown>,
+  config: TableExportConfig,
+): string | undefined {
+  if (config.dedupColumns && config.dedupColumns.length > 0) {
+    const parts: string[] = [];
+    for (const col of config.dedupColumns) {
+      const v = row[col];
+      if (v === undefined || v === null) return undefined;
+      parts.push(String(v));
+    }
+    return parts.join('');
+  }
+  const pk = PK_COLUMNS[config.tableName] ?? 'id';
+  const v = row[pk];
+  if (v === undefined || v === null) return undefined;
+  return String(v);
+}
+
+function stableStringify(obj: Record<string, unknown>): string {
+  const keys = Object.keys(obj).sort();
+  const ordered: Record<string, unknown> = {};
+  for (const k of keys) ordered[k] = obj[k];
+  return JSON.stringify(ordered);
+}
+
+function sha256Hex(s: string): string {
+  // sha256() from brain-shared operates on utf-8 strings; both paths yield the
+  // same hash for the same input. Kept as a thin wrapper for readability.
+  return sha256(s);
+}
+
+// ============================================================================
+// Presentation helpers (used by the CLI handler, exported for tests)
+// ============================================================================
+
+export interface DiffSummary {
+  readonly tablesChanged: number;
+  readonly totalAdded: number;
+  readonly totalRemoved: number;
+  readonly totalChanged: number;
+  readonly recordCountDelta: number;
+}
+
+export function summarizeDiff(result: BrainDiffResult): DiffSummary {
+  let tablesChanged = 0;
+  let totalAdded = 0;
+  let totalRemoved = 0;
+  let totalChanged = 0;
+  for (const t of result.tableDiffs) {
+    const hasChange =
+      t.delta !== 0 ||
+      (t.added && t.added.length > 0) ||
+      (t.removed && t.removed.length > 0) ||
+      (t.changed && t.changed.length > 0);
+    if (hasChange) tablesChanged++;
+    totalAdded += t.added?.length ?? 0;
+    totalRemoved += t.removed?.length ?? 0;
+    totalChanged += t.changed?.length ?? 0;
+  }
+  return {
+    tablesChanged,
+    totalAdded,
+    totalRemoved,
+    totalChanged,
+    recordCountDelta: result.manifestB.totalRecords - result.manifestA.totalRecords,
+  };
+}
+
+// Export internal helpers for test access without widening the public API.
+export const __test__ = { stableStringify, identityOf, buildIdentityMap, pkFor };

--- a/src/integrations/ruvector/brain-search.ts
+++ b/src/integrations/ruvector/brain-search.ts
@@ -1,0 +1,243 @@
+/**
+ * Brain Export Search
+ *
+ * Offline, read-only filtered search over a JSONL brain export directory.
+ * Useful for exploring what a snapshot contains without importing it.
+ *
+ * Defaults to searching qe_patterns but can target any of the 25 exported
+ * tables via the `table` option. Supports filters by domain, pattern_type,
+ * date range, and a substring query that matches `name` + `description`.
+ *
+ * RVF exports are not supported directly by this module — callers should use
+ * `aqe brain export --format jsonl` for searchable snapshots.
+ */
+
+import { existsSync, statSync } from 'fs';
+import { join, resolve } from 'path';
+import { safeJsonParse } from '../../shared/safe-json.js';
+import { readJsonl, TABLE_CONFIGS } from './brain-shared.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface BrainSearchOptions {
+  /** Table to search. Defaults to 'qe_patterns'. */
+  readonly table?: string;
+  /** Restrict to these domains (matched against the table's domain column). */
+  readonly domains?: readonly string[];
+  /** Restrict to rows with this exact pattern_type (qe_patterns only). */
+  readonly patternType?: string;
+  /** ISO timestamp — only rows at or after this are included. */
+  readonly since?: string;
+  /** ISO timestamp — only rows at or before this are included. */
+  readonly until?: string;
+  /** Case-insensitive substring matched against name + description. */
+  readonly query?: string;
+  /** Max rows to return. Defaults to 20. */
+  readonly limit?: number;
+}
+
+export interface BrainSearchHit {
+  /** Primary-key identity string (best effort per table). */
+  readonly id: string;
+  /** Minimal surface shown in default CLI output. */
+  readonly display: {
+    readonly name?: string;
+    readonly description?: string;
+    readonly domain?: string;
+    readonly patternType?: string;
+    readonly confidence?: number;
+    readonly updatedAt?: string;
+  };
+  /** Full raw row for callers that want more (used by --json). */
+  readonly row: Record<string, unknown>;
+}
+
+export interface BrainSearchResult {
+  readonly table: string;
+  readonly inputPath: string;
+  readonly totalScanned: number;
+  readonly totalMatched: number;
+  readonly limit: number;
+  readonly hits: readonly BrainSearchHit[];
+  readonly truncated: boolean;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const DEFAULT_LIMIT = 20;
+const DEFAULT_TABLE = 'qe_patterns';
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Search a brain export directory for rows matching the given filters.
+ *
+ * Throws if the path isn't a JSONL export directory, if the requested table
+ * isn't known, or if the JSONL file for that table is missing.
+ */
+export function searchBrain(
+  inputPath: string,
+  options: BrainSearchOptions = {},
+): BrainSearchResult {
+  const resolved = resolve(inputPath);
+  assertJsonlExport(resolved);
+
+  const tableName = options.table ?? DEFAULT_TABLE;
+  const config = TABLE_CONFIGS.find((c) => c.tableName === tableName);
+  if (!config) {
+    throw new Error(`Unknown table: ${tableName}`);
+  }
+
+  const filePath = join(resolved, config.fileName);
+  if (!existsSync(filePath)) {
+    throw new Error(
+      `Table file not found: ${config.fileName} ` +
+        `(expected in ${resolved}). Was this export generated with --format jsonl?`,
+    );
+  }
+
+  const rows = readJsonl<Record<string, unknown>>(filePath, safeJsonParse);
+  const domainColumn = config.domainColumn;
+
+  const limit = Math.max(1, options.limit ?? DEFAULT_LIMIT);
+  const queryLower = options.query ? options.query.toLowerCase() : undefined;
+  const domains = options.domains && options.domains.length > 0 ? new Set(options.domains) : undefined;
+  const since = options.since;
+  const until = options.until;
+  const patternType = options.patternType;
+
+  let matched = 0;
+  const hits: BrainSearchHit[] = [];
+
+  for (const row of rows) {
+    if (!rowMatches(row, { domainColumn, domains, patternType, since, until, queryLower })) {
+      continue;
+    }
+    matched++;
+    if (hits.length < limit) {
+      hits.push(toHit(row, config.tableName, domainColumn));
+    }
+  }
+
+  return {
+    table: tableName,
+    inputPath: resolved,
+    totalScanned: rows.length,
+    totalMatched: matched,
+    limit,
+    hits,
+    truncated: matched > limit,
+  };
+}
+
+// ============================================================================
+// Filtering
+// ============================================================================
+
+interface FilterContext {
+  readonly domainColumn?: string;
+  readonly domains?: Set<string>;
+  readonly patternType?: string;
+  readonly since?: string;
+  readonly until?: string;
+  readonly queryLower?: string;
+}
+
+function rowMatches(row: Record<string, unknown>, ctx: FilterContext): boolean {
+  // Domain filter — only applied if table has a domain column.
+  if (ctx.domains) {
+    if (!ctx.domainColumn) return false; // caller asked for a domain filter on a table that has none
+    const v = row[ctx.domainColumn];
+    if (typeof v !== 'string' || !ctx.domains.has(v)) return false;
+  }
+
+  // Pattern type filter — only meaningful for qe_patterns.
+  if (ctx.patternType !== undefined) {
+    const v = row['pattern_type'];
+    if (v !== ctx.patternType) return false;
+  }
+
+  // Date range — matched against updated_at | created_at | timestamp (in that order).
+  if (ctx.since !== undefined || ctx.until !== undefined) {
+    const ts = pickTimestamp(row);
+    if (ts === undefined) return false;
+    if (ctx.since !== undefined && ts < ctx.since) return false;
+    if (ctx.until !== undefined && ts > ctx.until) return false;
+  }
+
+  // Substring query — matched against name + description (case-insensitive).
+  if (ctx.queryLower !== undefined) {
+    const name = typeof row['name'] === 'string' ? (row['name'] as string).toLowerCase() : '';
+    const desc =
+      typeof row['description'] === 'string' ? (row['description'] as string).toLowerCase() : '';
+    if (!name.includes(ctx.queryLower) && !desc.includes(ctx.queryLower)) return false;
+  }
+
+  return true;
+}
+
+function pickTimestamp(row: Record<string, unknown>): string | undefined {
+  for (const col of ['updated_at', 'created_at', 'timestamp']) {
+    const v = row[col];
+    if (typeof v === 'string' && v.length > 0) return v;
+  }
+  return undefined;
+}
+
+// ============================================================================
+// Result formatting
+// ============================================================================
+
+function toHit(
+  row: Record<string, unknown>,
+  tableName: string,
+  domainColumn: string | undefined,
+): BrainSearchHit {
+  const id =
+    (typeof row['id'] === 'string' || typeof row['id'] === 'number'
+      ? String(row['id'])
+      : undefined) ?? `${tableName}:?`;
+
+  const display: BrainSearchHit['display'] = {
+    name: typeof row['name'] === 'string' ? (row['name'] as string) : undefined,
+    description: typeof row['description'] === 'string' ? (row['description'] as string) : undefined,
+    domain: domainColumn && typeof row[domainColumn] === 'string' ? (row[domainColumn] as string) : undefined,
+    patternType: typeof row['pattern_type'] === 'string' ? (row['pattern_type'] as string) : undefined,
+    confidence: typeof row['confidence'] === 'number' ? (row['confidence'] as number) : undefined,
+    updatedAt: pickTimestamp(row),
+  };
+
+  return { id, display, row };
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function assertJsonlExport(path: string): void {
+  if (!existsSync(path)) {
+    throw new Error(`Path not found: ${path}`);
+  }
+  const s = statSync(path);
+  if (s.isFile()) {
+    if (path.endsWith('.rvf')) {
+      throw new Error(
+        'Brain search does not support RVF exports. Re-export with --format jsonl, or use `aqe brain info` for RVF summaries.',
+      );
+    }
+    throw new Error(`Unsupported brain export: ${path} (expected a JSONL directory)`);
+  }
+  const manifest = join(path, 'manifest.json');
+  if (!existsSync(manifest)) {
+    throw new Error(`Manifest not found at ${manifest}. Is this a brain export directory?`);
+  }
+}
+
+// Re-export for test access / future helpers without widening the public API.
+export const __test__ = { pickTimestamp, rowMatches, toHit };

--- a/tests/integration/cli/upgrade-command.test.ts
+++ b/tests/integration/cli/upgrade-command.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Integration tests for `aqe upgrade`.
+ *
+ * Spawns the built CLI binary and verifies that:
+ *   - `aqe upgrade --json` emits a valid, shaped JSON report.
+ *   - The human renderer produces expected section headers and markers.
+ *   - Exit codes follow the contract: 0/1/2 based on dep state + --strict.
+ *
+ * These tests assume `npm run build` has been run (they execute the bundle
+ * in `dist/cli/bundle.js`). They do NOT re-run the build — doing so here
+ * would make them slow and duplicate CI work.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const CLI_PATH = resolve(__dirname, '..', '..', '..', 'dist', 'cli', 'bundle.js');
+
+function runCli(args: string[], envExtra: NodeJS.ProcessEnv = {}): {
+  stdout: string;
+  stderr: string;
+  status: number | null;
+} {
+  const res = spawnSync(process.execPath, [CLI_PATH, ...args], {
+    encoding: 'utf-8',
+    env: { ...process.env, ...envExtra },
+    // Give it a wide timeout — upgrade is fast but bundle import can take
+    // a second on a cold FS.
+    timeout: 20_000,
+  });
+  return {
+    stdout: res.stdout ?? '',
+    stderr: res.stderr ?? '',
+    status: res.status,
+  };
+}
+
+describe('aqe upgrade — integration', () => {
+  beforeAll(() => {
+    if (!existsSync(CLI_PATH)) {
+      throw new Error(
+        `CLI bundle not found at ${CLI_PATH}. Run \`npm run build\` before running integration tests.`,
+      );
+    }
+  });
+
+  it('emits a valid JSON report with --json', () => {
+    const res = runCli(['upgrade', '--json']);
+    expect(res.status === 0 || res.status === 1).toBe(true);
+    // The JSON payload is everything before the first newline after the last `}`.
+    // The CLI prints exactly one JSON object followed by '\n'.
+    const parsed = JSON.parse(res.stdout);
+
+    // Top-level shape
+    expect(parsed).toMatchObject({
+      aqeVersion: expect.any(String),
+      platform: {
+        os: expect.any(String),
+        arch: expect.any(String),
+        node: expect.stringMatching(/^v\d+\./),
+      },
+      natives: expect.any(Array),
+      flags: expect.any(Object),
+      envOverrides: expect.any(Array),
+      recommendations: expect.any(Array),
+      summary: {
+        requiredOk: expect.any(Boolean),
+        optionalMissingCount: expect.any(Number),
+        optionalLoadedCount: expect.any(Number),
+      },
+    });
+
+    // Natives shape — at least one entry, each with a status in the allowed set
+    expect(parsed.natives.length).toBeGreaterThan(0);
+    for (const n of parsed.natives) {
+      expect(n.packageName).toEqual(expect.any(String));
+      expect(['loaded', 'missing', 'required-missing']).toContain(n.status);
+    }
+
+    // Flags we expose in the report
+    for (const key of [
+      'useRVFPatternStore',
+      'useSublinearSolver',
+      'useNativeHNSW',
+      'useGraphMAEEmbeddings',
+      'useQEFlashAttention',
+    ]) {
+      expect(parsed.flags).toHaveProperty(key);
+      expect(typeof parsed.flags[key]).toBe('boolean');
+    }
+  }, 30_000);
+
+  it('human output carries the expected section headers', () => {
+    const res = runCli(['upgrade']);
+    expect(res.status === 0 || res.status === 1).toBe(true);
+    expect(res.stdout).toContain('aqe upgrade');
+    expect(res.stdout).toContain('Native bindings:');
+    expect(res.stdout).toContain('Flag state');
+    expect(res.stdout).toContain('Recommendations:');
+    expect(res.stdout).toContain('Summary:');
+  }, 30_000);
+
+  it('exit code matches the contract: 0 or 1 when required deps OK', () => {
+    const res = runCli(['upgrade', '--json']);
+    expect([0, 1]).toContain(res.status);
+    const parsed = JSON.parse(res.stdout);
+    expect(parsed.summary.requiredOk).toBe(true);
+  }, 30_000);
+
+  it('--strict produces a distinct exit code when optionals are missing', () => {
+    const normal = runCli(['upgrade', '--json']);
+    const strict = runCli(['upgrade', '--json', '--strict']);
+
+    const parsed = JSON.parse(normal.stdout);
+    if (parsed.summary.optionalMissingCount > 0) {
+      expect(normal.status).toBe(0);
+      expect(strict.status).toBe(1);
+    } else {
+      // Fully loaded environment: both should be 0.
+      expect(normal.status).toBe(0);
+      expect(strict.status).toBe(0);
+    }
+  }, 30_000);
+
+  it('reports any RUVECTOR_* env overrides in the JSON output', () => {
+    const res = runCli(['upgrade', '--json'], {
+      RUVECTOR_USE_RVF_PATTERN_STORE: 'true',
+    });
+    const parsed = JSON.parse(res.stdout);
+    const found = parsed.envOverrides.find(
+      (o: { envVar: string }) => o.envVar === 'RUVECTOR_USE_RVF_PATTERN_STORE',
+    );
+    expect(found).toBeDefined();
+    expect(found.value).toBe('true');
+    expect(found.flagName).toBe('useRVFPatternStore');
+  }, 30_000);
+});

--- a/tests/unit/brain-diff.test.ts
+++ b/tests/unit/brain-diff.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Tests for the brain-diff module (issue #332, C-10).
+ *
+ * The diff compares two JSONL exports at manifest + record level, and two
+ * RVF exports (or a mixed pair) at manifest level only.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { existsSync, mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { randomUUID } from 'crypto';
+
+import { exportBrain } from '../../src/integrations/ruvector/brain-exporter.js';
+import { diffBrains, summarizeDiff } from '../../src/integrations/ruvector/brain-diff.js';
+import { ensureTargetTables } from '../../src/integrations/ruvector/brain-shared.js';
+
+// ----------------------------------------------------------------------------
+// Fixtures
+// ----------------------------------------------------------------------------
+
+function createTestDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.pragma('journal_mode = WAL');
+  ensureTargetTables(db);
+  return db;
+}
+
+function insertPattern(db: Database.Database, p: {
+  id: string;
+  pattern_type?: string;
+  qe_domain?: string;
+  name?: string;
+  description?: string;
+  confidence?: number;
+  updated_at?: string;
+}): void {
+  db.prepare(`
+    INSERT INTO qe_patterns (id, pattern_type, qe_domain, domain, name, description, confidence, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    p.id,
+    p.pattern_type ?? 'test-template',
+    p.qe_domain ?? 'test-generation',
+    p.qe_domain ?? 'test-generation',
+    p.name ?? 'name-' + p.id,
+    p.description ?? 'desc-' + p.id,
+    p.confidence ?? 0.8,
+    p.updated_at ?? '2026-02-20T10:00:00Z',
+  );
+}
+
+function insertWitness(db: Database.Database, w: {
+  prev_hash: string;
+  action_hash: string;
+  action_type: string;
+  timestamp: string;
+  actor: string;
+}): void {
+  db.prepare(`
+    INSERT INTO witness_chain (prev_hash, action_hash, action_type, action_data, timestamp, actor)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run(w.prev_hash, w.action_hash, w.action_type, null, w.timestamp, w.actor);
+}
+
+let workDir: string;
+
+beforeEach(() => {
+  workDir = join(tmpdir(), 'aqe-brain-diff-' + randomUUID());
+  mkdirSync(workDir, { recursive: true });
+});
+
+afterEach(() => {
+  if (existsSync(workDir)) rmSync(workDir, { recursive: true, force: true });
+});
+
+// ----------------------------------------------------------------------------
+// Tests
+// ----------------------------------------------------------------------------
+
+describe('brain diff — JSONL↔JSONL', () => {
+  it('reports identical when two exports share the same data', () => {
+    const db = createTestDb();
+    insertPattern(db, { id: 'p1' });
+    insertPattern(db, { id: 'p2' });
+
+    const a = join(workDir, 'a');
+    const b = join(workDir, 'b');
+    exportBrain(db, { outputPath: a });
+    exportBrain(db, { outputPath: b });
+    db.close();
+
+    const result = diffBrains(a, b);
+
+    expect(result.identical).toBe(true);
+    expect(result.checksumMatch).toBe(true);
+    expect(result.versionMatch).toBe(true);
+    expect(result.recordLevel).toBe(true);
+    expect(summarizeDiff(result).tablesChanged).toBe(0);
+  });
+
+  it('detects added, removed, and changed records on a PK table', () => {
+    const dbA = createTestDb();
+    insertPattern(dbA, { id: 'kept', description: 'original' });
+    insertPattern(dbA, { id: 'removed' });
+    const a = join(workDir, 'a');
+    exportBrain(dbA, { outputPath: a });
+    dbA.close();
+
+    const dbB = createTestDb();
+    insertPattern(dbB, { id: 'kept', description: 'changed' }); // changed
+    insertPattern(dbB, { id: 'added' });                         // added
+    // 'removed' intentionally absent
+    const b = join(workDir, 'b');
+    exportBrain(dbB, { outputPath: b });
+    dbB.close();
+
+    const result = diffBrains(a, b);
+
+    expect(result.identical).toBe(false);
+    expect(result.checksumMatch).toBe(false);
+    expect(result.recordLevel).toBe(true);
+
+    const patternDiff = result.tableDiffs.find((t) => t.tableName === 'qe_patterns');
+    expect(patternDiff).toBeDefined();
+    expect(patternDiff?.countA).toBe(2);
+    expect(patternDiff?.countB).toBe(2);
+    expect(patternDiff?.added).toEqual(['added']);
+    expect(patternDiff?.removed).toEqual(['removed']);
+    expect(patternDiff?.changed).toEqual(['kept']);
+
+    const summary = summarizeDiff(result);
+    expect(summary.totalAdded).toBe(1);
+    expect(summary.totalRemoved).toBe(1);
+    expect(summary.totalChanged).toBe(1);
+    expect(summary.recordCountDelta).toBe(0);
+  });
+
+  it('does not flag append-only rows as "changed" — only added/removed', () => {
+    const dbA = createTestDb();
+    insertWitness(dbA, {
+      prev_hash: 'h0',
+      action_hash: 'h1',
+      action_type: 'test',
+      timestamp: '2026-03-01T00:00:00Z',
+      actor: 'agent-1',
+    });
+    const a = join(workDir, 'a');
+    exportBrain(dbA, { outputPath: a });
+    dbA.close();
+
+    const dbB = createTestDb();
+    // Same identity (action_hash + timestamp) but different actor — should be
+    // treated as "same row" for witness_chain because dedup columns are the
+    // identity.
+    insertWitness(dbB, {
+      prev_hash: 'h0',
+      action_hash: 'h1',
+      action_type: 'test',
+      timestamp: '2026-03-01T00:00:00Z',
+      actor: 'agent-2',
+    });
+    // And a truly new row
+    insertWitness(dbB, {
+      prev_hash: 'h1',
+      action_hash: 'h2',
+      action_type: 'test',
+      timestamp: '2026-03-02T00:00:00Z',
+      actor: 'agent-1',
+    });
+    const b = join(workDir, 'b');
+    exportBrain(dbB, { outputPath: b });
+    dbB.close();
+
+    const result = diffBrains(a, b);
+
+    const witnessDiff = result.tableDiffs.find((t) => t.tableName === 'witness_chain');
+    expect(witnessDiff?.added?.length).toBe(1);
+    expect(witnessDiff?.removed?.length ?? 0).toBe(0);
+    expect(witnessDiff?.changed?.length ?? 0).toBe(0);
+  });
+
+  it('reports domains only present in one side', () => {
+    const dbA = createTestDb();
+    insertPattern(dbA, { id: 'p1', qe_domain: 'test-generation' });
+    const a = join(workDir, 'a');
+    exportBrain(dbA, { outputPath: a });
+    dbA.close();
+
+    const dbB = createTestDb();
+    insertPattern(dbB, { id: 'p2', qe_domain: 'security-compliance' });
+    const b = join(workDir, 'b');
+    exportBrain(dbB, { outputPath: b });
+    dbB.close();
+
+    const result = diffBrains(a, b);
+
+    expect(result.domainsOnlyInA).toContain('test-generation');
+    expect(result.domainsOnlyInB).toContain('security-compliance');
+  });
+
+  it('honours the tableFilter option', () => {
+    const dbA = createTestDb();
+    insertPattern(dbA, { id: 'p1' });
+    const a = join(workDir, 'a');
+    exportBrain(dbA, { outputPath: a });
+    dbA.close();
+
+    const dbB = createTestDb();
+    insertPattern(dbB, { id: 'p1' });
+    insertPattern(dbB, { id: 'p2' });
+    const b = join(workDir, 'b');
+    exportBrain(dbB, { outputPath: b });
+    dbB.close();
+
+    const result = diffBrains(a, b, { tableFilter: 'qe_patterns' });
+
+    expect(result.tableDiffs).toHaveLength(1);
+    expect(result.tableDiffs[0]!.tableName).toBe('qe_patterns');
+    expect(result.tableDiffs[0]!.added).toEqual(['p2']);
+  });
+
+  it('throws on an unknown tableFilter', () => {
+    const dbA = createTestDb();
+    const a = join(workDir, 'a');
+    const b = join(workDir, 'b');
+    exportBrain(dbA, { outputPath: a });
+    exportBrain(dbA, { outputPath: b });
+    dbA.close();
+
+    expect(() => diffBrains(a, b, { tableFilter: 'does_not_exist' })).toThrow(
+      /Unknown table/,
+    );
+  });
+});
+
+describe('brain diff — error paths', () => {
+  it('throws when a path does not exist', () => {
+    expect(() => diffBrains('/no/such/path', '/also/not')).toThrow(/not found/);
+  });
+
+  it('caps per-bucket IDs via maxIdsPerBucket', () => {
+    const dbA = createTestDb();
+    for (let i = 0; i < 20; i++) insertPattern(dbA, { id: 'a' + i });
+    const a = join(workDir, 'a');
+    exportBrain(dbA, { outputPath: a });
+    dbA.close();
+
+    const dbB = createTestDb();
+    for (let i = 0; i < 20; i++) insertPattern(dbB, { id: 'b' + i });
+    const b = join(workDir, 'b');
+    exportBrain(dbB, { outputPath: b });
+    dbB.close();
+
+    const result = diffBrains(a, b, { maxIdsPerBucket: 5 });
+    const patternDiff = result.tableDiffs.find((t) => t.tableName === 'qe_patterns')!;
+    expect(patternDiff.added!.length).toBe(5);
+    expect(patternDiff.removed!.length).toBe(5);
+  });
+});

--- a/tests/unit/brain-search.test.ts
+++ b/tests/unit/brain-search.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Tests for the brain-search module (issue #332, C-09).
+ *
+ * Offline, filtered search over a JSONL brain export directory.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { randomUUID } from 'crypto';
+
+import { exportBrain } from '../../src/integrations/ruvector/brain-exporter.js';
+import { searchBrain } from '../../src/integrations/ruvector/brain-search.js';
+import { ensureTargetTables } from '../../src/integrations/ruvector/brain-shared.js';
+
+// ----------------------------------------------------------------------------
+// Fixtures
+// ----------------------------------------------------------------------------
+
+function createTestDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.pragma('journal_mode = WAL');
+  ensureTargetTables(db);
+  return db;
+}
+
+function insertPattern(db: Database.Database, p: {
+  id: string;
+  pattern_type?: string;
+  qe_domain?: string;
+  name?: string;
+  description?: string;
+  confidence?: number;
+  updated_at?: string;
+}): void {
+  db.prepare(`
+    INSERT INTO qe_patterns (id, pattern_type, qe_domain, domain, name, description, confidence, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    p.id,
+    p.pattern_type ?? 'test-template',
+    p.qe_domain ?? 'test-generation',
+    p.qe_domain ?? 'test-generation',
+    p.name ?? 'name-' + p.id,
+    p.description ?? 'desc-' + p.id,
+    p.confidence ?? 0.5,
+    p.updated_at ?? '2026-02-20T10:00:00Z',
+  );
+}
+
+let workDir: string;
+let exportPath: string;
+
+beforeEach(() => {
+  workDir = join(tmpdir(), 'aqe-brain-search-' + randomUUID());
+  mkdirSync(workDir, { recursive: true });
+  exportPath = join(workDir, 'export');
+});
+
+afterEach(() => {
+  if (existsSync(workDir)) rmSync(workDir, { recursive: true, force: true });
+});
+
+function buildExport(build: (db: Database.Database) => void): string {
+  const db = createTestDb();
+  build(db);
+  exportBrain(db, { outputPath: exportPath });
+  db.close();
+  return exportPath;
+}
+
+// ----------------------------------------------------------------------------
+// Tests
+// ----------------------------------------------------------------------------
+
+describe('brain search — filters', () => {
+  it('returns all qe_patterns when no filters are provided', () => {
+    buildExport((db) => {
+      insertPattern(db, { id: 'p1' });
+      insertPattern(db, { id: 'p2' });
+      insertPattern(db, { id: 'p3' });
+    });
+
+    const result = searchBrain(exportPath);
+
+    expect(result.totalScanned).toBe(3);
+    expect(result.totalMatched).toBe(3);
+    expect(result.hits.map((h) => h.id).sort()).toEqual(['p1', 'p2', 'p3']);
+  });
+
+  it('filters by a single domain', () => {
+    buildExport((db) => {
+      insertPattern(db, { id: 'p1', qe_domain: 'test-generation' });
+      insertPattern(db, { id: 'p2', qe_domain: 'security-compliance' });
+      insertPattern(db, { id: 'p3', qe_domain: 'coverage-analysis' });
+    });
+
+    const result = searchBrain(exportPath, { domains: ['test-generation'] });
+
+    expect(result.totalMatched).toBe(1);
+    expect(result.hits[0]?.id).toBe('p1');
+  });
+
+  it('filters by multiple domains', () => {
+    buildExport((db) => {
+      insertPattern(db, { id: 'p1', qe_domain: 'test-generation' });
+      insertPattern(db, { id: 'p2', qe_domain: 'security-compliance' });
+      insertPattern(db, { id: 'p3', qe_domain: 'coverage-analysis' });
+    });
+
+    const result = searchBrain(exportPath, {
+      domains: ['test-generation', 'coverage-analysis'],
+    });
+
+    expect(result.totalMatched).toBe(2);
+    expect(result.hits.map((h) => h.id).sort()).toEqual(['p1', 'p3']);
+  });
+
+  it('filters by pattern_type', () => {
+    buildExport((db) => {
+      insertPattern(db, { id: 'p1', pattern_type: 'unit-test' });
+      insertPattern(db, { id: 'p2', pattern_type: 'integration-test' });
+      insertPattern(db, { id: 'p3', pattern_type: 'unit-test' });
+    });
+
+    const result = searchBrain(exportPath, { patternType: 'unit-test' });
+
+    expect(result.totalMatched).toBe(2);
+    expect(result.hits.map((h) => h.id).sort()).toEqual(['p1', 'p3']);
+  });
+
+  it('filters by date range (since + until)', () => {
+    buildExport((db) => {
+      insertPattern(db, { id: 'old', updated_at: '2026-01-01T00:00:00Z' });
+      insertPattern(db, { id: 'mid', updated_at: '2026-02-15T00:00:00Z' });
+      insertPattern(db, { id: 'new', updated_at: '2026-04-01T00:00:00Z' });
+    });
+
+    const result = searchBrain(exportPath, {
+      since: '2026-02-01T00:00:00Z',
+      until: '2026-03-01T00:00:00Z',
+    });
+
+    expect(result.totalMatched).toBe(1);
+    expect(result.hits[0]?.id).toBe('mid');
+  });
+
+  it('matches query against name (case-insensitive)', () => {
+    buildExport((db) => {
+      insertPattern(db, { id: 'p1', name: 'OAuth2 flow' });
+      insertPattern(db, { id: 'p2', name: 'JWT validation' });
+      insertPattern(db, { id: 'p3', name: 'oauth helper' });
+    });
+
+    const result = searchBrain(exportPath, { query: 'OAUTH' });
+
+    expect(result.totalMatched).toBe(2);
+    expect(result.hits.map((h) => h.id).sort()).toEqual(['p1', 'p3']);
+  });
+
+  it('matches query against description', () => {
+    buildExport((db) => {
+      insertPattern(db, { id: 'p1', name: 'alpha', description: 'Checks CSRF tokens' });
+      insertPattern(db, { id: 'p2', name: 'beta', description: 'Nothing special' });
+    });
+
+    const result = searchBrain(exportPath, { query: 'csrf' });
+
+    expect(result.totalMatched).toBe(1);
+    expect(result.hits[0]?.id).toBe('p1');
+  });
+
+  it('combines filters (AND semantics)', () => {
+    buildExport((db) => {
+      insertPattern(db, {
+        id: 'p1',
+        qe_domain: 'security-compliance',
+        pattern_type: 'unit-test',
+        name: 'OAuth2 check',
+      });
+      insertPattern(db, {
+        id: 'p2',
+        qe_domain: 'security-compliance',
+        pattern_type: 'integration-test',
+        name: 'OAuth2 flow',
+      });
+      insertPattern(db, {
+        id: 'p3',
+        qe_domain: 'test-generation',
+        pattern_type: 'unit-test',
+        name: 'OAuth2 helper',
+      });
+    });
+
+    const result = searchBrain(exportPath, {
+      domains: ['security-compliance'],
+      patternType: 'unit-test',
+      query: 'oauth',
+    });
+
+    expect(result.totalMatched).toBe(1);
+    expect(result.hits[0]?.id).toBe('p1');
+  });
+
+  it('applies the limit but reports the true total match count', () => {
+    buildExport((db) => {
+      for (let i = 0; i < 10; i++) insertPattern(db, { id: 'p' + i });
+    });
+
+    const result = searchBrain(exportPath, { limit: 3 });
+
+    expect(result.totalMatched).toBe(10);
+    expect(result.hits.length).toBe(3);
+    expect(result.truncated).toBe(true);
+  });
+
+  it('populates display fields for CLI rendering', () => {
+    buildExport((db) => {
+      insertPattern(db, {
+        id: 'p1',
+        name: 'n',
+        description: 'd',
+        confidence: 0.77,
+        pattern_type: 'unit-test',
+        qe_domain: 'test-generation',
+        updated_at: '2026-02-20T10:00:00Z',
+      });
+    });
+
+    const result = searchBrain(exportPath);
+
+    const hit = result.hits[0];
+    expect(hit).toBeDefined();
+    expect(hit!.display.name).toBe('n');
+    expect(hit!.display.description).toBe('d');
+    expect(hit!.display.confidence).toBeCloseTo(0.77);
+    expect(hit!.display.patternType).toBe('unit-test');
+    expect(hit!.display.domain).toBe('test-generation');
+    expect(hit!.display.updatedAt).toBe('2026-02-20T10:00:00Z');
+  });
+
+  it('supports searching a non-default table', () => {
+    buildExport((db) => {
+      db.prepare(`
+        INSERT INTO rl_q_values (id, algorithm, agent_id, state_key, action_key, q_value, visits, domain, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run('qv1', 'sarsa', 'agent-1', 's', 'a', 0.5, 10, 'test-generation', '2026-02-20T00:00:00Z');
+    });
+
+    const result = searchBrain(exportPath, { table: 'rl_q_values' });
+
+    expect(result.table).toBe('rl_q_values');
+    expect(result.totalMatched).toBe(1);
+    expect(result.hits[0]?.id).toBe('qv1');
+  });
+});
+
+describe('brain search — error paths', () => {
+  it('throws when the path does not exist', () => {
+    expect(() => searchBrain('/no/such/path')).toThrow(/Path not found/);
+  });
+
+  it('throws when pointed at a .rvf file', () => {
+    const rvfPath = join(workDir, 'brain.rvf');
+    writeFileSync(rvfPath, 'pretend-rvf');
+    expect(() => searchBrain(rvfPath)).toThrow(/does not support RVF/);
+  });
+
+  it('throws for an unknown table', () => {
+    buildExport((db) => {
+      insertPattern(db, { id: 'p1' });
+    });
+
+    expect(() => searchBrain(exportPath, { table: 'nope' })).toThrow(/Unknown table/);
+  });
+
+  it('throws when the directory has no manifest', () => {
+    const fakeDir = join(workDir, 'not-a-brain');
+    mkdirSync(fakeDir, { recursive: true });
+
+    expect(() => searchBrain(fakeDir)).toThrow(/Manifest not found/);
+  });
+});

--- a/tests/unit/cli-upgrade.test.ts
+++ b/tests/unit/cli-upgrade.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Unit tests for `aqe upgrade` — pure logic.
+ *
+ * The goal is to drive detection / recommendation rules via injected probes
+ * and env maps so they can be exhaustively exercised without touching real
+ * native deps.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  buildRecommendations,
+  buildReport,
+  detectNatives,
+  exitCodeFor,
+  readEnvOverrides,
+  NATIVE_CATALOG,
+  type LoadProbe,
+  type NativeCheck,
+  type UpgradeReport,
+} from '../../src/cli/commands/upgrade.js';
+
+// ----------------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------------
+
+function probeWith(loaded: readonly string[], missing: readonly string[] = []): LoadProbe {
+  const allMissing = new Set(missing);
+  const allLoaded = new Set(loaded);
+  return (name) => {
+    if (allLoaded.has(name)) return { ok: true };
+    if (allMissing.has(name)) {
+      const err = new Error(`Cannot find module '${name}'`) as NodeJS.ErrnoException;
+      err.code = 'MODULE_NOT_FOUND';
+      return { ok: false, error: err };
+    }
+    // Default for unlisted packages: treat as missing so we don't accidentally
+    // depend on the local machine.
+    const err = new Error(`Cannot find module '${name}'`) as NodeJS.ErrnoException;
+    err.code = 'MODULE_NOT_FOUND';
+    return { ok: false, error: err };
+  };
+}
+
+const ALL_PACKAGES = NATIVE_CATALOG.map((c) => c.packageName);
+const REQUIRED_PACKAGES = NATIVE_CATALOG.filter((c) => c.required).map((c) => c.packageName);
+
+const HAPPY_FLAGS: UpgradeReport['flags'] = {
+  useRVFPatternStore: true,
+  useSublinearSolver: true,
+  useNativeHNSW: true,
+  useGraphMAEEmbeddings: true,
+  useQEFlashAttention: true,
+};
+
+// ----------------------------------------------------------------------------
+// detectNatives
+// ----------------------------------------------------------------------------
+
+describe('detectNatives', () => {
+  it('marks packages that load as "loaded"', () => {
+    const results = detectNatives(NATIVE_CATALOG, probeWith(ALL_PACKAGES));
+    expect(results.every((r) => r.status === 'loaded')).toBe(true);
+  });
+
+  it('marks required packages as "required-missing" when absent', () => {
+    const results = detectNatives(NATIVE_CATALOG, probeWith([]));
+    for (const r of results) {
+      if (r.required) expect(r.status).toBe('required-missing');
+      else expect(r.status).toBe('missing');
+    }
+  });
+
+  it('captures the load error message verbatim', () => {
+    const results = detectNatives(NATIVE_CATALOG, probeWith([]));
+    for (const r of results) {
+      expect(r.loadError).toMatch(/Cannot find module/);
+    }
+  });
+});
+
+// ----------------------------------------------------------------------------
+// readEnvOverrides
+// ----------------------------------------------------------------------------
+
+describe('readEnvOverrides', () => {
+  it('returns an empty list when no RUVECTOR_* env vars are set', () => {
+    expect(readEnvOverrides({})).toEqual([]);
+  });
+
+  it('picks up known RUVECTOR_* overrides and maps them to flag names', () => {
+    const overrides = readEnvOverrides({
+      RUVECTOR_USE_RVF_PATTERN_STORE: 'true',
+      RUVECTOR_USE_SUBLINEAR_SOLVER: 'false',
+      UNRELATED_VAR: 'hello',
+    });
+    const envVars = overrides.map((o) => o.envVar).sort();
+    expect(envVars).toEqual([
+      'RUVECTOR_USE_RVF_PATTERN_STORE',
+      'RUVECTOR_USE_SUBLINEAR_SOLVER',
+    ]);
+    const rvf = overrides.find((o) => o.envVar === 'RUVECTOR_USE_RVF_PATTERN_STORE');
+    expect(rvf?.flagName).toBe('useRVFPatternStore');
+    expect(rvf?.value).toBe('true');
+  });
+});
+
+// ----------------------------------------------------------------------------
+// buildRecommendations
+// ----------------------------------------------------------------------------
+
+describe('buildRecommendations', () => {
+  it('emits a positive info line when nothing is missing', () => {
+    const natives = detectNatives(NATIVE_CATALOG, probeWith(ALL_PACKAGES));
+    const recs = buildRecommendations({ natives, flags: HAPPY_FLAGS, envOverrides: [] });
+    expect(recs.some((r) => r.severity === 'info' && /no action/i.test(r.message))).toBe(true);
+    expect(recs.every((r) => r.severity !== 'error')).toBe(true);
+  });
+
+  it('reports error severity for missing required deps with an install action', () => {
+    // Load only optionals, miss the required ones.
+    const optionals = NATIVE_CATALOG.filter((c) => !c.required).map((c) => c.packageName);
+    const natives = detectNatives(NATIVE_CATALOG, probeWith(optionals));
+    const recs = buildRecommendations({ natives, flags: HAPPY_FLAGS, envOverrides: [] });
+
+    for (const required of REQUIRED_PACKAGES) {
+      const match = recs.find(
+        (r) => r.severity === 'error' && r.message.includes(required),
+      );
+      expect(match).toBeDefined();
+      expect(match?.action).toBe(`npm install ${required}`);
+    }
+  });
+
+  it('emits warn severity per missing optional with install action', () => {
+    // Load only required, miss all optionals.
+    const natives = detectNatives(NATIVE_CATALOG, probeWith(REQUIRED_PACKAGES));
+    const recs = buildRecommendations({ natives, flags: HAPPY_FLAGS, envOverrides: [] });
+
+    const optionalCatalog = NATIVE_CATALOG.filter((c: NativeCheck) => !c.required);
+    for (const opt of optionalCatalog) {
+      const match = recs.find(
+        (r) => r.severity === 'warn' && r.message.includes(opt.packageName),
+      );
+      expect(match, `missing warning for ${opt.packageName}`).toBeDefined();
+      expect(match?.action).toBe(`npm install ${opt.packageName}`);
+    }
+  });
+
+  it('warns when RUVECTOR_* forces a flag on but the native is missing', () => {
+    const natives = detectNatives(NATIVE_CATALOG, probeWith(REQUIRED_PACKAGES));
+    const recs = buildRecommendations({
+      natives,
+      flags: HAPPY_FLAGS,
+      envOverrides: [
+        { envVar: 'RUVECTOR_USE_RVF_PATTERN_STORE', value: 'true', flagName: 'useRVFPatternStore' },
+      ],
+    });
+
+    const conflict = recs.find(
+      (r) =>
+        r.severity === 'warn' &&
+        r.message.includes('RUVECTOR_USE_RVF_PATTERN_STORE') &&
+        r.message.includes('silently fall back'),
+    );
+    expect(conflict).toBeDefined();
+  });
+
+  it('does not emit a conflict warning when the flag override value is "false"', () => {
+    const natives = detectNatives(NATIVE_CATALOG, probeWith(REQUIRED_PACKAGES));
+    const recs = buildRecommendations({
+      natives,
+      flags: HAPPY_FLAGS,
+      envOverrides: [
+        { envVar: 'RUVECTOR_USE_RVF_PATTERN_STORE', value: 'false', flagName: 'useRVFPatternStore' },
+      ],
+    });
+    const conflict = recs.find((r) => r.message.includes('silently fall back'));
+    expect(conflict).toBeUndefined();
+  });
+});
+
+// ----------------------------------------------------------------------------
+// buildReport + exitCodeFor
+// ----------------------------------------------------------------------------
+
+describe('buildReport', () => {
+  it('summarises required vs optional counts', () => {
+    const report = buildReport({
+      aqeVersion: '9.9.9',
+      probe: probeWith(REQUIRED_PACKAGES),
+      env: {},
+      flags: HAPPY_FLAGS,
+    });
+    const optionalCount = NATIVE_CATALOG.filter((c) => !c.required).length;
+    expect(report.summary.requiredOk).toBe(true);
+    expect(report.summary.optionalLoadedCount).toBe(0);
+    expect(report.summary.optionalMissingCount).toBe(optionalCount);
+  });
+
+  it('reports requiredOk=false when a required dep fails to load', () => {
+    // Only load optionals.
+    const optionals = NATIVE_CATALOG.filter((c) => !c.required).map((c) => c.packageName);
+    const report = buildReport({
+      aqeVersion: '9.9.9',
+      probe: probeWith(optionals),
+      env: {},
+      flags: HAPPY_FLAGS,
+    });
+    expect(report.summary.requiredOk).toBe(false);
+  });
+
+  it('carries aqeVersion, platform + node through to the report', () => {
+    const report = buildReport({
+      aqeVersion: '9.9.9',
+      probe: probeWith(ALL_PACKAGES),
+      env: {},
+      flags: HAPPY_FLAGS,
+    });
+    expect(report.aqeVersion).toBe('9.9.9');
+    expect(report.platform.os).toBeTruthy();
+    expect(report.platform.arch).toBeTruthy();
+    expect(report.platform.node).toMatch(/^v/);
+  });
+});
+
+describe('exitCodeFor', () => {
+  const reportOk = (): UpgradeReport => buildReport({
+    aqeVersion: 'x',
+    probe: probeWith(ALL_PACKAGES),
+    env: {},
+    flags: HAPPY_FLAGS,
+  });
+
+  const reportOptionalMissing = (): UpgradeReport => buildReport({
+    aqeVersion: 'x',
+    probe: probeWith(REQUIRED_PACKAGES),
+    env: {},
+    flags: HAPPY_FLAGS,
+  });
+
+  const reportRequiredMissing = (): UpgradeReport => buildReport({
+    aqeVersion: 'x',
+    probe: probeWith([]),
+    env: {},
+    flags: HAPPY_FLAGS,
+  });
+
+  it('returns 0 when everything is loaded (strict or not)', () => {
+    expect(exitCodeFor(reportOk(), false)).toBe(0);
+    expect(exitCodeFor(reportOk(), true)).toBe(0);
+  });
+
+  it('returns 0 when optionals missing and strict=false', () => {
+    expect(exitCodeFor(reportOptionalMissing(), false)).toBe(0);
+  });
+
+  it('returns 1 when optionals missing and strict=true', () => {
+    expect(exitCodeFor(reportOptionalMissing(), true)).toBe(1);
+  });
+
+  it('returns 2 when required is missing (regardless of strict)', () => {
+    expect(exitCodeFor(reportRequiredMissing(), false)).toBe(2);
+    expect(exitCodeFor(reportRequiredMissing(), true)).toBe(2);
+  });
+});

--- a/tests/unit/cli/completions.test.ts
+++ b/tests/unit/cli/completions.test.ts
@@ -108,6 +108,23 @@ describe('Shell Completions', () => {
       expect(COMMANDS.agent).toBeDefined();
       expect(COMMANDS.completions).toBeDefined();
     });
+
+    it('should include brain + upgrade in COMMANDS (recent additions)', () => {
+      expect(COMMANDS.brain).toBeDefined();
+      expect(COMMANDS.brain.subcommands).toHaveProperty('diff');
+      expect(COMMANDS.brain.subcommands).toHaveProperty('search');
+      expect(COMMANDS.upgrade).toBeDefined();
+      expect(COMMANDS.upgrade.options).toContain('--json');
+      expect(COMMANDS.upgrade.options).toContain('--strict');
+    });
+
+    it('should list brain + upgrade in every shell generator output', () => {
+      for (const gen of [generateBashCompletion, generateZshCompletion, generateFishCompletion, generatePowerShellCompletion]) {
+        const out = gen();
+        expect(out).toContain('brain');
+        expect(out).toContain('upgrade');
+      }
+    });
   });
 
   describe('Bash Completion Generator', () => {


### PR DESCRIPTION
## Summary

Three new CLI commands that make the QE brain snapshot easier to inspect and make optional native deps visible:

- `aqe brain diff <a> <b>` — manifest-level and record-level diff across JSONL / RVF exports
- `aqe brain search -i <export>` — offline filtered search over a JSONL brain export
- `aqe upgrade` — read-only advisor for optional native bindings (`@ruvector/rvf-node`, `@ruvector/solver-node`, etc.)

Plus shell-completion wiring for both new commands (bash/zsh/fish/PowerShell), closes issues #332 + #355 (consolidated into #383 / #432), and marks #383 item 2 delivered.

## Verification

Real command output from the local release gate:

**Build**: `CLI bundle built successfully (v3.9.16)` + `MCP bundle built successfully (v3.9.16)`
**Typecheck**: `tsc --noEmit` → zero errors
**Unit suite**: `520 test files | 16,532 tests passed | 9 skipped | 0 failed` (~6.5 min)
**Performance gate**: `Total: 15 | Passed: 15 | Failed: 0 | Warnings: 0`
**Fresh-install check**: `aqe init --auto` in `/tmp/aqe-release-test` → `AQE v3 initialized successfully! Patterns: 0, Skills: 85, Agents: 60, Total time: 229ms`. `aqe --version` → `3.9.16`. `aqe status`, `aqe upgrade` run clean.
**Isolated install check**: `npm pack` → clean temp dir → `npm install ./agentic-qe-3.9.16.tgz` → `node node_modules/.bin/aqe --version` → `3.9.16`, exit 0.

**New-feature end-to-end smoke** (from an unrelated project after `npm install` of the tarball):
- `aqe brain diff a b --verbose` correctly identifies `+p-csrf` (added) and `~p-oauth` (changed), leaves identical `p-aaa` silent.
- `aqe brain search -i b --query oauth` finds 1 match with correct rendering.
- `aqe brain search --domain security-compliance --since 2026-04-01 --json` returns the correct 2-hit filtered set.
- `aqe upgrade --json` emits the declared shape; `--strict` exits 1 when optionals are missing.

**New unit + integration tests**: 45 added (brain-diff 8, brain-search 15, cli-upgrade 17 unit + 5 integration). All pass.

## Failure modes

- **Pre-existing `tests/integration/llm/multi-provider.test.ts` failures** (2 of 28 tests: `bidirectional mapping for Claude models`, `canonical name for display`). Verified to reproduce identically on `working-april` baseline without any of this branch's changes — not caused by this PR. Tracked separately; out of scope for this release.
- **RVF-only brain exports** don't get record-level diff (only manifest-level). Documented in the `--help` output and in the CLI hint when the user runs `brain diff` on two `.rvf` files. A JSONL re-export produces the full record-level view.
- **`aqe upgrade` is advisory only** — it doesn't mutate feature flags or env vars. Users must still `export RUVECTOR_*` themselves. This is intentional (per #383 item 2 scope), not a gap.
- **Shell completions coverage** — this PR adds `brain` and `upgrade` to the four generated scripts, but many other top-level commands (`workflow`, `daemon`, `fleet`, `memory`, `pipeline`, `skill`, `eval`, etc.) are still missing from the completion map — that's pre-existing drift, not a regression. Tracked for a future scoped cleanup.

---

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.** "Unlikely" is not an acceptable substitute. If you wrote "I don't think this can happen but...", that sentence is a failure mode and needs a test or an issue link.

### Optional context

- Linked issues: #332 (closed), #355 (closed, consolidated), #432 (new backlog), #383 item 2 (delivered)
- Trust tier change (if any): none
- Affects published API or CLI surface: yes — three new commands (`aqe brain diff`, `aqe brain search`, `aqe upgrade`); no breaking changes
- Touches the init flow / `npm-publish.yml` / `tests/fixtures/init-corpus/`: no
  - If yes: did you run `./tests/fixtures/init-corpus/run-gate.sh` locally? not applicable

See [CHANGELOG](CHANGELOG.md) for details.