### PR TITLE
fix(hooks): UserPromptSubmit reads stdin event JSON for routing (v3.9.17)

### DIFF
--- a/.claude/skills/skills-manifest.json
+++ b/.claude/skills/skills-manifest.json
@@ -939,7 +939,7 @@
   },
   "metadata": {
     "generatedBy": "Agentic QE Fleet",
-    "fleetVersion": "3.9.16",
+    "fleetVersion": "3.9.17",
     "manifestVersion": "1.4.0",
     "lastUpdated": "2026-04-13T00:00:00.000Z",
     "contributors": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Agentic QE project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.17] - 2026-04-27
+
+**One-line fix that closes the routing learning loop.** The shipped `aqe init` template wired the UserPromptSubmit hook to `--task "$PROMPT"`, but Claude Code never exposed `$PROMPT` as an env var — every prompt routed as empty. The CLI now reads stdin event JSON, the templates drop the broken arg, and existing projects upgrade automatically on re-init.
+
+### Fixed
+
+- **`aqe init` UserPromptSubmit hook silently routed every prompt as empty** — the generated `.claude/settings.json` template invoked `npx agentic-qe hooks route --task "$PROMPT" --json`, but Claude Code (≥2.1) does **not** export `$PROMPT` as an env var for `UserPromptSubmit` hooks; the prompt body only arrives via stdin event JSON. The shell expanded `"$PROMPT"` to `""`, so `aqe hooks route` always saw an empty task, the reasoningBank returned the same default agent on every prompt, and `routing_outcomes.task_json` was persisted as `{"description":""}` for every entry — closing the routing learning loop. Fix: `aqe hooks route` now reads stdin JSON events as a fallback and extracts `event.prompt` / `event.user_prompt` / `event.command` / `event.tool_input.{prompt,description}`; the templates in `src/init/phases/07-hooks.ts` and `src/init/init-wizard-hooks.ts` drop the broken `--task "$PROMPT"` argument so stdin delivery works. Re-running `aqe init` on existing projects detects the broken old hook (smart-merge `isAqeHookEntry`) and replaces it with the fixed one. Manual `--task <description>` usage is preserved for backward compatibility.
+
+### Upgrade Notes
+
+- Existing projects: re-run `npx agentic-qe init --upgrade`. Verify with `jq '.hooks.UserPromptSubmit' .claude/settings.json` — the hook should read `npx agentic-qe hooks route --json` (no `--task "$PROMPT"`). After a few prompts, confirm `sqlite3 .agentic-qe/memory.db "SELECT task_json FROM routing_outcomes ORDER BY rowid DESC LIMIT 5"` shows real prompt content instead of `{"description":""}`.
+
 ## [3.9.16] - 2026-04-24
 
 **Brain-export tooling + native-binding advisor.** Three new CLI commands that make the QE brain snapshot easier to inspect and make optional native deps visible. Closes the last actionable items on issue #332 (brain export improvements) and item 2 of issue #383 (upgrade advisor).

