### PR TITLE
fix: bootstrap patterns never reach RVF HNSW index — patternCount always 0

### DIFF
--- a/src/learning/pattern-store.ts
+++ b/src/learning/pattern-store.ts
@@ -373,6 +373,10 @@ export interface IPatternStore {
 
   /** Dispose the store */
   dispose(): Promise<void>;
+
+  /** Get the underlying RVF adapter, if any (RvfPatternStore only).
+   *  Returns null or undefined on non-RVF implementations. */
+  getAdapter?(): import('../integrations/ruvector/rvf-native-adapter.js').RvfNativeAdapter | null;
 }
 
 // ============================================================================

--- a/src/learning/qe-reasoning-bank.ts
+++ b/src/learning/qe-reasoning-bank.ts
@@ -235,7 +235,7 @@ export class QEReasoningBank implements IQEReasoningBank {
             logger.info('Backfilled RVF from SQLite', { count: vectors.length });
           }
         } catch (err) {
-          logger.warn('RVF backfill failed (non-fatal)', { error: getErrorMessage(err) });
+          logger.warn('RVF backfill failed (non-fatal)', { error: toErrorMessage(err) });
         }
       }
       return;

--- a/src/learning/qe-reasoning-bank.ts
+++ b/src/learning/qe-reasoning-bank.ts
@@ -213,13 +213,40 @@ export class QEReasoningBank implements IQEReasoningBank {
     const stats = await this.patternStore.getStats();
     if (stats.totalPatterns > 0) {
       logger.info('Found existing patterns', { totalPatterns: stats.totalPatterns });
+      // Backfill: ingest SQLite embeddings into the HNSW adapter for installations
+      // where patterns.rvf was never populated (pre-fix initial seeding path).
+      // Uses patternStore.getAdapter() — always available after initialize() —
+      // not rvfDualWriter, which is null in the hook invocation path.
+      // Guard on totalVectors === 0: adapter.ingest() is not idempotent.
+      const adapter = this.patternStore.getAdapter();
+      if (adapter && (adapter.status()?.totalVectors ?? 0) === 0) {
+        try {
+          const embeddings = this.getSqliteStore().getAllEmbeddings();
+          const vectors = embeddings
+            .filter(({ embedding }) => embedding && embedding.length > 0)
+            .map(({ patternId, embedding }) => ({
+              id: patternId,
+              vector: embedding instanceof Float32Array
+                ? embedding
+                : new Float32Array(embedding),
+            }));
+          if (vectors.length > 0) {
+            adapter.ingest(vectors);
+            logger.info('Backfilled RVF from SQLite', { count: vectors.length });
+          }
+        } catch (err) {
+          logger.warn('RVF backfill failed (non-fatal)', { error: getErrorMessage(err) });
+        }
+      }
       return;
     }
 
-    // Add foundational patterns from extracted module
+    // Use storePattern() (not patternStore.create() directly) so that:
+    // 1. embeddings are computed via this.embed()
+    // 2. patternStore.store() calls adapter.ingest() for each pattern
     for (const options of PRETRAINED_PATTERNS) {
       try {
-        await this.patternStore.create(options);
+        await this.storePattern(options);
       } catch (error) {
         logger.warn('Failed to load pattern', { name: options.name, error });
       }
@@ -669,3 +696,4 @@ export {
 } from './qe-guidance.js';
 
 export type { QEGuidance } from './qe-guidance.js';
+

--- a/src/learning/qe-reasoning-bank.ts
+++ b/src/learning/qe-reasoning-bank.ts
@@ -218,7 +218,7 @@ export class QEReasoningBank implements IQEReasoningBank {
       // Uses patternStore.getAdapter() — always available after initialize() —
       // not rvfDualWriter, which is null in the hook invocation path.
       // Guard on totalVectors === 0: adapter.ingest() is not idempotent.
-      const adapter = this.patternStore.getAdapter();
+      const adapter = this.patternStore.getAdapter?.();
       if (adapter && (adapter.status()?.totalVectors ?? 0) === 0) {
         try {
           const embeddings = this.getSqliteStore().getAllEmbeddings();
@@ -231,8 +231,11 @@ export class QEReasoningBank implements IQEReasoningBank {
                 : new Float32Array(embedding),
             }));
           if (vectors.length > 0) {
-            adapter.ingest(vectors);
-            logger.info('Backfilled RVF from SQLite', { count: vectors.length });
+            const { accepted, rejected } = adapter.ingest(vectors);
+            logger.info('Backfilled RVF from SQLite', { count: vectors.length, accepted });
+            if (rejected > 0) {
+              logger.warn('RVF backfill partially rejected', { accepted, rejected });
+            }
           }
         } catch (err) {
           logger.warn('RVF backfill failed (non-fatal)', { error: toErrorMessage(err) });

--- a/tests/unit/learning/qe-reasoning-bank-rvf-backfill.test.ts
+++ b/tests/unit/learning/qe-reasoning-bank-rvf-backfill.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Regression test for PR #445 — bootstrap patterns must reach the RVF HNSW index.
+ *
+ * Pins two invariants in QEReasoningBank.loadPretrainedPatterns:
+ *   1. Fresh install — each pretrained pattern reaches patternStore.create()
+ *      WITH an embedding (i.e. routed through storePattern(), not the raw
+ *      patternStore.create() which would skip RvfPatternStore.store()'s
+ *      `pattern.embedding && this.adapter` ingest gate).
+ *   2. Existing install — when patternStore reports patterns but the RVF
+ *      adapter is empty (totalVectors === 0), embeddings are read from
+ *      SQLite and batch-ingested into the adapter (the backfill path).
+ *
+ * The gate behavior itself is already covered by
+ * tests/unit/learning/rvf-pattern-store.test.ts (lines 162, 181). These tests
+ * verify that QEReasoningBank feeds the gate correctly.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { IPatternStore, PatternStoreStats } from '../../../src/learning/pattern-store.js';
+import type { CreateQEPatternOptions, QEPattern } from '../../../src/learning/qe-patterns.js';
+import type { Result } from '../../../src/shared/types/index.js';
+import { ok } from '../../../src/shared/types/index.js';
+
+const mocks = vi.hoisted(() => {
+  const adapter = {
+    statusValue: { totalVectors: 0 },
+    status: vi.fn(),
+    ingest: vi.fn(),
+  };
+  adapter.status.mockImplementation(() => adapter.statusValue);
+  adapter.ingest.mockImplementation((entries: Array<{ id: string; vector: Float32Array }>) => ({
+    accepted: entries.length,
+    rejected: 0,
+  }));
+
+  const sqliteEmbeddings: Array<{ patternId: string; embedding: number[] }> = [];
+
+  const patternStore: Partial<IPatternStore> & { __sqliteEmbeddings: typeof sqliteEmbeddings } = {
+    initialize: vi.fn(async () => undefined),
+    setSqliteStore: vi.fn(),
+    store: vi.fn(async (p: QEPattern): Promise<Result<string>> => ok(p.id)),
+    create: vi.fn(async (opts: CreateQEPatternOptions): Promise<Result<QEPattern>> =>
+      ok({
+        id: `id-${Math.random().toString(36).slice(2, 8)}`,
+        patternType: opts.patternType,
+        qeDomain: opts.qeDomain ?? 'test-generation',
+        domain: 'generic',
+        name: opts.name,
+        description: opts.description,
+        confidence: opts.confidence ?? 0.7,
+        usageCount: 0,
+        successRate: 0,
+        qualityScore: 0.5,
+        context: { tags: [], ...opts.context },
+        template: { example: '', ...opts.template },
+        embedding: opts.embedding,
+        tier: 'short-term',
+        createdAt: new Date(),
+        lastUsedAt: new Date(),
+        successfulUses: 0,
+        reusable: false,
+        reuseCount: 0,
+        averageTokenSavings: 0,
+      } as unknown as QEPattern),
+    ),
+    get: vi.fn(async () => null),
+    search: vi.fn(async () => ok([])),
+    recordUsage: vi.fn(async () => ok(undefined)),
+    promote: vi.fn(async () => ok(undefined)),
+    delete: vi.fn(async () => ok(undefined)),
+    getStats: vi.fn(async (): Promise<PatternStoreStats> => ({
+      totalPatterns: 0,
+      byTier: { shortTerm: 0, longTerm: 0 },
+      byDomain: {} as PatternStoreStats['byDomain'],
+      byType: {} as PatternStoreStats['byType'],
+      avgConfidence: 0,
+      avgQualityScore: 0,
+      avgSuccessRate: 0,
+      searchOperations: 0,
+      avgSearchLatencyMs: 0,
+      hnswStats: { totalNodes: 0, totalEdges: 0, levels: 0, nativeAvailable: true },
+    })),
+    cleanup: vi.fn(async () => ({ removed: 0, promoted: 0 })),
+    dispose: vi.fn(async () => undefined),
+    getAdapter: vi.fn(() => adapter as never),
+    __sqliteEmbeddings: sqliteEmbeddings,
+  };
+
+  return { adapter, patternStore, sqliteEmbeddings };
+});
+
+vi.mock('../../../src/learning/pattern-store.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/learning/pattern-store.js')>();
+  return {
+    ...actual,
+    createPatternStore: vi.fn(() => mocks.patternStore as unknown as IPatternStore),
+  };
+});
+
+vi.mock('../../../src/learning/sqlite-persistence.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/learning/sqlite-persistence.js')>();
+  return {
+    ...actual,
+    createSQLitePatternStore: vi.fn(() => ({
+      initialize: vi.fn(async () => undefined),
+      getAllEmbeddings: vi.fn(() => mocks.sqliteEmbeddings),
+      recordUsage: vi.fn(),
+      storePattern: vi.fn(),
+      getPattern: vi.fn(() => undefined),
+    })),
+  };
+});
+
+import { QEReasoningBank } from '../../../src/learning/qe-reasoning-bank.js';
+import { PRETRAINED_PATTERNS } from '../../../src/learning/pretrained-patterns.js';
+import { createMockMemory } from '../../mocks/index.js';
+
+describe('QEReasoningBank.loadPretrainedPatterns — RVF bootstrap (PR #445 regression)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.adapter.statusValue.totalVectors = 0;
+    mocks.sqliteEmbeddings.length = 0;
+    // Re-arm mock implementations cleared by clearAllMocks
+    mocks.adapter.status.mockImplementation(() => mocks.adapter.statusValue);
+    mocks.adapter.ingest.mockImplementation((entries: Array<{ id: string; vector: Float32Array }>) => ({
+      accepted: entries.length,
+      rejected: 0,
+    }));
+    (mocks.patternStore.getAdapter as ReturnType<typeof vi.fn>).mockImplementation(() => mocks.adapter as never);
+  });
+
+  it('fresh install: routes each pretrained pattern through storePattern() so embeddings reach patternStore.create()', async () => {
+    (mocks.patternStore.getStats as ReturnType<typeof vi.fn>).mockResolvedValue({
+      totalPatterns: 0,
+      byTier: { shortTerm: 0, longTerm: 0 },
+      byDomain: {},
+      byType: {},
+      avgConfidence: 0,
+      avgQualityScore: 0,
+      avgSuccessRate: 0,
+      searchOperations: 0,
+      avgSearchLatencyMs: 0,
+      hnswStats: { totalNodes: 0, totalEdges: 0, levels: 0, nativeAvailable: true },
+    });
+
+    const bank = new QEReasoningBank(createMockMemory());
+    await bank.initialize();
+
+    const createCalls = (mocks.patternStore.create as ReturnType<typeof vi.fn>).mock.calls;
+    // At minimum, one create per pretrained pattern (cross-domain seeding may add more)
+    expect(createCalls.length).toBeGreaterThanOrEqual(PRETRAINED_PATTERNS.length);
+
+    // The first N calls correspond to the pretrained loop — each must carry an embedding.
+    // This is the actual fix: pre-PR, patternStore.create(options) was called without
+    // an embedding, so RvfPatternStore.store()'s `pattern.embedding && this.adapter`
+    // gate skipped adapter.ingest(). Routing through storePattern() pre-computes it.
+    for (let i = 0; i < PRETRAINED_PATTERNS.length; i++) {
+      const opts = createCalls[i][0] as CreateQEPatternOptions;
+      expect(opts.embedding, `pretrained pattern ${i} (${opts.name}) missing embedding`).toBeDefined();
+      expect((opts.embedding as ArrayLike<number>).length).toBeGreaterThan(0);
+    }
+
+    await bank.dispose();
+  });
+
+  it('existing install: backfills the RVF adapter from SQLite when totalVectors === 0', async () => {
+    // Simulate post-bug state: SQLite holds embeddings, .rvf is empty
+    (mocks.patternStore.getStats as ReturnType<typeof vi.fn>).mockResolvedValue({
+      totalPatterns: 3,
+      byTier: { shortTerm: 3, longTerm: 0 },
+      byDomain: {},
+      byType: {},
+      avgConfidence: 0.7,
+      avgQualityScore: 0.5,
+      avgSuccessRate: 0,
+      searchOperations: 0,
+      avgSearchLatencyMs: 0,
+      hnswStats: { totalNodes: 0, totalEdges: 0, levels: 0, nativeAvailable: true },
+    });
+    mocks.sqliteEmbeddings.push(
+      { patternId: 'p1', embedding: Array.from({ length: 384 }, () => 0.1) },
+      { patternId: 'p2', embedding: Array.from({ length: 384 }, () => 0.2) },
+      { patternId: 'p3', embedding: Array.from({ length: 384 }, () => 0.3) },
+    );
+    mocks.adapter.statusValue.totalVectors = 0;
+
+    const bank = new QEReasoningBank(createMockMemory());
+    await bank.initialize();
+
+    expect(mocks.adapter.ingest).toHaveBeenCalledTimes(1);
+    const ingestArg = (mocks.adapter.ingest as ReturnType<typeof vi.fn>).mock.calls[0][0] as Array<{
+      id: string;
+      vector: Float32Array;
+    }>;
+    expect(ingestArg).toHaveLength(3);
+    expect(ingestArg.map((e) => e.id).sort()).toEqual(['p1', 'p2', 'p3']);
+    expect(ingestArg[0].vector).toBeInstanceOf(Float32Array);
+    expect(ingestArg[0].vector.length).toBe(384);
+
+    // No fresh-install path should have run
+    expect(mocks.patternStore.create).not.toHaveBeenCalled();
+
+    await bank.dispose();
+  });
+
+  it('existing install: skips backfill when adapter already has vectors (idempotent guard)', async () => {
+    (mocks.patternStore.getStats as ReturnType<typeof vi.fn>).mockResolvedValue({
+      totalPatterns: 3,
+      byTier: { shortTerm: 3, longTerm: 0 },
+      byDomain: {},
+      byType: {},
+      avgConfidence: 0.7,
+      avgQualityScore: 0.5,
+      avgSuccessRate: 0,
+      searchOperations: 0,
+      avgSearchLatencyMs: 0,
+      hnswStats: { totalNodes: 0, totalEdges: 0, levels: 0, nativeAvailable: true },
+    });
+    mocks.sqliteEmbeddings.push({
+      patternId: 'p1',
+      embedding: Array.from({ length: 384 }, () => 0.1),
+    });
+    mocks.adapter.statusValue.totalVectors = 19; // already populated
+
+    const bank = new QEReasoningBank(createMockMemory());
+    await bank.initialize();
+
+    // adapter.ingest must NOT be re-called — ingest is not idempotent
+    expect(mocks.adapter.ingest).not.toHaveBeenCalled();
+
+    await bank.dispose();
+  });
+
+  it('existing install: no-op when patternStore has no getAdapter (non-RVF store)', async () => {
+    (mocks.patternStore.getStats as ReturnType<typeof vi.fn>).mockResolvedValue({
+      totalPatterns: 5,
+      byTier: { shortTerm: 5, longTerm: 0 },
+      byDomain: {},
+      byType: {},
+      avgConfidence: 0.7,
+      avgQualityScore: 0.5,
+      avgSuccessRate: 0,
+      searchOperations: 0,
+      avgSearchLatencyMs: 0,
+      hnswStats: { totalNodes: 0, totalEdges: 0, levels: 0, nativeAvailable: false },
+    });
+    // Simulate non-RVF store: getAdapter returns undefined
+    (mocks.patternStore.getAdapter as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
+
+    const bank = new QEReasoningBank(createMockMemory());
+    await expect(bank.initialize()).resolves.toBeUndefined();
+    expect(mocks.adapter.ingest).not.toHaveBeenCalled();
+
+    await bank.dispose();
+  });
+});


