### PR TITLE
chore(release): v3.9.23

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-qe",
-  "version": "3.9.22",
+  "version": "3.9.23",
   "description": "Agentic Quality Engineering — AI-powered QE platform with 60 specialized agents, 75+ skills, sublinear coverage analysis, ReasoningBank pattern learning, and deep MCP integration for Claude Code and 11 coding agent platforms",
   "author": {
     "name": "Agentic QE Team",

--- a/.claude/skills/skills-manifest.json
+++ b/.claude/skills/skills-manifest.json
@@ -939,7 +939,7 @@
   },
   "metadata": {
     "generatedBy": "Agentic QE Fleet",
-    "fleetVersion": "3.9.22",
+    "fleetVersion": "3.9.23",
     "manifestVersion": "1.4.0",
     "lastUpdated": "2026-04-13T00:00:00.000Z",
     "contributors": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to the Agentic QE project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.23] - 2026-05-11
+
+**Fixes the routing learning loop — `patternCount: 0` forever.** On every install
+shipped between v3.9.5 and v3.9.22, the 19 bootstrap patterns landed in SQLite
+but never reached the persistent HNSW index (`.agentic-qe/patterns.rvf`). The
+file sat at 162 bytes (header only) for the lifetime of the installation,
+which meant `routeTask()` returned `patternCount: 0` in every hook output and
+routing confidence couldn't improve from the domain-match baseline. After this
+fix, `patterns.rvf` reaches the expected ~30 KB on first init and existing
+installations are backfilled from SQLite on next startup.
+
+### Fixed
+
+- **Bootstrap patterns never reached the RVF HNSW index — `patternCount` was permanently 0** (#445) — `QEReasoningBank.loadPretrainedPatterns` seeded patterns via `patternStore.create(options)` where `options` carried no `.embedding`. `RvfPatternStore.store()` gates `adapter.ingest()` on `pattern.embedding && this.adapter`, so all 19 patterns persisted to SQLite but the HNSW file stayed empty. On subsequent startups the method returned early ("Found existing patterns") without writing the HNSW either, so even after the underlying bug was patched, `.rvf` remained 162 bytes forever. Two-part fix: (1) fresh installs now route through `storePattern()` which pre-computes the embedding before reaching `patternStore.create()`, hitting the ingest gate on the happy path; (2) existing installs trigger a one-time backfill — when `adapter.status().totalVectors === 0`, embeddings are read from `qe_pattern_embeddings` and batch-ingested via `adapter.ingest()`. Guarded against re-ingestion (not idempotent) and safe on non-RVF stores via the optional `IPatternStore.getAdapter?()` interface method. Partial-rejection ingest results now log a warning. Thanks to @Jordi-Izquierdo-DDS for the diagnosis and initial patch.
+
+### Added
+
+- **`tests/unit/learning/qe-reasoning-bank-rvf-backfill.test.ts`** — 4 regression tests pinning: fresh install routes each pretrained pattern through `storePattern()` so embeddings reach `patternStore.create()`; existing install backfills the RVF adapter from SQLite when `totalVectors === 0`; idempotent guard skips backfill when adapter already has vectors; non-RVF stores (no `getAdapter`) are a clean no-op.
+
+### Upgrade Notes
+
+- No breaking changes. After upgrading, the next process start will populate `.agentic-qe/patterns.rvf` with the 19 indexed vectors automatically — no manual action required.
+- Backfill runs once per process per installation (gated on `totalVectors === 0`), so the overhead is bounded.
+- `IPatternStore` gains an optional `getAdapter?()` method. Custom stores that implement the interface continue to work unchanged; only RVF-backed stores need to expose it.
+
 ## [3.9.22] - 2026-05-09
 
 **Stops the Exp counter from silently shrinking.** The consolidator's safety

--- a/assets/skills/skills-manifest.json
+++ b/assets/skills/skills-manifest.json
@@ -939,7 +939,7 @@
   },
   "metadata": {
     "generatedBy": "Agentic QE Fleet",
-    "fleetVersion": "3.9.22",
+    "fleetVersion": "3.9.23",
     "manifestVersion": "1.4.0",
     "lastUpdated": "2026-04-13T00:00:00.000Z",
     "contributors": [

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -4,6 +4,7 @@ All Agentic QE release notes organized by version.
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| [v3.9.23](v3.9.23.md) | 2026-05-11 | Routing learning loop fix: bootstrap patterns now reach the HNSW index (`patternCount > 0`), existing installs auto-backfill (#445) |
 | [v3.9.22](v3.9.22.md) | 2026-05-09 | Non-destructive consolidation safety valve (no more silent Exp counter shrinkage) + CLI-only `aqe init` flow now persists hooked experiences |
 | [v3.9.21](v3.9.21.md) | 2026-05-08 | Windows install unblocked (#439), RVF FsyncFailed root-cause fix, hypergraph `untested` / `impacted` queries return useful results |
 | [v3.9.20](v3.9.20.md) | 2026-05-08 | Second wave wire-gap fixes: HNSW A in routing, hook-side embeddings inline, dream cycle busy_timeout, pattern quality_score moves on hook flow, TrajectoryBridge → unified memory |

--- a/docs/releases/v3.9.23.md
+++ b/docs/releases/v3.9.23.md
@@ -1,0 +1,41 @@
+# v3.9.23 Release Notes
+
+**Release Date:** 2026-05-11
+
+## Highlights
+
+Fixes the routing learning loop. Every install shipped between v3.9.5 and v3.9.22 had `patternCount: 0` in routing hook output forever — the 19 bootstrap patterns landed in SQLite but never reached the persistent HNSW index (`.agentic-qe/patterns.rvf` stayed at 162 bytes, header only). After this fix, the file reaches ~30 KB on first init, existing installs are backfilled on next startup, and routing confidence can finally improve from the domain-match baseline.
+
+## Fixed
+
+- **Bootstrap patterns never reached the RVF HNSW index — `patternCount` was permanently 0** (#445). `QEReasoningBank.loadPretrainedPatterns` seeded patterns via `patternStore.create(options)` where the `options` objects (from `PRETRAINED_PATTERNS`) carried no `.embedding` field. `RvfPatternStore.store()` gates `adapter.ingest()` on `pattern.embedding && this.adapter`, so all 19 patterns persisted into the `qe_pattern_embeddings` table but the HNSW file stayed empty. On subsequent startups the method returned early ("Found existing patterns") without writing anything to HNSW either, so even after the underlying defect was patched, `.rvf` remained 162 bytes for the lifetime of the installation. Two-part fix:
+  1. **Fresh installs** — replaced `this.patternStore.create(options)` with `this.storePattern(options)`. `storePattern` calls `this.embed()` first, then `patternStore.create(withEmbedding)`, so the `pattern.embedding && this.adapter` gate inside `RvfPatternStore.store()` is hit on the happy path and each pattern is ingested.
+  2. **Existing installs (the trickier case)** — before the early `return`, read all embeddings from SQLite via `getSqliteStore().getAllEmbeddings()` and batch-ingest them through `this.patternStore.getAdapter?.()`. Gated on `adapter.status().totalVectors === 0` because `ingest()` is not idempotent. Safe on non-RVF stores: the new optional `IPatternStore.getAdapter?()` method returns `undefined`, the existing `if (adapter && ...)` guard skips the path cleanly.
+  Partial-rejection `{accepted, rejected}` results from `adapter.ingest()` are now logged so future ingest failures are visible. Thanks to @Jordi-Izquierdo-DDS for the diagnosis and initial patch.
+
+## Added
+
+- **`tests/unit/learning/qe-reasoning-bank-rvf-backfill.test.ts`** — 4 regression tests:
+  - Fresh install: each pretrained pattern reaches `patternStore.create()` with a non-empty embedding.
+  - Existing install with empty HNSW: backfill calls `adapter.ingest()` once with the SQLite embeddings.
+  - Idempotent guard: when `totalVectors > 0`, `adapter.ingest()` is not re-invoked.
+  - Non-RVF store: when `getAdapter` is undefined, the path is a no-op (no crash, no ingest).
+
+## Upgrade Notes
+
+- No breaking changes. After upgrading, the next process start populates `.agentic-qe/patterns.rvf` with the 19 indexed vectors automatically — no manual action required.
+- Backfill runs once per process per installation (gated on `totalVectors === 0`), so the overhead is bounded.
+- `IPatternStore` gains an optional `getAdapter?()` method returning `RvfNativeAdapter | null`. Custom implementations of `IPatternStore` continue to work unchanged; only RVF-backed stores need to expose it.
+
+## Verification
+
+- `tsc --noEmit` clean on the modified files.
+- PR #445 CI: 10 of 12 jobs passed (all Journey tests, Postgres, Contract, Infrastructure, Performance Gates, Code Intelligence, Coherence Verification, pr-template-check). The 2 failing jobs (Coverage Analysis, Test Dashboard) were chronically flaky worker timeouts on test files unrelated to this change, matching the same pattern that hit PR #444.
+- Empirical evidence from the original bug report:
+
+  | Signal | Before | After |
+  |---|---|---|
+  | `patterns.rvf` size | 162 bytes (header only) | 29,912 bytes (19 × 384-dim) |
+  | `qe_pattern_embeddings` rows | 19 | 19 |
+  | `patternCount` in routing hook output | 0 (always) | > 0 |
+  | `routing_outcomes` success rate | 0 / 65 = 0% | accumulates with use |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentic-qe",
-  "version": "3.9.22",
+  "version": "3.9.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentic-qe",
-      "version": "3.9.22",
+      "version": "3.9.23",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-qe",
-  "version": "3.9.22",
+  "version": "3.9.23",
   "description": "Agentic Quality Engineering V3 - Domain-Driven Design Architecture with 13 Bounded Contexts, O(log n) coverage analysis, ReasoningBank learning, 60 specialized QE agents, mathematical Coherence verification, deep Claude Flow integration",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Release v3.9.23 — version bump, CHANGELOG, and release notes for the routing
learning loop fix that landed in #445 (squash-merged as `5e1126c5`).

After this release: `patternCount` in routing hook output is non-zero, and
existing installs auto-backfill `.agentic-qe/patterns.rvf` from SQLite on
next startup. The HNSW index file grows from 162 bytes (header only) to
~30 KB (19 indexed vectors).

## Verification

```
$ node -p "require('./package.json').version"
3.9.23

$ npm run build
[…]
CLI bundle built successfully (v3.9.23)
MCP bundle built successfully (v3.9.23)

$ npm run typecheck
> tsc --noEmit
(zero errors)

$ ls -la dist/cli/bundle.js dist/index.js dist/mcp/bundle.js
-rwxr-xr-x  12013 dist/cli/bundle.js
-rw-r--r--   5245 dist/index.js
-rwxr-xr-x 3530502 dist/mcp/bundle.js

$ node dist/cli/bundle.js --version
3.9.23
```

Version strings updated everywhere (no stale `3.9.22` remains in source):
`package.json`, `package-lock.json`, `.claude/skills/skills-manifest.json`
(`fleetVersion`), `.claude-plugin/plugin.json`, `assets/skills/skills-manifest.json`.

Full test suite skipped locally per CLAUDE.md ("DO NOT run local tests in
Codespace if they OOM — CI tests in the workflow are sufficient"). CI on
the source fix (PR #445) passed 10 of 12 jobs; the 2 failures (Coverage
Analysis, Test Dashboard) were chronically flaky worker timeouts on test
files unrelated to this change.

## Failure modes

- **Backfill ingests the same vectors twice** — guarded by `if (adapter.status()?.totalVectors ?? 0) === 0`. Regression test: `qe-reasoning-bank-rvf-backfill.test.ts` "existing install: skips backfill when adapter already has vectors (idempotent guard)".
- **Backfill crashes on non-RVF stores** — `IPatternStore.getAdapter?()` is optional; the `if (adapter && ...)` guard handles `undefined`. Regression test: `qe-reasoning-bank-rvf-backfill.test.ts` "existing install: no-op when patternStore has no getAdapter (non-RVF store)".
- **Fresh install reverts to creating patterns without embeddings** — `storePattern()` pre-computes the embedding. Regression test: `qe-reasoning-bank-rvf-backfill.test.ts` "fresh install: routes each pretrained pattern through storePattern() so embeddings reach patternStore.create()".
- **Stale `patterns.rvf` from before fix lingers as 162 bytes** — backfill repopulates from SQLite source-of-truth on next process start. Not a new failure mode introduced here; it's the recovery path for the previous bug.

No new failure modes introduced by the release prep itself (version bump + docs).

---

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.** "Unlikely" is not an acceptable substitute. If you wrote "I don't think this can happen but...", that sentence is a failure mode and needs a test or an issue link.

### Optional context

- Linked issues: closes the routing-learning-loop bug tracked via #445
- Trust tier change (if any): none
- Affects published API or CLI surface: no (internal `IPatternStore.getAdapter?()` is the only signature change; optional, additive)
- Touches the init flow / `npm-publish.yml` / `tests/fixtures/init-corpus/`: no

See [CHANGELOG](CHANGELOG.md) and [docs/releases/v3.9.23.md](docs/releases/v3.9.23.md) for details.