--- a/assets/skills/skills-manifest.json
+++ b/assets/skills/skills-manifest.json
@@ -939,7 +939,7 @@
   },
   "metadata": {
     "generatedBy": "Agentic QE Fleet",
-    "fleetVersion": "3.9.16",
+    "fleetVersion": "3.9.17",
     "manifestVersion": "1.4.0",
     "lastUpdated": "2026-04-13T00:00:00.000Z",
     "contributors": [

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -4,6 +4,7 @@ All Agentic QE release notes organized by version.
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| [v3.9.17](v3.9.17.md) | 2026-04-27 | Fix: UserPromptSubmit hook now reads stdin event JSON — closes the routing learning loop for fresh `aqe init` |
 | [v3.9.16](v3.9.16.md) | 2026-04-24 | Brain-export tooling: `aqe brain diff`/`search`, native-binding advisor `aqe upgrade` |
 | [v3.9.15](v3.9.15.md) | 2026-04-22 | qe-browser Implemented (ADR-091): `aqe eval run` CLI, CI gate, Linux ARM64 browser hint |
 | [v3.9.14](v3.9.14.md) | 2026-04-20 | Security + supply-chain: 15 critical vulns fixed, tarball -52%, command injection patched |

--- a/docs/releases/v3.9.17.md
+++ b/docs/releases/v3.9.17.md
@@ -1,0 +1,21 @@
+# v3.9.17 Release Notes
+
+**Release Date:** 2026-04-27
+
+## Highlights
+
+One-line fix that closes the routing learning loop. The shipped `aqe init` template wired the UserPromptSubmit hook to `--task "$PROMPT"`, but Claude Code never exposed `$PROMPT` as an env var — every prompt routed as empty and `routing_outcomes.task_json` was persisted as `{"description":""}` for every entry. The CLI now reads stdin event JSON, the templates drop the broken arg, and existing projects upgrade automatically on re-init.
+
+## Fixed
+
+- **`aqe init` UserPromptSubmit hook silently routed every prompt as empty** — the generated `.claude/settings.json` template invoked `npx agentic-qe hooks route --task "$PROMPT" --json`, but Claude Code (≥2.1) does **not** export `$PROMPT` as an env var for `UserPromptSubmit` hooks; the prompt body only arrives via stdin event JSON. The shell expanded `"$PROMPT"` to `""`, so `aqe hooks route` always saw an empty task, the reasoningBank returned the same default agent on every prompt, and `routing_outcomes.task_json` was persisted as `{"description":""}` for every entry — closing the routing learning loop. Fix: `aqe hooks route` now reads stdin JSON events as a fallback and extracts `event.prompt` / `event.user_prompt` / `event.command` / `event.tool_input.{prompt,description}`; the templates in `src/init/phases/07-hooks.ts` and `src/init/init-wizard-hooks.ts` drop the broken `--task "$PROMPT"` argument so stdin delivery works. Re-running `aqe init` on existing projects detects the broken old hook (smart-merge `isAqeHookEntry`) and replaces it with the fixed one. Manual `--task <description>` usage is preserved for backward compatibility.
+
+## Upgrade Notes
+
+- Existing projects: re-run `npx agentic-qe init --upgrade`. Verify with `jq '.hooks.UserPromptSubmit' .claude/settings.json` — the hook should read `npx agentic-qe hooks route --json` (no `--task "$PROMPT"`).
+- After a few prompts, confirm `sqlite3 .agentic-qe/memory.db "SELECT task_json FROM routing_outcomes ORDER BY rowid DESC LIMIT 5"` shows real prompt content instead of `{"description":""}`.
+- No API or CLI surface changes: `aqe hooks route --task <description>` still works for direct invocations and scripts; stdin is now a fallback when `--task` is missing or empty.
+
+## Credit
+
+Diagnosis from an upstream user report (5-Whys self-applied to the AQE routing system). The proposed remedy (route through `.claude/helpers/hook-handler.cjs`) would have downgraded routing to a placeholder keyword router and stopped writing to `routing_outcomes`; this release fixes the issue at the right layer instead — the CLI itself.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentic-qe",
-  "version": "3.9.16",
+  "version": "3.9.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentic-qe",
-      "version": "3.9.16",
+      "version": "3.9.17",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-qe",
-  "version": "3.9.16",
+  "version": "3.9.17",
   "description": "Agentic Quality Engineering V3 - Domain-Driven Design Architecture with 13 Bounded Contexts, O(log n) coverage analysis, ReasoningBank learning, 60 specialized QE agents, mathematical Coherence verification, deep Claude Flow integration",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/cli/commands/hooks-handlers/routing-hooks.ts
+++ b/src/cli/commands/hooks-handlers/routing-hooks.ts
@@ -22,6 +22,69 @@ import {
 } from './hooks-shared.js';
 
 /**
+ * Read piped stdin with a short timeout. Claude Code delivers
+ * UserPromptSubmit / PostToolUse / etc. events as JSON on stdin —
+ * `$PROMPT` is NOT exposed as an env var, so reading stdin is the
+ * only reliable way to recover the prompt body for routing.
+ *
+ * Returns '' when stdin is a TTY (interactive run) or no data arrives
+ * before the timeout. Never throws — a hook must never crash the host.
+ */
+async function readStdinJsonEvent(timeoutMs = 500): Promise<string> {
+  if (process.stdin.isTTY) return '';
+  return new Promise<string>((resolve) => {
+    let data = '';
+    const timer = setTimeout(() => {
+      process.stdin.removeAllListeners();
+      process.stdin.pause();
+      resolve(data);
+    }, timeoutMs);
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => {
+      data += chunk;
+    });
+    process.stdin.on('end', () => {
+      clearTimeout(timer);
+      resolve(data);
+    });
+    process.stdin.on('error', () => {
+      clearTimeout(timer);
+      resolve(data);
+    });
+    process.stdin.resume();
+  });
+}
+
+/**
+ * Extract a routable task description from a Claude Code hook event JSON
+ * payload. Different hook surfaces use different field names — try the
+ * documented ones in priority order. Exported for unit testing.
+ */
+export function extractPromptFromEvent(raw: string): string {
+  if (!raw.trim()) return '';
+  let event: Record<string, unknown>;
+  try {
+    event = JSON.parse(raw);
+  } catch {
+    // Not JSON — treat the whole stdin as the prompt body
+    return raw.trim();
+  }
+  const candidates = [
+    event.prompt,
+    event.user_prompt,
+    event.command,
+    (event.tool_input as Record<string, unknown> | undefined)?.prompt,
+    (event.tool_input as Record<string, unknown> | undefined)?.description,
+    (event.toolInput as Record<string, unknown> | undefined)?.prompt,
+    (event.toolInput as Record<string, unknown> | undefined)?.description,
+  ];
+  for (const c of candidates) {
+    if (typeof c === 'string' && c.trim()) return c;
+  }
+  return '';
+}
+
+/**
  * Register route subcommand on the hooks command.
  */
 export function registerRoutingHooks(hooks: Command): void {
@@ -31,16 +94,30 @@ export function registerRoutingHooks(hooks: Command): void {
   hooks
     .command('route')
     .description('Route a task to the optimal QE agent')
-    .requiredOption('-t, --task <description>', 'Task description')
+    .option('-t, --task <description>', 'Task description (falls back to stdin event JSON)')
     .option('-d, --domain <domain>', 'Target QE domain hint')
     .option('-c, --capabilities <caps...>', 'Required capabilities')
     .option('--json', 'Output as JSON')
     .action(async (options) => {
       try {
+        // Resolve task: explicit --task wins, otherwise read the Claude Code
+        // hook event from stdin (UserPromptSubmit ships {prompt: "..."} on stdin
+        // and exposes nothing useful in env vars).
+        let task = (options.task as string | undefined) ?? '';
+        if (!task.trim()) {
+          const stdin = await readStdinJsonEvent();
+          task = extractPromptFromEvent(stdin);
+        }
+        if (!task.trim()) {
+          throw new Error(
+            'No task provided. Pass --task <description> or pipe a Claude Code hook event JSON to stdin.'
+          );
+        }
+
         const { reasoningBank } = await getHooksSystem();
 
         const request: QERoutingRequest = {
-          task: options.task,
+          task,
           domain: options.domain as QEDomain,
           capabilities: options.capabilities,
         };
@@ -65,7 +142,7 @@ export function registerRoutingHooks(hooks: Command): void {
           });
         } else {
           console.log(chalk.bold('\n🎯 Task Routing Result'));
-          console.log(chalk.dim(`  Task: "${options.task}"`));
+          console.log(chalk.dim(`  Task: "${task}"`));
 
           console.log(chalk.bold('\n👤 Recommended Agent:'), chalk.cyan(routing.recommendedAgent));
           console.log(chalk.dim(`  Confidence: ${(routing.confidence * 100).toFixed(1)}%`));
@@ -104,7 +181,7 @@ export function registerRoutingHooks(hooks: Command): void {
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
           `).run(
             outcomeId,
-            JSON.stringify({ description: options.task, domain: options.domain }),
+            JSON.stringify({ description: task, domain: options.domain }),
             JSON.stringify({
               recommended: routing.recommendedAgent,
               confidence: routing.confidence,

--- a/src/init/init-wizard-hooks.ts
+++ b/src/init/init-wizard-hooks.ts
@@ -143,8 +143,11 @@ export async function configureHooks(projectRoot: string, config: AQEInitConfig)
       {
         hooks: [
           {
+            // Claude Code delivers the prompt body on stdin as JSON
+            // (e.g. {"prompt":"..."}). $PROMPT is NOT exposed as an env
+            // var, so we let the CLI read stdin directly.
             type: 'command',
-            command: 'npx agentic-qe hooks route --task "$PROMPT" --json',
+            command: 'npx agentic-qe hooks route --json',
             timeout: 5000,
             continueOnError: true,
           },

--- a/src/init/phases/07-hooks.ts
+++ b/src/init/phases/07-hooks.ts
@@ -547,8 +547,11 @@ if (process.argv.includes('--json')) process.stdout.write(JSON.stringify(result)
         {
           hooks: [
             {
+              // Claude Code delivers the prompt body on stdin as JSON
+              // (e.g. {"prompt":"..."}). $PROMPT is NOT exposed as an env
+              // var, so we let the CLI read stdin directly.
               type: 'command',
-              command: 'npx agentic-qe hooks route --task "$PROMPT" --json',
+              command: 'npx agentic-qe hooks route --json',
               timeout: 5000,
               continueOnError: true,
             },

--- a/tests/unit/cli/commands/hooks-routing.test.ts
+++ b/tests/unit/cli/commands/hooks-routing.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Routing hook CLI - prompt extraction tests
+ *
+ * Regression coverage for the UserPromptSubmit stdin path. Claude Code
+ * delivers the prompt body on stdin as a JSON event ({prompt: "..."}),
+ * not as an env var. Before this fix, the init template passed
+ * --task "$PROMPT" which the shell expanded to "" — so every routing
+ * decision saw an empty task and routing_outcomes.task_json ended up
+ * {"description":""} on every entry, breaking the learning loop.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { extractPromptFromEvent } from '../../../../src/cli/commands/hooks-handlers/routing-hooks.js';
+
+describe('extractPromptFromEvent', () => {
+  it('returns empty string for empty input', () => {
+    expect(extractPromptFromEvent('')).toBe('');
+    expect(extractPromptFromEvent('   ')).toBe('');
+  });
+
+  it('extracts prompt from UserPromptSubmit event shape', () => {
+    const event = JSON.stringify({
+      hook_event_name: 'UserPromptSubmit',
+      session_id: 'abc',
+      prompt: 'generate tests for auth module',
+    });
+    expect(extractPromptFromEvent(event)).toBe('generate tests for auth module');
+  });
+
+  it('falls back to user_prompt field', () => {
+    const event = JSON.stringify({ user_prompt: 'find coverage gaps' });
+    expect(extractPromptFromEvent(event)).toBe('find coverage gaps');
+  });
+
+  it('extracts command from PreToolUse Bash events', () => {
+    const event = JSON.stringify({
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Bash',
+      command: 'npm test',
+    });
+    expect(extractPromptFromEvent(event)).toBe('npm test');
+  });
+
+  it('reads tool_input.prompt for Task tool events (snake_case)', () => {
+    const event = JSON.stringify({
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Task',
+      tool_input: { prompt: 'review PR for security issues' },
+    });
+    expect(extractPromptFromEvent(event)).toBe('review PR for security issues');
+  });
+
+  it('reads toolInput.description for Task tool events (camelCase)', () => {
+    const event = JSON.stringify({
+      toolInput: { description: 'run security scan' },
+    });
+    expect(extractPromptFromEvent(event)).toBe('run security scan');
+  });
+
+  it('treats non-JSON input as the prompt body verbatim', () => {
+    expect(extractPromptFromEvent('plain text prompt\n')).toBe('plain text prompt');
+  });
+
+  it('returns empty string when no recognized field is present', () => {
+    const event = JSON.stringify({ unrelated: 'data', count: 5 });
+    expect(extractPromptFromEvent(event)).toBe('');
+  });
+
+  it('ignores empty or whitespace-only prompt fields and tries the next candidate', () => {
+    const event = JSON.stringify({
+      prompt: '',
+      command: '   ',
+      user_prompt: 'real prompt',
+    });
+    expect(extractPromptFromEvent(event)).toBe('real prompt');
+  });
+
+  it('does not crash on malformed JSON — falls through to verbatim path', () => {
+    expect(extractPromptFromEvent('{not valid json')).toBe('{not valid json');
+  });
+});


### PR DESCRIPTION
## Summary

`aqe init` was wiring the Claude Code UserPromptSubmit hook to a command that **silently routed every prompt as empty**, breaking the routing learning loop for everyone on v3.9.x. This PR fixes the template, teaches the underlying CLI to read the prompt the way Claude Code actually delivers it, and bumps to v3.9.17.

Credit to the upstream report (`.test-tmp/UPSTREAM-aqe-issue-brief.md`) for the diagnosis. Their proposed remedy (route through `.claude/helpers/hook-handler.cjs`) would have downgraded routing to a placeholder keyword router and stopped writing to `routing_outcomes`; this PR fixes it at the right layer instead — the CLI itself.

## Why it matters

User-visible symptoms before the fix:

- Every prompt recommended the same default agent (`qe-test-architect` at ~27% confidence)
- `routing_outcomes.task_json` filled with `{"description":""}` rows
- Routing accuracy never improved no matter how many sessions, dreams, or patterns accumulated

Root cause: the template emitted `npx agentic-qe hooks route --task "$PROMPT" --json`, but Claude Code (≥2.1) does not expose `$PROMPT` as an env var for `UserPromptSubmit`. The prompt body only ships via stdin event JSON. The shell expanded `"$PROMPT"` to `""` and the CLI dutifully routed an empty string.

## How it's fixed

- **`aqe hooks route`** now reads stdin JSON events as a fallback when `--task` is missing/empty, and extracts the prompt from `event.prompt`, `event.user_prompt`, `event.command`, `event.tool_input.{prompt,description}`, or `event.toolInput.{prompt,description}`. Plain-text stdin is treated as the prompt verbatim. Empty input + no `--task` now errors helpfully instead of silently routing on `""`.
- **Templates** (`07-hooks.ts`, `init-wizard-hooks.ts`) drop the broken `--task "$PROMPT"` argument so stdin delivery works. The smart-merge `isAqeHookEntry` detector still matches both old and new shapes, so re-running `aqe init --upgrade` automatically replaces the broken hook with the fixed one.
- **Manual `--task <description>`** still works for direct CLI runs / scripts.

## Verification

Real commands, real output — no "I believe it works":

- `npm run build` — clean (`v3.9.17` bundles produced)
- New unit suite `tests/unit/cli/commands/hooks-routing.test.ts` — **10/10 pass** (UserPromptSubmit shape, PreToolUse/Bash, Task `tool_input` snake/camel, fallback ordering, empty-field skip, malformed-JSON safety, plain-text passthrough)
- Adjacent regressions still green: `tests/unit/init/settings-merge.test.ts` (17), `tests/unit/cli/init-command.test.ts` (20)
- **End-to-end in fresh fixture** (`.test-tmp/fixproof`): ran `aqe init --auto`, piped `{"hook_event_name":"UserPromptSubmit","prompt":"generate tests for auth module"}` into the configured route command. The router picked up `security-compliance` domain from "auth" (proving the prompt content actually reached the router) and persisted `task_json = {"description":"generate tests for auth module"}` in `routing_outcomes`. Pre-fix this row would have read `{"description":""}`.
- **Backward-compat**: `aqe hooks route --task "explicit task wins" --json` still routes and persists the explicit value.
- **Negative path**: `node dist/cli/bundle.js hooks route --json </dev/null` errors with `No task provided. Pass --task <description> or pipe a Claude Code hook event JSON to stdin.` (no silent empty routing).
- **Pack-install gate** (release skill §8e): `npm pack` → install in clean tempdir → `aqe --version` → prints `3.9.17`, exit 0.

Pre-fix evidence (still observable in this very repo's `.agentic-qe/memory.db`): `SELECT task_json FROM routing_outcomes ORDER BY rowid DESC LIMIT 5` returns rows with `{"description":""}`.

## Failure modes

- **Stdin read hangs the hook** — mitigated by 500ms timeout (mirrors `hook-handler.cjs:59`); `process.stdin.isTTY` short-circuits when invoked interactively. Tested with `</dev/null` and confirmed exit 0.
- **Existing settings.json with the broken hook is not upgraded** — mitigated: `isAqeHookEntry` matches commands containing `aqe`/`agentic-qe` regardless of args, so smart-merge replaces the broken old entry on `aqe init --upgrade`. Covered by `settings-merge.test.ts` (line 39 explicitly tests detection of the old `--task "$PROMPT"` shape, so legacy entries are still classified as AQE-managed and replaced).
- **Malformed stdin JSON crashes the route** — mitigated: `extractPromptFromEvent` falls through to verbatim-text handling on parse errors. Covered by the "does not crash on malformed JSON" unit test.
- **Hook surfaces other than UserPromptSubmit deliver different field names** — mitigated: parser tries `prompt`, `user_prompt`, `command`, and both snake/camel `tool_input.{prompt,description}` in priority order. Covered by 5 dedicated unit tests.
- **Other broken `$PROMPT` references hide elsewhere** — searched exhaustively: `grep -rn '\$PROMPT\|--task "\$' src/ assets/` returns only the explanatory comments I added. None found in the shipped templates.

## Upgrade path for existing users

```bash
npx agentic-qe@3.9.17 init --upgrade
jq '.hooks.UserPromptSubmit' .claude/settings.json
# expect: "command": "npx agentic-qe hooks route --json"  (no --task "$PROMPT")
```

After a few prompts:

```bash
sqlite3 .agentic-qe/memory.db \
  "SELECT task_json FROM routing_outcomes ORDER BY rowid DESC LIMIT 5"
# expect: actual prompt strings, not {"description":""}
```

---

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.** Each failure mode in the section above has a unit test or smart-merge test cited; the "other broken refs" mode is closed by an exhaustive grep of `src/` and `assets/`.

### Optional context

- Linked issues: closes the routing-learning-loop regression first reported as an upstream brief in `.test-tmp/UPSTREAM-aqe-issue-brief.md` (no GitHub issue was filed; happy to backfill one if needed).
- Trust tier change (if any): no change.
- Affects published API or CLI surface: **yes** — `aqe hooks route --task <description>` becomes optional (was required); stdin is now read as fallback. Backward-compatible: every existing call still works.
- Touches the init flow / `npm-publish.yml` / `tests/fixtures/init-corpus/`: **yes (init flow)** — `src/init/phases/07-hooks.ts` and `src/init/init-wizard-hooks.ts` template change. End-to-end verified by running `aqe init --auto` in a fresh fixture and exercising the generated hook with a real Claude Code-shaped event; not run against the full `init-corpus/run-gate.sh` because the change is template-only and covered by `settings-merge.test.ts` + `init-command.test.ts`. Happy to run the corpus if reviewer asks.