### PR DESCRIPTION
## Problem

`QEReasoningBank.loadPretrainedPatterns` seeds the 19 bootstrap patterns via
`this.patternStore.create(options)`. The `options` objects come from
`PRETRAINED_PATTERNS` and have no `.embedding` field. `RvfPatternStore.store()`
only calls `adapter.ingest()` when `pattern.embedding` is truthy — so all 19
patterns land in SQLite but the HNSW index (`.rvf` file) stays empty.

On subsequent startups the method returns early ("Found existing patterns") without
writing anything to the HNSW index either. Result: `patterns.rvf` stays at
~162 bytes (file header only) for the lifetime of the installation.

`routeTask()` searches via `this.patternStore.search(embedding, {useVectorSearch: true})`,
which delegates to `adapter.search()` on the empty HNSW index → always returns `[]`
→ `patternCount: 0` in every routing hook output → routing confidence never improves
from domain-match baseline → learning feedback loop cannot close.

## Root cause in two paths

1. **Fresh install**: `patternStore.create(options)` — no embedding computed, no HNSW ingest.
2. **Existing install** (early-return): method returns immediately, HNSW never populated even though SQLite holds 19 embeddings.

## Empirical evidence (v3.9.21, `aqe-mcp` hook setup)

| Signal | Expected | Actual |
|---|---|---|
| `patterns.rvf` size | ≥ 29 KB (19 × 1536 B) | **162 bytes** (header only) |
| `qe_pattern_embeddings` rows | 19 | 19 |
| `patternCount` in routing hook output | > 0 | **0 (always)** |
| `routing_outcomes` success rate | > 0% | **0 / 65 = 0%** |
| `qe_pattern_usage` rows | > 0 after use | **0** |

## Fix

Two-part change in `loadPretrainedPatterns`:

1. **Existing install backfill**: Before returning early, call `patternStore.getAdapter()` (always set after `patternStore.initialize()`), read all embeddings from the SQLite store, and batch-`ingest()` them into the HNSW adapter. One-time O(n) operation per process start until `patterns.rvf` is populated. Guard: `adapter.status().totalVectors === 0` prevents re-ingestion (ingest is not idempotent). Non-fatal on error.

2. **Fresh install path**: Replace `patternStore.create(options)` with `this.storePattern(options)`. `storePattern` computes the embedding first, then calls `patternStore.create(withEmbedding)`, which reaches the `adapter.ingest()` branch inside `RvfPatternStore.store()`.

**Why `patternStore.getAdapter()` not `rvfDualWriter`:** `this.rvfDualWriter` is never injected in the standard hook invocation path (the `QEReasoningBank` constructor receives no `rvfDualWriter` option in the MCP/hook process). Any fix gated on `if(this.rvfDualWriter)` is a dead branch. `patternStore.getAdapter()` returns the same underlying RVF adapter and IS available after `patternStore.initialize()`.

## Impact

- No schema changes.
- No breaking changes to the public API.
- After this fix: `patternCount > 0` in routing hook output, routing confidence improves with use, pattern reuse metrics accumulate.

## Verification

```bash
# Before: patterns.rvf is ~162 bytes
ls -la .agentic-qe/patterns.rvf

# Apply fix, restart

# After: patterns.rvf holds 19 indexed vectors
ls -la .agentic-qe/patterns.rvf
# Observed: 29,912 bytes (19 × 384-dim float32 + header + HNSW graph)

# Routing hook returns patternCount > 0
aqe hooks route --task "generate unit tests for auth module" --json | jq .patternCount
# Observed: 9 (filtered to query-matching patterns from 19 indexed)
```


---

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.**

Covered failure modes and their tests:
- Fresh install: `patternStore.create()` called without embedding → covered by `qe-reasoning-bank-rvf-backfill.test.ts` "fresh install: routes each pretrained pattern through storePattern()"
- Existing install with empty HNSW: backfill must populate adapter → covered by "existing install: backfills the RVF adapter from SQLite when totalVectors === 0"
- Re-running on populated adapter (ingest is not idempotent): guard must skip → covered by "existing install: skips backfill when adapter already has vectors (idempotent guard)"
- Non-RVF pattern store (no `getAdapter`): must be no-op, no crash → covered by "existing install: no-op when patternStore has no getAdapter (non-RVF store)"
- Partial ingest rejection: now logged via `if (rejected > 0)` warn line in `loadPretrainedPatterns`
