### PR TITLE
chore(release): v3.9.26 — 10 learning-pipeline fixes (#453–#465)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-qe",
-  "version": "3.9.25",
+  "version": "3.9.26",
   "description": "Agentic Quality Engineering — AI-powered QE platform with 60 specialized agents, 75+ skills, sublinear coverage analysis, ReasoningBank pattern learning, and deep MCP integration for Claude Code and 11 coding agent platforms",
   "author": {
     "name": "Agentic QE Team",

--- a/.claude/skills/skills-manifest.json
+++ b/.claude/skills/skills-manifest.json
@@ -939,7 +939,7 @@
   },
   "metadata": {
     "generatedBy": "Agentic QE Fleet",
-    "fleetVersion": "3.9.25",
+    "fleetVersion": "3.9.26",
     "manifestVersion": "1.4.0",
     "lastUpdated": "2026-04-13T00:00:00.000Z",
     "contributors": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,110 @@ All notable changes to the Agentic QE project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.26] - 2026-05-13
+
+**Ten learning-pipeline fixes reported by Jordi against v3.9.24.** Most are
+short-circuits in the post-task hook chain that look fine in isolation but
+break the end-to-end Stream B/D/F learning loop: experiences land tagged as
+`agent='unknown'` and `task='edit: '`, every Q-learning bucket converges on
+the same key, dream insights are generated but never applied, patterns cross
+the promotion thresholds but stay short-term forever, and stale sentinels
+invert the routing-quality metric. Each fix is small but the cumulative
+effect is that the learning loop now actually converges on real per-agent
+signal instead of zeros.
+
+### Fixed
+
+- **`post-edit` recorded experiences with `task = "edit: "` for ~88% of
+  turns** (#453) — `$TOOL_INPUT_file_path` doesn't expand reliably in
+  Claude Code's PostToolUse context, so `--file ""` arrived empty and every
+  captured experience was tagged with no path. Embeddings were useless and
+  consolidation matched nothing. Now falls back to reading
+  `tool_input.file_path` from the Claude Code event JSON on stdin (mirrors
+  the existing route-hook stdin path).
+
+- **`aqe hooks stats --json` always reported zero** (#454) —
+  `QEReasoningBank.getStats()` only read in-memory counters, which reset to
+  zero on every hook subprocess start. Live DBs with 1,900+ routing rows
+  and 270+ learning outcomes all reported as 0. Now falls back to
+  aggregated DB totals when the in-memory counters are zero. Live verify:
+  `routingRequests: 1904, avgRoutingConfidence: 0.396, learningOutcomes:
+  272, patternSuccessRate: 0.75`.
+
+- **Patterns never promoted from `short-term` to `long-term`** (#455) —
+  `recordOutcome()` runs with a synthetic `task:agent:taskId` pattern ID
+  that never matches `qe_patterns.id`, so the promotion check was always
+  skipped. The bridge loop in `persistTaskOutcome` updates the real pattern
+  IDs but had no inline promotion check. Patterns crossed
+  `successful_uses≥3 / success_rate≥0.7 / confidence≥0.6` and stayed pinned
+  at short-term forever. Added a guarded UPDATE inside the bridge loop.
+
+- **Dream cycles wrote insights but never applied them** (#456) — hook-fired
+  dreams called `engine.dream()` and closed the engine without invoking
+  `applyInsight()`. `DreamScheduler.autoApplyInsights()` wires this in the
+  daemon path; the hook path had no equivalent. Reporter saw 378 unapplied
+  insights vs. 9 applied. Now iterates `result.insights` and applies each
+  `actionable && confidenceScore ≥ 0.5` after `dream()` returns.
+
+- **Q-learning router couldn't differentiate per agent** (#460) —
+  `--agent "$TOOL_RESULT_agent_id"` arrived empty (Claude Code doesn't
+  expose that env var in PostToolUse), so every `rl_q_values` row landed
+  under `action_key='unknown'`. Now falls back to the pre-task bridge's
+  recommended agent when `--agent` is empty, while still respecting an
+  explicit user override.
+
+- **Concurrent hooks triggered overlapping dream cycles that died on
+  `database is locked`** (#461) — multiple subprocesses saw the same stale
+  `lastDreamTime`, all started ~10s cycles, and ~35% failed on the WAL
+  writer (`busy_timeout` only serializes sequential contention, not
+  simultaneous writers). Added a `dream_cycles` peek before opening the
+  engine: if a `status='running'` row exists in the last 60s, bail out
+  with `reason='already-running'`. Fail-open.
+
+- **`patterns.rvf` accumulated orphan vectors across upgrades** (#462) —
+  upgrade workflows rewrote `qe_patterns` via `INSERT OR REPLACE` without
+  calling `RvfPatternStore.delete()` on the old IDs. Ghost vectors won
+  cosine-similarity matches and routed to non-existent IDs, so
+  `getPattern()` returned null and writes failed silently. Reporter saw
+  24 RVF vectors vs. 16 DB rows. `initialize()` now diffs the RVF idmap
+  against the DB and deletes orphans on every cold start.
+
+- **`experience_applications.tokens_saved` was hardcoded to 0** (#463) —
+  the learning-ROI column was permanently useless across every post-task
+  invocation. Replaced the literal 0 with `Math.round(qualityScore * 100)`,
+  scaling the existing 6-dim outcome quality (0.335 worst-case to 0.675
+  best-case) into a non-trivial 34-68 signal until a real per-task
+  token-delta calculation is wired in.
+
+- **High-quality `cli-hook` experiences blanket-excluded from
+  consolidation** (#464) — issue #348 had filtered out
+  `agent='cli-hook'` rows to keep low-quality Bash telemetry
+  (quality ~0.40) out of the pipeline. But post-edit experiences are also
+  tagged `agent='cli-hook'` with quality ~0.75 and success_rate ~1.0,
+  and they're the dominant share. The `HAVING avg_quality≥0.5 AND
+  success_rate≥0.6` clause already filters by quality — dropping the
+  over-broad agent-name filter so real usage produces patterns again.
+
+- **Stale `routing_outcomes` sentinels inverted the quality metric** (#465)
+  — sessions that terminated without firing `Stop` (compact, kill, IDE
+  crash) left their sentinels at `quality_score=-1` forever, and newer
+  sessions kept pre-empting them in `ORDER BY DESC` so the LIMIT-1 close
+  never reached them. Reporter saw 122/149 rows stuck at -1, inverting
+  `AVG(quality_score)` from a real +0.666 to an observed -0.717. `post-route`
+  now runs a second sweep UPDATE on sentinels older than 5 minutes, tagged
+  with `error='stale-sentinel'` for filterability.
+
+### Closed as duplicates
+
+- #457 (dup of #454) — getStats DB aggregation fallback
+- #458 (dup of #455) — bridge-loop pattern promotion
+- #459 (dup of #456) — dream insight auto-apply
+
+### Security
+
+- **Patched 11 Dependabot alerts** — `@protobufjs/utf8` and OpenTelemetry
+  bumps merged from main (#476).
+
 ## [3.9.25] - 2026-05-12
 
 **Fixes the route sentinel that `routing_outcomes` never closed.** `route` hooks

--- a/assets/skills/skills-manifest.json
+++ b/assets/skills/skills-manifest.json
@@ -939,7 +939,7 @@
   },
   "metadata": {
     "generatedBy": "Agentic QE Fleet",
-    "fleetVersion": "3.9.25",
+    "fleetVersion": "3.9.26",
     "manifestVersion": "1.4.0",
     "lastUpdated": "2026-04-13T00:00:00.000Z",
     "contributors": [

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -4,6 +4,7 @@ All Agentic QE release notes organized by version.
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| [v3.9.26](v3.9.26.md) | 2026-05-13 | Ten learning-pipeline fixes: post-edit stdin file_path, getStats DB fallback, pattern promotion, dream apply, Q-learning agent key, concurrent-dream guard, RVF orphan purge, tokens_saved, cli-hook consolidation, stale sentinel sweep (#453–#465) |
 | [v3.9.25](v3.9.25.md) | 2026-05-12 | Fix: new `post-route` Stop hook closes route sentinels 1:1 — `routing_outcomes` no longer accumulates `quality_score=-1` rows (#451) |
 | [v3.9.24](v3.9.24.md) | 2026-05-12 | Fix: `post-task` no longer skips Stream B/D/F when `--task-id` is missing — `rl_q_values` populates on every invocation (#449) |
 | [v3.9.23](v3.9.23.md) | 2026-05-11 | Two self-learning fixes: bootstrap patterns now reach HNSW (#445), `qe_pattern_usage` no longer permanently empty after `ON CONFLICT` upserts (#447) |

--- a/docs/releases/v3.9.26.md
+++ b/docs/releases/v3.9.26.md
@@ -1,0 +1,134 @@
+# v3.9.26 Release Notes
+
+**Release Date:** 2026-05-13
+
+## Highlights
+
+Ten learning-pipeline fixes reported by Jordi against v3.9.24. Individually they
+look like small short-circuits in the post-task hook chain; together they were
+keeping the end-to-end Stream B/D/F learning loop pinned at zero — experiences
+tagged `agent='unknown'` and `task='edit: '`, Q-learning buckets all converging
+on one key, dream insights generated but never applied, patterns crossing the
+promotion thresholds but staying short-term forever, and stale sentinels
+inverting the routing-quality metric from a real +0.666 to an observed −0.717.
+
+After this release the learning loop actually converges on real per-agent
+signal instead of zeros.
+
+## Fixed
+
+- **`post-edit` recorded experiences with `task = "edit: "` for ~88% of
+  turns** (#453) — `$TOOL_INPUT_file_path` doesn't expand reliably in
+  Claude Code's PostToolUse context, so `--file ""` arrived empty and every
+  captured experience was tagged with no path. Embeddings were useless and
+  consolidation matched nothing. Now falls back to reading
+  `tool_input.file_path` from the Claude Code event JSON on stdin.
+
+- **`aqe hooks stats --json` always reported zero** (#454) —
+  `QEReasoningBank.getStats()` only read in-memory counters, which reset on
+  every hook subprocess start. Live DBs with 1,900+ routing rows reported
+  as 0. Now falls back to aggregated DB totals
+  (`routing_outcomes` count, `qe_pattern_usage` count, `AVG(success_rate)`)
+  when in-memory counters are zero.
+
+- **Patterns never promoted from `short-term` to `long-term`** (#455) —
+  `recordOutcome()` runs with a synthetic `task:agent:taskId` pattern ID
+  that never matches `qe_patterns.id`, so the promotion check was always
+  skipped for the real UUIDs updated via the bridge loop. Patterns crossed
+  `successful_uses≥3 / success_rate≥0.7 / confidence≥0.6` and stayed pinned
+  short-term. Added a guarded UPDATE inside the bridge loop.
+
+- **Dream cycles wrote insights but never applied them** (#456) — hook-fired
+  dreams called `engine.dream()` and closed the engine without invoking
+  `applyInsight()`. The daemon path wires this via
+  `DreamScheduler.autoApplyInsights`; the hook path had no equivalent.
+  Reporter saw 378 unapplied insights vs. 9 applied. Now iterates
+  `result.insights` and applies each `actionable && confidenceScore ≥ 0.5`.
+
+- **Q-learning router couldn't differentiate per agent** (#460) —
+  `--agent "$TOOL_RESULT_agent_id"` arrived empty (Claude Code doesn't
+  expose that env var in PostToolUse), so every `rl_q_values` row landed
+  under `action_key='unknown'`. Now falls back to the pre-task bridge's
+  recommended agent when `--agent` is empty, while still respecting an
+  explicit user override.
+
+- **Concurrent hooks triggered overlapping dream cycles that died on
+  `database is locked`** (#461) — multiple subprocesses saw the same stale
+  `lastDreamTime`, all started ~10s cycles, and ~35% failed on the WAL
+  writer (`busy_timeout` only serializes sequential contention, not
+  simultaneous writers). Added a `dream_cycles` peek before opening the
+  engine: if a `status='running'` row exists in the last 60s, bail out
+  with `reason='already-running'`. Fail-open.
+
+- **`patterns.rvf` accumulated orphan vectors across upgrades** (#462) —
+  upgrade workflows rewrote `qe_patterns` via `INSERT OR REPLACE` without
+  calling `RvfPatternStore.delete()` on the old IDs. Ghost vectors won
+  cosine-similarity matches and routed to non-existent IDs, so
+  `getPattern()` returned null and writes failed silently. Reporter saw
+  24 RVF vectors vs. 16 DB rows. `initialize()` now diffs the RVF idmap
+  against the DB and deletes orphans on every cold start.
+
+- **`experience_applications.tokens_saved` was hardcoded to 0** (#463) —
+  the learning-ROI column was permanently useless. Replaced the literal 0
+  with `Math.round(qualityScore * 100)`, scaling the existing 6-dim
+  outcome quality into a non-trivial 34–68 signal until a real per-task
+  token-delta calculation is wired in.
+
+- **High-quality `cli-hook` experiences blanket-excluded from
+  consolidation** (#464) — the consolidation pipeline filtered out every
+  `agent='cli-hook'` row to keep low-quality Bash telemetry out, but
+  post-edit experiences are also tagged `agent='cli-hook'` with quality
+  ~0.75 / success_rate ~1.0 and they're the dominant share. The
+  `HAVING avg_quality≥0.5 AND success_rate≥0.6` clause already filters by
+  quality — dropping the over-broad agent-name filter so real usage
+  produces patterns again.
+
+- **Stale `routing_outcomes` sentinels inverted the quality metric** (#465)
+  — sessions that terminated without firing `Stop` left their sentinels at
+  `quality_score=-1` forever, and newer sessions kept pre-empting them in
+  `ORDER BY DESC` so the LIMIT-1 close never reached them. 122/149 rows
+  stuck at -1, inverting `AVG(quality_score)` from +0.666 to −0.717.
+  `post-route` now runs a second sweep UPDATE on sentinels older than
+  5 minutes, tagged with `error='stale-sentinel'`.
+
+## Closed as duplicates
+
+- #457 (dup of #454), #458 (dup of #455), #459 (dup of #456) — same titles
+  and evidence as the originals, closed with a pointer to the merged fix.
+
+## Security
+
+- **Patched 11 Dependabot alerts** — `@protobufjs/utf8` and OpenTelemetry
+  bumps merged from main (#476).
+
+## Verification
+
+- `npm run build` — both CLI and MCP bundles built cleanly.
+- `npm run typecheck` — zero errors.
+- New regression suites for every fix:
+  - `tests/unit/cli/commands/hooks-editing.test.ts` (10 tests, #453)
+  - `tests/unit/learning/sqlite-aggregate-stats.test.ts` (4 tests, #454)
+  - `tests/unit/cli/commands/post-task-promotion.test.ts` (4 tests, #455)
+  - `tests/unit/cli/commands/hooks-dream-apply-insights.test.ts` (4 tests, #456)
+  - `tests/unit/cli/commands/post-task-agent-fallback.test.ts` (4 tests, #460)
+  - `tests/unit/cli/commands/hooks-dream-concurrent-guard.test.ts` (3 tests, #461)
+  - `tests/unit/learning/rvf-pattern-store-orphan-purge.test.ts` (5 tests, #462)
+  - `tests/unit/cli/commands/post-task-tokens-saved.test.ts` (4 tests, #463)
+  - `tests/unit/cli/commands/consolidation-cli-hook.test.ts` (4 tests, #464)
+  - `tests/unit/cli/commands/post-route-sentinel-sweep.test.ts` (4 tests, #465)
+- Existing regression suites (`hooks-routing`, `task-hooks-no-taskid`) continue
+  to pass. **58 / 58 tests across 12 suites passing.**
+
+## Upgrade Notes
+
+- No breaking changes. Drop-in upgrade.
+- The orphan-vector purge in `RvfPatternStore.initialize()` runs once at
+  cold start. If your `patterns.rvf` has accumulated ghosts, you'll see a
+  `[RvfPatternStore] Removed N ghost vectors` log line on first run.
+- The stale-sentinel sweep in `post-route` will retroactively clean up old
+  `quality_score=-1` rows on first turn after upgrade. Rows are tagged
+  with `error='stale-sentinel'` so you can filter them from
+  precision-sensitive queries.
+
+Thanks again to @Jordi-Izquierdo-DDS for the meticulous bug reports and
+patch shapes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentic-qe",
-  "version": "3.9.25",
+  "version": "3.9.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentic-qe",
-      "version": "3.9.25",
+      "version": "3.9.26",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-qe",
-  "version": "3.9.25",
+  "version": "3.9.26",
   "description": "Agentic Quality Engineering V3 - Domain-Driven Design Architecture with 13 Bounded Contexts, O(log n) coverage analysis, ReasoningBank learning, 60 specialized QE agents, mathematical Coherence verification, deep Claude Flow integration",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/cli/commands/hooks-handlers/editing-hooks.ts
+++ b/src/cli/commands/hooks-handlers/editing-hooks.ts
@@ -19,6 +19,8 @@ import {
   printSuccess,
   printError,
   printGuidance,
+  readStdinJsonEvent,
+  extractFilePathFromEvent,
 } from './hooks-shared.js';
 
 /**
@@ -103,15 +105,29 @@ export function registerEditingHooks(hooks: Command): void {
 
         const success = options.success || !options.failure;
 
-        // Generate synthetic patternId from file path if none provided
-        const filePath = options.file || '';
+        // Generate synthetic patternId from file path if none provided.
+        //
+        // `--file` falls back to the Claude Code hook event JSON on stdin.
+        // PostToolUse events carry `tool_input.file_path` (and older shapes use
+        // `toolInput.file_path`) — without this fallback, $TOOL_INPUT_file_path
+        // expansion silently produces `--file ""` and every captured experience
+        // ends up tagged `edit: ` with no file path (#453).
+        let filePath = options.file || '';
+        if (!filePath.trim()) {
+          try {
+            const rawEvent = await readStdinJsonEvent();
+            filePath = extractFilePathFromEvent(rawEvent);
+          } catch {
+            // best-effort — never crash the hook host
+          }
+        }
         const fileName = filePath.split('/').pop() || 'unknown';
         const isTestFile = /\.(test|spec)\.(ts|js|tsx|jsx)$/.test(fileName);
         const domain = isTestFile ? 'test-generation' : 'code-intelligence';
         const syntheticPatternId = options.patternId || `edit:${domain}:${fileName}`;
 
         const results = await hookRegistry.emit(QE_HOOK_EVENTS.PostTestGeneration, {
-          targetFile: options.file,
+          targetFile: filePath,
           success,
           patternId: syntheticPatternId,
           generatedTests: null,
@@ -160,13 +176,13 @@ export function registerEditingHooks(hooks: Command): void {
         if (options.json) {
           printJson({
             success: true,
-            file: options.file,
+            file: filePath,
             editSuccess: success,
             patternsLearned: result.patternsLearned || 0,
             dreamTriggered,
           });
         } else {
-          printSuccess(`Recorded edit outcome for ${options.file}`);
+          printSuccess(`Recorded edit outcome for ${filePath || '(unknown file)'}`);
           if (result.patternsLearned) {
             console.log(chalk.green(`  Patterns learned: ${result.patternsLearned}`));
           }

--- a/src/cli/commands/hooks-handlers/hooks-dream-learning.ts
+++ b/src/cli/commands/hooks-handlers/hooks-dream-learning.ts
@@ -782,9 +782,16 @@ export async function consolidateExperiencesToPatterns(): Promise<number> {
   }
 
   // Aggregate unprocessed experiences by domain+agent with quality thresholds.
-  // Exclude 'cli-hook' agent — these are low-quality hook telemetry events
-  // (quality ~0.40, success_rate ~0.24) that flood the pipeline and block
-  // real pattern creation. See issue #348.
+  //
+  // Issue #464: dropped the `AND agent != 'cli-hook'` filter. The original
+  // exclusion (issue #348) was meant to keep low-quality Bash telemetry
+  // (quality ~0.40, success_rate ~0.24) from flooding the pipeline — but
+  // post-edit experiences also use agent='cli-hook' and have avg_quality
+  // ~0.75 / success_rate ~1.0, well above the HAVING thresholds. Excluding
+  // by agent name meant the dominant share of high-quality experiences was
+  // ineligible and consolidation never produced patterns. The HAVING clause
+  // below is the real quality gate; tighten it if #348's concern resurfaces
+  // rather than filtering by agent name.
   const aggregates = db.prepare(`
     SELECT
       domain,
@@ -797,7 +804,6 @@ export async function consolidateExperiencesToPatterns(): Promise<number> {
       GROUP_CONCAT(DISTINCT source) as sources
     FROM captured_experiences
     WHERE application_count = 0
-      AND agent != 'cli-hook'
     GROUP BY domain, agent
     HAVING cnt >= 3 AND avg_quality >= 0.5 AND success_rate >= 0.6
     ORDER BY avg_quality DESC

--- a/src/cli/commands/hooks-handlers/hooks-dream-learning.ts
+++ b/src/cli/commands/hooks-handlers/hooks-dream-learning.ts
@@ -39,6 +39,8 @@ export async function checkAndTriggerDream(memoryBackend: MemoryBackend): Promis
   triggered: boolean;
   reason?: string;
   insightsGenerated?: number;
+  /** Number of insights that were applied to qe_patterns (#456). */
+  insightsApplied?: number;
 }> {
   try {
     // Load persisted dream state
@@ -103,6 +105,26 @@ export async function checkAndTriggerDream(memoryBackend: MemoryBackend): Promis
 
     const result = await engine.dream(10000);
 
+    // Issue #456: apply actionable insights inline so the hook path doesn't
+    // leave the backlog growing forever. DreamScheduler.autoApplyInsights()
+    // wires this in the daemon path, but checkAndTriggerDream is the
+    // hook-driven path and has no scheduler — without this block, every
+    // hook-fired dream cycle writes insights with applied=0 and they
+    // accumulate indefinitely (#456 evidence: 378 unapplied / 9 applied).
+    // Threshold matches DreamSchedulerConfig.insightConfidenceThreshold
+    // default (0.5) and InsightGenerator's `actionable` gate.
+    let insightsApplied = 0;
+    try {
+      for (const insight of result.insights) {
+        if (insight.actionable && insight.confidenceScore >= 0.5) {
+          const applyResult = await engine.applyInsight(insight.id);
+          if (applyResult.success) insightsApplied++;
+        }
+      }
+    } catch (applyErr) {
+      console.error(chalk.dim(`[hooks] Dream apply: ${applyErr instanceof Error ? applyErr.message : 'unknown'}`));
+    }
+
     // Update state
     dreamState.lastDreamTime = new Date().toISOString();
     dreamState.experienceCount = 0;
@@ -115,6 +137,7 @@ export async function checkAndTriggerDream(memoryBackend: MemoryBackend): Promis
       triggered: true,
       reason,
       insightsGenerated: result.insights.length,
+      insightsApplied,
     };
   } catch (error) {
     console.error(chalk.dim(`[hooks] Dream trigger failed: ${error instanceof Error ? error.message : 'unknown'}`));

--- a/src/cli/commands/hooks-handlers/hooks-dream-learning.ts
+++ b/src/cli/commands/hooks-handlers/hooks-dream-learning.ts
@@ -386,7 +386,14 @@ export async function persistTaskOutcome(opts: {
       'cli-hook-post-task',
     );
 
-    // 2. Base experience_applications row
+    // 2. Base experience_applications row.
+    //
+    // Issue #463: tokens_saved was hardcoded to 0 on every row, so the
+    // learning-ROI column was permanently useless. qualityScore is already
+    // computed above and ranges 0.34 (failure+slow) to 0.68 (success+fast).
+    // Scale by 100 as a proxy until a real per-task token-delta calculation
+    // is wired in — gives a non-trivial 34-68 signal that downstream
+    // analytics can reason about.
     db.prepare(`
       INSERT INTO experience_applications
         (id, experience_id, task, success, tokens_saved, feedback, applied_at)
@@ -396,7 +403,7 @@ export async function persistTaskOutcome(opts: {
       experienceId,
       taskField,
       opts.success ? 1 : 0,
-      0,
+      Math.round(qualityScore * 100),
       `[Patch 060] post-task outcome: ${opts.success ? 'success' : 'failure'}`,
     );
 

--- a/src/cli/commands/hooks-handlers/hooks-dream-learning.ts
+++ b/src/cli/commands/hooks-handlers/hooks-dream-learning.ts
@@ -69,6 +69,39 @@ export async function checkAndTriggerDream(memoryBackend: MemoryBackend): Promis
     const reason = timeTriggered ? 'time-interval' : 'experience-threshold';
     console.log(chalk.dim(`[hooks] Dream trigger: ${reason} (${dreamState.experienceCount} experiences, ${Math.round(timeSinceLastDream / 60000)}min since last dream)`));
 
+    // Issue #461: concurrent hook subprocesses all see the same stale
+    // dreamState.lastDreamTime, race past the time/experience triggers, and
+    // start ~10s dream cycles in parallel. They then all hit the WAL writer
+    // at roughly the same time and 35% of cycles fail with
+    // `database is locked` (duration_ms ≈ 10050ms — the full cycle ran, only
+    // the write-back failed). `busy_timeout` doesn't help: it serializes
+    // sequential contention, not simultaneous writers.
+    //
+    // Peek at dream_cycles before we open the engine — if another process
+    // has started a cycle in the last 60s, bail out with reason='already-
+    // running'. Fail-open: any error in the guard lets the dream proceed,
+    // so this can never make things worse than they were before.
+    try {
+      const { getUnifiedMemory } = await import('../../../kernel/unified-memory.js');
+      const um = getUnifiedMemory();
+      if (um.isInitialized()) {
+        const db = um.getDatabase();
+        const running = db
+          .prepare(
+            `SELECT COUNT(*) AS n FROM dream_cycles
+             WHERE status = 'running'
+               AND start_time > datetime('now', '-60 seconds')`,
+          )
+          .get() as { n: number } | undefined;
+        if (running && running.n > 0) {
+          return { triggered: false, reason: 'already-running' };
+        }
+      }
+    } catch {
+      // fail-open — if dream_cycles table is missing or unified memory not
+      // ready, we'd rather risk the rare lock than block dreaming entirely.
+    }
+
     // Run a quick dream cycle
     const { createDreamEngine } = await import('../../../learning/dream/index.js');
     const { createQEReasoningBank: createRB } = await import('../../../learning/qe-reasoning-bank.js');

--- a/src/cli/commands/hooks-handlers/hooks-dream-learning.ts
+++ b/src/cli/commands/hooks-handlers/hooks-dream-learning.ts
@@ -390,6 +390,27 @@ export async function persistTaskOutcome(opts: {
           WHERE id = ?
         `);
         const getPatternConfidence = db.prepare(`SELECT confidence FROM qe_patterns WHERE id = ?`);
+        // Issue #455: recordOutcome() is called with a synthetic
+        // `task:agent:taskId` patternId that never matches qe_patterns.id, so
+        // checkPatternPromotionWithCoherence() is skipped for the real UUIDs
+        // updated here. Without an inline promotion check, short-term patterns
+        // that cross the thresholds (successful_uses ≥ 3, success_rate ≥ 0.7,
+        // confidence ≥ 0.6) stay short-term forever — qe_patterns.long-term
+        // count never grows past zero.
+        const promotionSelectStmt = db.prepare(`
+          SELECT tier, successful_uses, success_rate, confidence
+          FROM qe_patterns
+          WHERE id = ?
+        `);
+        const promotionUpdateStmt = db.prepare(`
+          UPDATE qe_patterns
+          SET tier = 'long-term', updated_at = datetime('now')
+          WHERE id = ?
+            AND tier = 'short-term'
+            AND successful_uses >= 3
+            AND success_rate >= 0.7
+            AND confidence >= 0.6
+        `);
         for (const patternId of bridge.selectedPatternIds) {
           insertApp.run(
             `app-${Date.now()}-${randomUUID().slice(0, 8)}`,
@@ -404,6 +425,22 @@ export async function persistTaskOutcome(opts: {
             if (row) {
               const successInc = opts.success ? 1 : 0;
               updatePatternUsage.run(successInc, successInc, row.confidence, successInc, patternId);
+            }
+          } catch { /* fail-soft per pattern */ }
+          // Issue #455: re-read post-UPDATE state and promote if thresholds met.
+          // Guarded WHERE clause makes the UPDATE idempotent and no-op for
+          // already-long-term rows or rows below threshold.
+          try {
+            const pm = promotionSelectStmt.get(patternId) as
+              | { tier: string; successful_uses: number; success_rate: number; confidence: number }
+              | undefined;
+            if (
+              pm?.tier === 'short-term' &&
+              pm.successful_uses >= 3 &&
+              pm.success_rate >= 0.7 &&
+              pm.confidence >= 0.6
+            ) {
+              promotionUpdateStmt.run(patternId);
             }
           } catch { /* fail-soft per pattern */ }
         }

--- a/src/cli/commands/hooks-handlers/hooks-shared.ts
+++ b/src/cli/commands/hooks-handlers/hooks-shared.ts
@@ -314,6 +314,77 @@ export function printGuidance(guidance: string[]): void {
 }
 
 // ============================================================================
+// Stdin Event Helpers
+// ============================================================================
+
+/**
+ * Read piped stdin with a short timeout. Claude Code delivers
+ * UserPromptSubmit / PostToolUse / PreToolUse events as JSON on stdin —
+ * `$PROMPT`, `$TOOL_INPUT_file_path`, etc. are NOT exposed as env vars in
+ * every hook surface, so reading stdin is the only reliable fallback when
+ * the explicit CLI option resolves to an empty string.
+ *
+ * Returns '' when stdin is a TTY (interactive run) or no data arrives
+ * before the timeout. Never throws — a hook must never crash the host.
+ */
+export async function readStdinJsonEvent(timeoutMs = 500): Promise<string> {
+  if (process.stdin.isTTY) return '';
+  return new Promise<string>((resolve) => {
+    let data = '';
+    const timer = setTimeout(() => {
+      process.stdin.removeAllListeners();
+      process.stdin.pause();
+      resolve(data);
+    }, timeoutMs);
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => {
+      data += chunk;
+    });
+    process.stdin.on('end', () => {
+      clearTimeout(timer);
+      resolve(data);
+    });
+    process.stdin.on('error', () => {
+      clearTimeout(timer);
+      resolve(data);
+    });
+    process.stdin.resume();
+  });
+}
+
+/**
+ * Extract a file path from a Claude Code PostToolUse / PreToolUse hook event.
+ * Edit / Write / MultiEdit / NotebookEdit tools all put the target path in
+ * `tool_input.file_path` (snake_case from Claude Code) — older transports
+ * use `toolInput.file_path`. Returns '' when no recognized field is present.
+ *
+ * Exported for unit testing.
+ */
+export function extractFilePathFromEvent(raw: string): string {
+  if (!raw.trim()) return '';
+  let event: Record<string, unknown>;
+  try {
+    event = JSON.parse(raw);
+  } catch {
+    return '';
+  }
+  const toolInputSnake = event.tool_input as Record<string, unknown> | undefined;
+  const toolInputCamel = event.toolInput as Record<string, unknown> | undefined;
+  const candidates = [
+    toolInputSnake?.file_path,
+    toolInputSnake?.filePath,
+    toolInputCamel?.file_path,
+    toolInputCamel?.filePath,
+    event.file_path,
+    event.filePath,
+  ];
+  for (const c of candidates) {
+    if (typeof c === 'string' && c.trim()) return c;
+  }
+  return '';
+}
+
+// ============================================================================
 // Dream Scheduler & Learning — re-exported from hooks-dream-learning.ts
 // ============================================================================
 export {

--- a/src/cli/commands/hooks-handlers/routing-hooks.ts
+++ b/src/cli/commands/hooks-handlers/routing-hooks.ts
@@ -237,13 +237,40 @@ export function registerRoutingHooks(hooks: Command): void {
           )
         `).run(success ? 1 : 0, qualityScore);
 
+        // Issue #465: orphan-sentinel sweep. Sessions that terminate without
+        // firing Stop (context compact, process kill, IDE crash) leave their
+        // sentinels at quality_score=-1 forever — every subsequent post-route
+        // call only closes the most-recent one (LIMIT 1) and newer rows keep
+        // pre-empting old ones in the ORDER BY DESC. Reporter saw 122/149
+        // rows stuck at -1, inverting AVG(quality_score) to -0.717.
+        //
+        // We use the conservative base score (0.325 = no success/duration
+        // bonus) rather than the current turn's qualityScore: those orphans
+        // belong to UNKNOWN historical turns and shouldn't inherit the
+        // current turn's outcome. Tag with error='stale-sentinel' so
+        // precision-sensitive queries can filter them out.
+        const staleResult = db.prepare(`
+          UPDATE routing_outcomes
+          SET success = 0,
+              quality_score = 0.325,
+              duration_ms = 0,
+              error = 'stale-sentinel'
+          WHERE quality_score = -1
+            AND created_at < datetime('now', '-300 seconds')
+        `).run();
+
         if (options.json) {
           printJson({
             success: true,
             resolved: result.changes > 0,
+            staleSwept: staleResult.changes,
             qualityScore,
             turnSuccess: success,
           });
+        } else if (staleResult.changes > 0) {
+          console.log(
+            chalk.dim(`[hooks] post-route: swept ${staleResult.changes} stale sentinel(s)`),
+          );
         }
         return;
       } catch (error) {

--- a/src/cli/commands/hooks-handlers/routing-hooks.ts
+++ b/src/cli/commands/hooks-handlers/routing-hooks.ts
@@ -249,6 +249,12 @@ export function registerRoutingHooks(hooks: Command): void {
         // belong to UNKNOWN historical turns and shouldn't inherit the
         // current turn's outcome. Tag with error='stale-sentinel' so
         // precision-sensitive queries can filter them out.
+        // Discriminator mirrors the LIMIT-1 close above and #451's symmetric
+        // design: route sentinels are owned by post-route, pre-task sentinels
+        // (task_json carries "taskId") are owned by post-task. Sweeping a
+        // pre-task sentinel here would race with updateRoutingOutcomeQuality
+        // and break the ownership split. If pre-task sentinels orphan, that
+        // belongs in a separate fix.
         const staleResult = db.prepare(`
           UPDATE routing_outcomes
           SET success = 0,
@@ -256,6 +262,7 @@ export function registerRoutingHooks(hooks: Command): void {
               duration_ms = 0,
               error = 'stale-sentinel'
           WHERE quality_score = -1
+            AND task_json NOT LIKE '%"taskId"%'
             AND created_at < datetime('now', '-300 seconds')
         `).run();
 

--- a/src/cli/commands/hooks-handlers/routing-hooks.ts
+++ b/src/cli/commands/hooks-handlers/routing-hooks.ts
@@ -20,41 +20,8 @@ import {
   printJson,
   printError,
   printGuidance,
+  readStdinJsonEvent,
 } from './hooks-shared.js';
-
-/**
- * Read piped stdin with a short timeout. Claude Code delivers
- * UserPromptSubmit / PostToolUse / etc. events as JSON on stdin —
- * `$PROMPT` is NOT exposed as an env var, so reading stdin is the
- * only reliable way to recover the prompt body for routing.
- *
- * Returns '' when stdin is a TTY (interactive run) or no data arrives
- * before the timeout. Never throws — a hook must never crash the host.
- */
-async function readStdinJsonEvent(timeoutMs = 500): Promise<string> {
-  if (process.stdin.isTTY) return '';
-  return new Promise<string>((resolve) => {
-    let data = '';
-    const timer = setTimeout(() => {
-      process.stdin.removeAllListeners();
-      process.stdin.pause();
-      resolve(data);
-    }, timeoutMs);
-    process.stdin.setEncoding('utf8');
-    process.stdin.on('data', (chunk) => {
-      data += chunk;
-    });
-    process.stdin.on('end', () => {
-      clearTimeout(timer);
-      resolve(data);
-    });
-    process.stdin.on('error', () => {
-      clearTimeout(timer);
-      resolve(data);
-    });
-    process.stdin.resume();
-  });
-}
 
 /**
  * Extract a routable task description from a Claude Code hook event JSON

--- a/src/cli/commands/hooks-handlers/task-hooks.ts
+++ b/src/cli/commands/hooks-handlers/task-hooks.ts
@@ -349,10 +349,21 @@ export function registerTaskHooks(hooks: Command): void {
               success,
             });
 
+            // Issue #460: when --agent arrives empty (Claude Code does not
+            // expose $TOOL_RESULT_agent_id in PostToolUse context), `agent`
+            // resolves to 'unknown' and every Q-value lands in the same
+            // bucket — the router can never learn per-agent differentiation.
+            // The pre-task bridge already carries `agent: routing.recommendedAgent`
+            // which is the correct action key, so prefer that over 'unknown'.
+            const effectiveAgent =
+              agent === 'unknown' && outcome.bridge?.agent
+                ? outcome.bridge.agent
+                : agent;
+
             // Stream D (patch 150): apply 6-dim outcome quality to the
             // routing_outcomes sentinel that pre-task wrote with quality=-1.
             await updateRoutingOutcomeQuality({
-              agent,
+              agent: effectiveAgent,
               success,
               durationMs,
               qualityScore: outcome.qualityScore,
@@ -366,7 +377,7 @@ export function registerTaskHooks(hooks: Command): void {
                 priority: outcome.bridge.priority,
                 domain: outcome.bridge.domain,
                 complexityBucket: outcome.bridge.complexityBucket,
-                agent,
+                agent: effectiveAgent,
                 success,
               });
             }

--- a/src/cli/commands/hooks-handlers/task-hooks.ts
+++ b/src/cli/commands/hooks-handlers/task-hooks.ts
@@ -295,7 +295,12 @@ export function registerTaskHooks(hooks: Command): void {
         // Initialize hooks system and record learning outcome
         // BUG FIX: Must call getHooksSystem() FIRST to initialize, not check state.initialized
         let patternsLearned = 0;
-        let dreamResult: { triggered: boolean; reason?: string; insightsGenerated?: number } = { triggered: false };
+        let dreamResult: {
+          triggered: boolean;
+          reason?: string;
+          insightsGenerated?: number;
+          insightsApplied?: number;
+        } = { triggered: false };
 
         try {
           // Initialize system (creates ReasoningBank and HookRegistry)
@@ -391,6 +396,7 @@ export function registerTaskHooks(hooks: Command): void {
             dreamTriggered: dreamResult.triggered,
             dreamReason: dreamResult.reason,
             dreamInsights: dreamResult.insightsGenerated,
+            dreamInsightsApplied: dreamResult.insightsApplied,
           });
         } else {
           printSuccess(`Task completed: ${options.taskId || 'unknown'}`);
@@ -399,7 +405,11 @@ export function registerTaskHooks(hooks: Command): void {
             console.log(chalk.green(`  Patterns learned: ${patternsLearned}`));
           }
           if (dreamResult.triggered) {
-            console.log(chalk.blue(`  🌙 Dream cycle triggered (${dreamResult.reason}): ${dreamResult.insightsGenerated} insights`));
+            const appliedSuffix =
+              typeof dreamResult.insightsApplied === 'number'
+                ? `, ${dreamResult.insightsApplied} applied`
+                : '';
+            console.log(chalk.blue(`  🌙 Dream cycle triggered (${dreamResult.reason}): ${dreamResult.insightsGenerated} insights${appliedSuffix}`));
           }
         }
 

--- a/src/learning/qe-reasoning-bank.ts
+++ b/src/learning/qe-reasoning-bank.ts
@@ -590,19 +590,51 @@ export class QEReasoningBank implements IQEReasoningBank {
       byDomain[domain] = patternStoreStats.byDomain[domain] || 0;
     }
 
+    // DB fallback (#454): in-memory `this.stats` is reset on every process
+    // start, but every hook invocation spawns a fresh node. Without a DB
+    // fallback, `aqe hooks stats` always reports zeros even when historical
+    // routing_outcomes / qe_pattern_usage rows exist. We use the in-memory
+    // counters when they're non-zero (live, current-process data), otherwise
+    // fall back to aggregated DB totals.
+    let routingRequests = this.stats.routingRequests;
+    let avgRoutingConfidence =
+      this.stats.routingRequests > 0
+        ? this.stats.totalRoutingConfidence / this.stats.routingRequests
+        : 0;
+    let learningOutcomes = this.stats.learningOutcomes;
+    let patternSuccessRate =
+      this.stats.learningOutcomes > 0
+        ? this.stats.successfulOutcomes / this.stats.learningOutcomes
+        : 0;
+
+    if (routingRequests === 0 || learningOutcomes === 0) {
+      try {
+        const agg = this.getSqliteStore().getAggregateOutcomeStats();
+        if (routingRequests === 0 && agg.routingRequests > 0) {
+          routingRequests = agg.routingRequests;
+          avgRoutingConfidence = agg.avgRoutingConfidence;
+        }
+        if (learningOutcomes === 0 && agg.learningOutcomes > 0) {
+          learningOutcomes = agg.learningOutcomes;
+          // Prefer per-usage success rate (closer to recordOutcome semantics);
+          // fall back to qe_patterns.success_rate aggregate when no usage rows.
+          patternSuccessRate =
+            agg.learningOutcomes > 0
+              ? agg.successfulOutcomes / agg.learningOutcomes
+              : agg.avgPatternSuccessRate;
+        }
+      } catch {
+        // best-effort — never let stats reporting crash the host
+      }
+    }
+
     return {
       totalPatterns: patternStoreStats.totalPatterns,
       byDomain,
-      routingRequests: this.stats.routingRequests,
-      avgRoutingConfidence:
-        this.stats.routingRequests > 0
-          ? this.stats.totalRoutingConfidence / this.stats.routingRequests
-          : 0,
-      learningOutcomes: this.stats.learningOutcomes,
-      patternSuccessRate:
-        this.stats.learningOutcomes > 0
-          ? this.stats.successfulOutcomes / this.stats.learningOutcomes
-          : 0,
+      routingRequests,
+      avgRoutingConfidence,
+      learningOutcomes,
+      patternSuccessRate,
       patternStoreStats,
     };
   }

--- a/src/learning/rvf-pattern-store.ts
+++ b/src/learning/rvf-pattern-store.ts
@@ -139,6 +139,60 @@ export class RvfPatternStore implements IPatternStore {
         // SQLite auto-attach is best-effort
       }
     }
+
+    // Issue #462: purge orphan vectors that survived in patterns.rvf when an
+    // upgrade workflow rewrote qe_patterns via INSERT OR REPLACE without
+    // calling RvfPatternStore.delete() on the old IDs. Ghost vectors win
+    // cosine-similarity matches, route to non-existent pattern IDs, and
+    // every learning write fails silently. Run once on init.
+    await this.purgeOrphanedVectors();
+  }
+
+  /**
+   * Compare the RVF vector count with the SQLite pattern count; if RVF has
+   * more rows, read the idmap.json and delete any vector IDs that no longer
+   * have a matching qe_patterns row.
+   *
+   * Fail-open: any error in the purge path is swallowed so a stale or
+   * corrupted idmap can't keep the store from initializing (#462).
+   */
+  private async purgeOrphanedVectors(): Promise<void> {
+    if (!this.adapter || !this.sqliteStore) return;
+    try {
+      const rvfCount = this.adapter.status()?.totalVectors ?? 0;
+      const dbCount = this.sqliteStore.getStats()?.totalPatterns ?? 0;
+      if (rvfCount <= dbCount) return;
+
+      const { readFileSync, existsSync } = await import('node:fs');
+      const idmapPath = `${this.rvfPath}.idmap.json`;
+      if (!existsSync(idmapPath)) return;
+
+      const idmap = JSON.parse(readFileSync(idmapPath, 'utf-8')) as {
+        entries?: Array<[string, number]>;
+      };
+      const rvfIds = new Set<string>(
+        (idmap.entries ?? [])
+          .map((e) => (Array.isArray(e) ? e[0] : undefined))
+          .filter((id): id is string => typeof id === 'string'),
+      );
+
+      const dbIds = new Set<string>(
+        this.sqliteStore.getPatterns({ limit: 10_000 }).map((p) => p.id),
+      );
+
+      const orphans = [...rvfIds].filter((id) => !dbIds.has(id));
+      if (orphans.length === 0) return;
+
+      this.adapter.delete(orphans);
+      console.log(
+        `[RvfPatternStore] Removed ${orphans.length} ghost vectors (index ${rvfCount} > DB ${dbCount})`,
+      );
+    } catch (error) {
+      // fail-open: a stale idmap or read error must not block initialization
+      console.warn(
+        `[RvfPatternStore] orphan purge skipped: ${toErrorMessage(error)}`,
+      );
+    }
   }
 
   async dispose(): Promise<void> {

--- a/src/learning/sqlite-persistence.ts
+++ b/src/learning/sqlite-persistence.ts
@@ -787,6 +787,80 @@ export class SQLitePatternStore {
   }
 
   /**
+   * Aggregate outcome counters used by QEReasoningBank.getStats() as a fallback
+   * when the in-memory `this.stats` object is zero — every hook subprocess
+   * starts with a fresh counter, so without this fallback observability is
+   * always blank (#454).
+   *
+   * routing_outcomes and qe_pattern_usage live in the same unified memory.db
+   * as qe_patterns. avgConfidence/avgSuccessRate return 0 when the source
+   * tables are empty rather than NaN.
+   */
+  getAggregateOutcomeStats(): {
+    routingRequests: number;
+    avgRoutingConfidence: number;
+    successfulRoutings: number;
+    learningOutcomes: number;
+    successfulOutcomes: number;
+    avgPatternSuccessRate: number;
+  } {
+    const empty = {
+      routingRequests: 0,
+      avgRoutingConfidence: 0,
+      successfulRoutings: 0,
+      learningOutcomes: 0,
+      successfulOutcomes: 0,
+      avgPatternSuccessRate: 0,
+    };
+    if (!this.db) return empty;
+    const safeGet = <T>(sql: string): T | undefined => {
+      try {
+        return this.db!.prepare(sql).get() as T | undefined;
+      } catch {
+        return undefined;
+      }
+    };
+
+    // routing_outcomes carries (success, quality_score) per closed turn.
+    // Sentinels still have quality_score = -1, so filter to closed rows.
+    const routing = safeGet<{
+      total: number;
+      closed: number;
+      avg_q: number | null;
+      succ: number;
+    }>(`
+      SELECT
+        COUNT(*) AS total,
+        COUNT(CASE WHEN quality_score >= 0 THEN 1 END) AS closed,
+        AVG(CASE WHEN quality_score >= 0 THEN quality_score END) AS avg_q,
+        COALESCE(SUM(CASE WHEN success = 1 THEN 1 ELSE 0 END), 0) AS succ
+      FROM routing_outcomes
+    `);
+
+    const usage = safeGet<{ total: number; succ: number }>(`
+      SELECT
+        COUNT(*) AS total,
+        COALESCE(SUM(CASE WHEN success = 1 THEN 1 ELSE 0 END), 0) AS succ
+      FROM qe_pattern_usage
+    `);
+
+    const patternAvg = safeGet<{ avg_sr: number | null }>(`
+      SELECT AVG(success_rate) AS avg_sr
+      FROM qe_patterns
+      WHERE usage_count > 0
+    `);
+
+    return {
+      routingRequests: routing?.total ?? 0,
+      avgRoutingConfidence: routing?.avg_q ?? 0,
+      successfulRoutings: routing?.succ ?? 0,
+      learningOutcomes: usage?.total ?? 0,
+      successfulOutcomes: usage?.succ ?? 0,
+      avgPatternSuccessRate: patternAvg?.avg_sr ?? 0,
+    };
+  }
+
+  /**
    * Check if there's any historical data (embeddings, usage, trajectories)
    * even if qe_patterns is empty. Used to detect data loss vs fresh database.
    */

--- a/tests/unit/cli/commands/consolidation-cli-hook.test.ts
+++ b/tests/unit/cli/commands/consolidation-cli-hook.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Regression: issue #464
+ *
+ * consolidateExperiencesToPatterns() previously excluded `agent='cli-hook'`
+ * rows because issue #348 had observed low-quality Bash telemetry (quality
+ * ~0.40, success_rate ~0.24) flooding the pipeline. But post-edit also
+ * tags experiences with agent='cli-hook', and those rows have quality
+ * ~0.75 and success_rate ~1.0 — well above the HAVING thresholds. The
+ * agent-name filter blanket-excluded the dominant share of high-quality
+ * experiences and the consolidation pipeline never produced any patterns.
+ *
+ * The fix: remove the agent-name filter. The HAVING clause
+ * (avg_quality >= 0.5 AND success_rate >= 0.6 AND cnt >= 3) is the real
+ * quality gate. This test seeds a mix of high-quality cli-hook rows and
+ * low-quality cli-hook rows, runs consolidation, and asserts only the
+ * high-quality group creates a pattern.
+ */
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const { fakeUnifiedMemoryFactory } = vi.hoisted(() => ({
+  fakeUnifiedMemoryFactory: vi.fn(),
+}));
+
+vi.mock('../../../../src/kernel/unified-memory.js', () => ({
+  getUnifiedMemory: () => fakeUnifiedMemoryFactory(),
+  findProjectRoot: () => process.cwd(),
+}));
+
+// Embedding helper does heavy I/O; stub it out so consolidation tests stay
+// hermetic. Pattern row creation is what we care about.
+vi.mock('../../../../src/learning/embed-and-insert-pattern.js', () => ({
+  ensurePatternEmbedding: vi.fn(async () => undefined),
+}));
+
+import Database from 'better-sqlite3';
+import { consolidateExperiencesToPatterns } from '../../../../src/cli/commands/hooks-handlers/hooks-dream-learning.js';
+
+const createSchema = (db: Database.Database): void => {
+  db.exec(`
+    CREATE TABLE captured_experiences (
+      id TEXT PRIMARY KEY,
+      task TEXT,
+      agent TEXT,
+      domain TEXT,
+      success INTEGER,
+      quality REAL,
+      duration_ms INTEGER,
+      started_at TEXT,
+      completed_at TEXT,
+      source TEXT,
+      application_count INTEGER DEFAULT 0,
+      consolidated_into TEXT,
+      consolidation_count INTEGER DEFAULT 1,
+      quality_updated_at TEXT,
+      reuse_success_count INTEGER DEFAULT 0,
+      reuse_failure_count INTEGER DEFAULT 0
+    );
+    CREATE TABLE qe_patterns (
+      id TEXT PRIMARY KEY, pattern_type TEXT, qe_domain TEXT, domain TEXT,
+      name TEXT, description TEXT, confidence REAL DEFAULT 0.5,
+      usage_count INTEGER DEFAULT 0, successful_uses INTEGER DEFAULT 0,
+      success_rate REAL DEFAULT 0.0, quality_score REAL DEFAULT 0.0,
+      tier TEXT DEFAULT 'short-term',
+      template_json TEXT, context_json TEXT,
+      created_at TEXT, updated_at TEXT
+    );
+  `);
+};
+
+const seed = (
+  db: Database.Database,
+  rows: Array<{ agent: string; domain: string; quality: number; success: 0 | 1; source: string }>,
+): void => {
+  const insert = db.prepare(`
+    INSERT INTO captured_experiences
+      (id, task, agent, domain, success, quality, duration_ms, source, application_count)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)
+  `);
+  for (let i = 0; i < rows.length; i++) {
+    const r = rows[i];
+    insert.run(`exp-${i}`, `t${i}`, r.agent, r.domain, r.success, r.quality, 100, r.source);
+  }
+};
+
+describe('consolidation does not exclude cli-hook agent (#464)', () => {
+  let tmpDir: string;
+  let db: Database.Database;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aqe-cli-hook-consol-'));
+    db = new Database(path.join(tmpDir, 'unified.db'));
+    createSchema(db);
+    fakeUnifiedMemoryFactory.mockReturnValue({
+      isInitialized: () => true,
+      initialize: async () => undefined,
+      getDatabase: () => db,
+    });
+  });
+
+  afterEach(() => {
+    try { db.close(); } catch { /* ignore */ }
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('creates a pattern from high-quality cli-hook experiences (post-edit shape)', async () => {
+    // 4 post-edit cli-hook rows, all success, avg_quality 0.75 — well above
+    // HAVING thresholds. Pre-fix this returned 0; now we expect 1 pattern.
+    seed(db, [
+      { agent: 'cli-hook', domain: 'code-intelligence', quality: 0.75, success: 1, source: 'cli-hook-post-edit' },
+      { agent: 'cli-hook', domain: 'code-intelligence', quality: 0.75, success: 1, source: 'cli-hook-post-edit' },
+      { agent: 'cli-hook', domain: 'code-intelligence', quality: 0.75, success: 1, source: 'cli-hook-post-edit' },
+      { agent: 'cli-hook', domain: 'code-intelligence', quality: 0.75, success: 1, source: 'cli-hook-post-edit' },
+    ]);
+
+    const created = await consolidateExperiencesToPatterns();
+    expect(created).toBe(1);
+
+    const patterns = db
+      .prepare(`SELECT name, success_rate, confidence, tier, usage_count FROM qe_patterns`)
+      .all() as Array<{ name: string; success_rate: number; confidence: number; tier: string; usage_count: number }>;
+    expect(patterns).toHaveLength(1);
+    expect(patterns[0].name).toMatch(/^cli-hook-code-intelligence-\d{4}-\d{2}$/);
+    expect(patterns[0].success_rate).toBeCloseTo(1.0, 5);
+    expect(patterns[0].usage_count).toBe(4);
+    expect(patterns[0].tier).toBe('short-term');
+  });
+
+  it('does NOT create a pattern from low-quality cli-hook experiences (HAVING gate)', async () => {
+    // 4 rows: quality 0.4, success_rate 0.25. Mirrors the #348 Bash-telemetry
+    // shape. HAVING filters this out even though the agent is now eligible.
+    seed(db, [
+      { agent: 'cli-hook', domain: 'shell-ops', quality: 0.4, success: 1, source: 'cli-hook-post-command' },
+      { agent: 'cli-hook', domain: 'shell-ops', quality: 0.4, success: 0, source: 'cli-hook-post-command' },
+      { agent: 'cli-hook', domain: 'shell-ops', quality: 0.4, success: 0, source: 'cli-hook-post-command' },
+      { agent: 'cli-hook', domain: 'shell-ops', quality: 0.4, success: 0, source: 'cli-hook-post-command' },
+    ]);
+
+    const created = await consolidateExperiencesToPatterns();
+    expect(created).toBe(0);
+    const count = (db.prepare(`SELECT COUNT(*) AS n FROM qe_patterns`).get() as { n: number }).n;
+    expect(count).toBe(0);
+  });
+
+  it('still consolidates non-cli-hook agents the same way it always did', async () => {
+    seed(db, [
+      { agent: 'qe-test-architect', domain: 'test-generation', quality: 0.8, success: 1, source: 'mcp-task' },
+      { agent: 'qe-test-architect', domain: 'test-generation', quality: 0.8, success: 1, source: 'mcp-task' },
+      { agent: 'qe-test-architect', domain: 'test-generation', quality: 0.8, success: 1, source: 'mcp-task' },
+    ]);
+
+    const created = await consolidateExperiencesToPatterns();
+    expect(created).toBe(1);
+
+    const pattern = db.prepare(`SELECT name FROM qe_patterns`).get() as { name: string };
+    expect(pattern.name).toMatch(/^qe-test-architect-test-generation-\d{4}-\d{2}$/);
+  });
+
+  it('marks consolidated experiences as processed (application_count > 0)', async () => {
+    seed(db, [
+      { agent: 'cli-hook', domain: 'code-intelligence', quality: 0.8, success: 1, source: 'cli-hook-post-edit' },
+      { agent: 'cli-hook', domain: 'code-intelligence', quality: 0.8, success: 1, source: 'cli-hook-post-edit' },
+      { agent: 'cli-hook', domain: 'code-intelligence', quality: 0.8, success: 1, source: 'cli-hook-post-edit' },
+    ]);
+
+    await consolidateExperiencesToPatterns();
+    const remaining = (
+      db.prepare(`SELECT COUNT(*) AS n FROM captured_experiences WHERE application_count = 0`).get() as { n: number }
+    ).n;
+    expect(remaining).toBe(0);
+  });
+});

--- a/tests/unit/cli/commands/hooks-dream-apply-insights.test.ts
+++ b/tests/unit/cli/commands/hooks-dream-apply-insights.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Regression: issue #456
+ *
+ * checkAndTriggerDream() previously generated insights via dreamEngine.dream()
+ * but never called dreamEngine.applyInsight(). DreamScheduler.autoApplyInsights
+ * wires this in the daemon path, but the hook-driven path had no equivalent —
+ * so every hook-fired dream cycle left applied=0 rows piling up indefinitely
+ * (#456 evidence: 378 unapplied / 9 applied).
+ *
+ * This test mocks the dream engine and the reasoning bank, feeds three
+ * insights (high-confidence actionable, low-confidence actionable,
+ * non-actionable), and asserts applyInsight() is called exactly once — for the
+ * single insight that crosses both gates.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+  dreamMock,
+  applyInsightMock,
+  initializeMock,
+  closeMock,
+  loadPatternsAsConceptsMock,
+} = vi.hoisted(() => ({
+  dreamMock: vi.fn(),
+  applyInsightMock: vi.fn(),
+  initializeMock: vi.fn(),
+  closeMock: vi.fn(),
+  loadPatternsAsConceptsMock: vi.fn(),
+}));
+
+vi.mock('../../../../src/learning/dream/index.js', () => ({
+  createDreamEngine: vi.fn(() => ({
+    initialize: initializeMock,
+    loadPatternsAsConcepts: loadPatternsAsConceptsMock,
+    dream: dreamMock,
+    applyInsight: applyInsightMock,
+    close: closeMock,
+  })),
+}));
+
+vi.mock('../../../../src/learning/qe-reasoning-bank.js', () => ({
+  createQEReasoningBank: vi.fn(() => ({
+    initialize: async () => undefined,
+    searchPatterns: async () => ({ success: true, value: [] }),
+  })),
+}));
+
+import { checkAndTriggerDream } from '../../../../src/cli/commands/hooks-handlers/hooks-dream-learning.js';
+import type { MemoryBackend } from '../../../../src/kernel/interfaces.js';
+
+function createFakeMemory(lastDreamMsAgo: number, experienceCount: number): MemoryBackend {
+  const store = new Map<string, unknown>();
+  store.set('dream-scheduler:hook-state', {
+    lastDreamTime: new Date(Date.now() - lastDreamMsAgo).toISOString(),
+    experienceCount,
+    sessionStartTime: new Date(Date.now() - 7_200_000).toISOString(),
+    totalDreamsThisSession: 0,
+  });
+  return {
+    initialize: async () => undefined,
+    dispose: async () => undefined,
+    get: async <T>(key: string) => store.get(key) as T | undefined,
+    set: async (key, value) => {
+      store.set(key, value);
+    },
+    delete: async (key) => store.delete(key),
+    has: async (key) => store.has(key),
+    search: async () => [],
+    vectorSearch: async () => [],
+    storeVector: async () => undefined,
+    count: async () => 0,
+    hasCodeIntelligenceIndex: async () => false,
+  } as unknown as MemoryBackend;
+}
+
+describe('checkAndTriggerDream auto-applies high-confidence insights (#456)', () => {
+  beforeEach(() => {
+    dreamMock.mockReset();
+    applyInsightMock.mockReset();
+    initializeMock.mockReset();
+    closeMock.mockReset();
+    loadPatternsAsConceptsMock.mockReset();
+
+    initializeMock.mockResolvedValue(undefined);
+    closeMock.mockResolvedValue(undefined);
+    loadPatternsAsConceptsMock.mockResolvedValue(undefined);
+    applyInsightMock.mockImplementation(async (id: string) => ({
+      success: true,
+      patternId: `dream-pattern-${id}`,
+    }));
+  });
+
+  it('applies insights that are actionable AND confidenceScore >= 0.5', async () => {
+    dreamMock.mockResolvedValue({
+      cycle: {},
+      insights: [
+        { id: 'i-high', actionable: true, confidenceScore: 0.9 },
+        { id: 'i-low', actionable: true, confidenceScore: 0.3 },
+        { id: 'i-non-actionable', actionable: false, confidenceScore: 0.95 },
+        { id: 'i-edge', actionable: true, confidenceScore: 0.5 }, // exactly at threshold
+      ],
+      activationStats: { totalIterations: 1, peakActivation: 1, nodesActivated: 1 },
+      patternsCreated: 0,
+    });
+
+    const memory = createFakeMemory(2 * 3600_000, 25); // 2h ago + 25 experiences
+    const result = await checkAndTriggerDream(memory);
+
+    expect(result.triggered).toBe(true);
+    expect(result.insightsGenerated).toBe(4);
+    expect(result.insightsApplied).toBe(2);
+
+    // Only i-high and i-edge satisfy actionable && confidenceScore >= 0.5
+    expect(applyInsightMock).toHaveBeenCalledTimes(2);
+    const appliedIds = applyInsightMock.mock.calls.map((c) => c[0]).sort();
+    expect(appliedIds).toEqual(['i-edge', 'i-high']);
+  });
+
+  it('does NOT crash when applyInsight throws — surfaces the count up to the failure', async () => {
+    dreamMock.mockResolvedValue({
+      cycle: {},
+      insights: [
+        { id: 'i-1', actionable: true, confidenceScore: 0.8 },
+        { id: 'i-2', actionable: true, confidenceScore: 0.8 },
+      ],
+      activationStats: { totalIterations: 1, peakActivation: 1, nodesActivated: 1 },
+      patternsCreated: 0,
+    });
+    applyInsightMock.mockImplementationOnce(async () => ({
+      success: true,
+      patternId: 'dream-pattern-i-1',
+    }));
+    applyInsightMock.mockImplementationOnce(async () => {
+      throw new Error('db locked');
+    });
+
+    const memory = createFakeMemory(2 * 3600_000, 25);
+    const result = await checkAndTriggerDream(memory);
+
+    expect(result.triggered).toBe(true);
+    expect(result.insightsApplied).toBe(1);
+  });
+
+  it('counts only successful applyInsight results', async () => {
+    dreamMock.mockResolvedValue({
+      cycle: {},
+      insights: [{ id: 'i-1', actionable: true, confidenceScore: 0.9 }],
+      activationStats: { totalIterations: 1, peakActivation: 1, nodesActivated: 1 },
+      patternsCreated: 0,
+    });
+    applyInsightMock.mockResolvedValue({ success: false, error: 'already applied' });
+
+    const memory = createFakeMemory(2 * 3600_000, 25);
+    const result = await checkAndTriggerDream(memory);
+
+    expect(result.triggered).toBe(true);
+    expect(result.insightsApplied).toBe(0);
+  });
+
+  it('does not fire when min gap has not elapsed', async () => {
+    const memory = createFakeMemory(60_000, 100); // 1min ago — under 5min gap
+    const result = await checkAndTriggerDream(memory);
+    expect(result.triggered).toBe(false);
+    expect(applyInsightMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/cli/commands/hooks-dream-concurrent-guard.test.ts
+++ b/tests/unit/cli/commands/hooks-dream-concurrent-guard.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Regression: issue #461
+ *
+ * Multiple Claude Code hooks fire concurrently. When dream eligibility
+ * conditions are met, every parallel process sees the same stale
+ * `dreamState.lastDreamTime`, races past the time/experience trigger, and
+ * tries to start its own ~10-second dream cycle. They all hit the WAL writer
+ * at roughly the same moment and 35% fail with `database is locked` —
+ * `busy_timeout` only serializes sequential contention, not simultaneous
+ * writers.
+ *
+ * `checkAndTriggerDream` now peeks at `dream_cycles` before opening the
+ * engine: if a row with status='running' AND start_time > now-60s exists,
+ * it bails out with reason='already-running'. This test mocks the unified
+ * memory layer and asserts both branches (guard fires, guard misses).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+  dreamMock,
+  applyInsightMock,
+  initializeMock,
+  closeMock,
+  loadPatternsAsConceptsMock,
+  prepareMock,
+} = vi.hoisted(() => ({
+  dreamMock: vi.fn(),
+  applyInsightMock: vi.fn(),
+  initializeMock: vi.fn(),
+  closeMock: vi.fn(),
+  loadPatternsAsConceptsMock: vi.fn(),
+  prepareMock: vi.fn(),
+}));
+
+vi.mock('../../../../src/learning/dream/index.js', () => ({
+  createDreamEngine: vi.fn(() => ({
+    initialize: initializeMock,
+    loadPatternsAsConcepts: loadPatternsAsConceptsMock,
+    dream: dreamMock,
+    applyInsight: applyInsightMock,
+    close: closeMock,
+  })),
+}));
+
+vi.mock('../../../../src/learning/qe-reasoning-bank.js', () => ({
+  createQEReasoningBank: vi.fn(() => ({
+    initialize: async () => undefined,
+    searchPatterns: async () => ({ success: true, value: [] }),
+  })),
+}));
+
+vi.mock('../../../../src/kernel/unified-memory.js', () => ({
+  findProjectRoot: () => process.cwd(),
+  getUnifiedMemory: () => ({
+    isInitialized: () => true,
+    initialize: async () => undefined,
+    getDatabase: () => ({
+      prepare: prepareMock,
+    }),
+  }),
+}));
+
+import { checkAndTriggerDream } from '../../../../src/cli/commands/hooks-handlers/hooks-dream-learning.js';
+import type { MemoryBackend } from '../../../../src/kernel/interfaces.js';
+
+function createFakeMemory(lastDreamMsAgo: number, experienceCount: number): MemoryBackend {
+  const store = new Map<string, unknown>();
+  store.set('dream-scheduler:hook-state', {
+    lastDreamTime: new Date(Date.now() - lastDreamMsAgo).toISOString(),
+    experienceCount,
+    sessionStartTime: new Date(Date.now() - 7_200_000).toISOString(),
+    totalDreamsThisSession: 0,
+  });
+  return {
+    initialize: async () => undefined,
+    dispose: async () => undefined,
+    get: async <T>(key: string) => store.get(key) as T | undefined,
+    set: async (key, value) => {
+      store.set(key, value);
+    },
+    delete: async (key) => store.delete(key),
+    has: async (key) => store.has(key),
+    search: async () => [],
+    vectorSearch: async () => [],
+    storeVector: async () => undefined,
+    count: async () => 0,
+    hasCodeIntelligenceIndex: async () => false,
+  } as unknown as MemoryBackend;
+}
+
+describe('checkAndTriggerDream skips when a recent cycle is still running (#461)', () => {
+  beforeEach(() => {
+    dreamMock.mockReset();
+    applyInsightMock.mockReset();
+    initializeMock.mockReset();
+    closeMock.mockReset();
+    loadPatternsAsConceptsMock.mockReset();
+    prepareMock.mockReset();
+
+    initializeMock.mockResolvedValue(undefined);
+    closeMock.mockResolvedValue(undefined);
+    loadPatternsAsConceptsMock.mockResolvedValue(undefined);
+    dreamMock.mockResolvedValue({
+      cycle: {},
+      insights: [],
+      activationStats: { totalIterations: 1, peakActivation: 1, nodesActivated: 1 },
+      patternsCreated: 0,
+    });
+  });
+
+  it('returns reason="already-running" when a recent running cycle exists', async () => {
+    // dream_cycles guard query returns n=1
+    prepareMock.mockReturnValueOnce({
+      get: () => ({ n: 1 }),
+    });
+
+    const memory = createFakeMemory(2 * 3600_000, 25);
+    const result = await checkAndTriggerDream(memory);
+
+    expect(result.triggered).toBe(false);
+    expect(result.reason).toBe('already-running');
+    // Dream engine must NOT have been opened/run
+    expect(initializeMock).not.toHaveBeenCalled();
+    expect(dreamMock).not.toHaveBeenCalled();
+  });
+
+  it('proceeds normally when no recent running cycle exists', async () => {
+    // dream_cycles guard query returns n=0
+    prepareMock.mockReturnValueOnce({
+      get: () => ({ n: 0 }),
+    });
+
+    const memory = createFakeMemory(2 * 3600_000, 25);
+    const result = await checkAndTriggerDream(memory);
+
+    expect(result.triggered).toBe(true);
+    expect(result.reason).toBe('time-interval');
+    expect(dreamMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails open: if the guard query throws, the dream still runs', async () => {
+    prepareMock.mockImplementationOnce(() => {
+      throw new Error('dream_cycles table not yet created');
+    });
+
+    const memory = createFakeMemory(2 * 3600_000, 25);
+    const result = await checkAndTriggerDream(memory);
+
+    expect(result.triggered).toBe(true);
+    expect(dreamMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/cli/commands/hooks-editing.test.ts
+++ b/tests/unit/cli/commands/hooks-editing.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Editing hook CLI - file_path extraction tests (#453)
+ *
+ * Regression coverage for the PostToolUse stdin path. Claude Code delivers
+ * the edited file path on stdin as a JSON event (tool_input.file_path), not
+ * as a reliable env var. Before this fix, the init template passed
+ * --file "$TOOL_INPUT_file_path" which expanded to "" in many hook surfaces
+ * — so 88% of captured_experiences rows ended up tagged `task = "edit: "`
+ * with no file path, useless embeddings, and zero pattern lookups.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { extractFilePathFromEvent } from '../../../../src/cli/commands/hooks-handlers/hooks-shared.js';
+
+describe('extractFilePathFromEvent', () => {
+  it('returns empty string for empty input', () => {
+    expect(extractFilePathFromEvent('')).toBe('');
+    expect(extractFilePathFromEvent('   ')).toBe('');
+  });
+
+  it('extracts file_path from PostToolUse Edit events (snake_case)', () => {
+    const event = JSON.stringify({
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Edit',
+      tool_input: {
+        file_path: '/workspaces/agentic-qe/src/example.ts',
+        old_string: 'foo',
+        new_string: 'bar',
+      },
+    });
+    expect(extractFilePathFromEvent(event)).toBe(
+      '/workspaces/agentic-qe/src/example.ts'
+    );
+  });
+
+  it('extracts file_path from Write events', () => {
+    const event = JSON.stringify({
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Write',
+      tool_input: {
+        file_path: '/tmp/output.json',
+        content: '{}',
+      },
+    });
+    expect(extractFilePathFromEvent(event)).toBe('/tmp/output.json');
+  });
+
+  it('extracts file_path from camelCase toolInput envelopes', () => {
+    const event = JSON.stringify({
+      toolInput: { file_path: '/src/legacy.ts' },
+    });
+    expect(extractFilePathFromEvent(event)).toBe('/src/legacy.ts');
+  });
+
+  it('falls back to camelCase filePath inside snake_case envelope', () => {
+    const event = JSON.stringify({
+      tool_input: { filePath: '/src/mixed.ts' },
+    });
+    expect(extractFilePathFromEvent(event)).toBe('/src/mixed.ts');
+  });
+
+  it('falls back to top-level file_path when no tool_input envelope is present', () => {
+    const event = JSON.stringify({ file_path: '/src/top-level.ts' });
+    expect(extractFilePathFromEvent(event)).toBe('/src/top-level.ts');
+  });
+
+  it('returns empty string when no recognized field is present', () => {
+    const event = JSON.stringify({ unrelated: 'data', count: 5 });
+    expect(extractFilePathFromEvent(event)).toBe('');
+  });
+
+  it('ignores empty or whitespace-only file_path candidates', () => {
+    const event = JSON.stringify({
+      tool_input: { file_path: '   ' },
+      toolInput: { file_path: '/src/winner.ts' },
+    });
+    expect(extractFilePathFromEvent(event)).toBe('/src/winner.ts');
+  });
+
+  it('does not crash on malformed JSON — returns empty string', () => {
+    expect(extractFilePathFromEvent('{not valid json')).toBe('');
+  });
+
+  it('does not throw on non-string file_path values', () => {
+    const event = JSON.stringify({ tool_input: { file_path: 42 } });
+    expect(extractFilePathFromEvent(event)).toBe('');
+  });
+});

--- a/tests/unit/cli/commands/post-route-sentinel-sweep.test.ts
+++ b/tests/unit/cli/commands/post-route-sentinel-sweep.test.ts
@@ -182,28 +182,32 @@ describe('post-route sweeps stale sentinels (#465)', () => {
   });
 
   it('skips pre-task sentinels (task_json LIKE %"taskId"%) — those are owned by post-task', async () => {
-    // Pre-task sentinel: task_json carries `"taskId"`. The LIMIT-1 close
-    // discriminator filters these out — but the stale sweep does NOT
-    // filter by taskId because pre-task sentinels are post-task's
-    // responsibility to close (different lifecycle). However, if they
-    // genuinely become orphaned (post-task never fired), the sweep is
-    // still the right place to clean them up. Document the current
-    // behavior: the LIMIT-1 close skips them; the sweep does NOT.
-    insertSentinel(db, 'pre-task-sentinel', "datetime('now', '-10 seconds')", '{"taskId":"abc"}');
+    // Pre-task sentinels carry "taskId" in task_json and are owned by
+    // post-task / updateRoutingOutcomeQuality. The discriminator
+    // `task_json NOT LIKE '%"taskId"%'` is applied to BOTH the LIMIT-1
+    // close AND the stale sweep, so even a pre-task sentinel that's been
+    // sitting around for hours stays untouched here. This mirrors the
+    // symmetric ownership split established in #451.
+    insertSentinel(db, 'pre-task-old', "datetime('now', '-1 hour')", '{"taskId":"abc"}');
+    insertSentinel(db, 'pre-task-fresh', "datetime('now', '-10 seconds')", '{"taskId":"xyz"}');
     insertSentinel(db, 'fresh-route', "datetime('now', '-5 seconds')");
 
     await runPostRoute(true);
 
-    // The route sentinel should be resolved by LIMIT-1
+    // The route sentinel resolves via LIMIT-1
     const fresh = db
       .prepare(`SELECT quality_score FROM routing_outcomes WHERE id = 'fresh-route'`)
       .get() as { quality_score: number };
     expect(fresh.quality_score).toBeCloseTo(0.675, 5);
 
-    // The pre-task sentinel is still at -1 (too new for sweep, skipped by LIMIT-1)
-    const preTask = db
-      .prepare(`SELECT quality_score FROM routing_outcomes WHERE id = 'pre-task-sentinel'`)
-      .get() as { quality_score: number };
-    expect(preTask.quality_score).toBe(-1);
+    // Both pre-task sentinels stay at -1 — old one rejected by sweep
+    // discriminator, fresh one rejected by LIMIT-1 discriminator.
+    const preTasks = db
+      .prepare(`SELECT id, quality_score, error FROM routing_outcomes WHERE id LIKE 'pre-task-%'`)
+      .all() as Array<{ id: string; quality_score: number; error: string | null }>;
+    for (const row of preTasks) {
+      expect(row.quality_score).toBe(-1);
+      expect(row.error).not.toBe('stale-sentinel');
+    }
   });
 });

--- a/tests/unit/cli/commands/post-route-sentinel-sweep.test.ts
+++ b/tests/unit/cli/commands/post-route-sentinel-sweep.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Regression: issue #465
+ *
+ * post-route closed routing_outcomes sentinels one at a time (LIMIT 1).
+ * Sessions that terminated without firing Stop — compact, kill, crash —
+ * left their sentinels at quality_score=-1 forever, and newer sessions
+ * kept pre-empting them in the ORDER BY DESC ordering. The reporter saw
+ * 122/149 rows stuck at -1, inverting AVG(quality_score) from a real
+ * +0.666 to an observed -0.717.
+ *
+ * Fix: after the LIMIT-1 close, run a sweep UPDATE on sentinels older than
+ * 5 minutes, setting quality_score=0.325 (conservative base) and tagging
+ * error='stale-sentinel' so precision-sensitive queries can filter them.
+ */
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Command } from 'commander';
+
+const { fakeUnifiedMemoryFactory } = vi.hoisted(() => ({
+  fakeUnifiedMemoryFactory: vi.fn(),
+}));
+
+vi.mock('../../../../src/kernel/unified-memory.js', () => ({
+  getUnifiedMemory: () => fakeUnifiedMemoryFactory(),
+  findProjectRoot: () => process.cwd(),
+}));
+
+// hooks-shared.ts builds a CoherenceService and ReasoningBank on import;
+// only stub the few helpers that post-route actually calls. (Re-importing
+// the actual module would pull in heavy WASM init we don't need.)
+vi.mock('../../../../src/cli/commands/hooks-handlers/hooks-shared.js', () => ({
+  applyHookBusyTimeout: vi.fn(),
+  getHooksSystem: vi.fn(),
+  createHybridBackendWithTimeout: vi.fn(),
+  incrementDreamExperience: vi.fn(),
+  printJson: (data: unknown) => {
+    // capture in a global the tests can read
+    (globalThis as unknown as { __lastJson: unknown }).__lastJson = data;
+  },
+  printError: vi.fn(),
+  printGuidance: vi.fn(),
+  readStdinJsonEvent: vi.fn(),
+}));
+
+import Database from 'better-sqlite3';
+import { registerRoutingHooks } from '../../../../src/cli/commands/hooks-handlers/routing-hooks.js';
+
+const createSchema = (db: Database.Database): void => {
+  db.exec(`
+    CREATE TABLE routing_outcomes (
+      id TEXT PRIMARY KEY,
+      task_json TEXT,
+      decision_json TEXT,
+      used_agent TEXT,
+      followed_recommendation INTEGER,
+      success INTEGER,
+      quality_score REAL,
+      duration_ms INTEGER,
+      error TEXT,
+      created_at TEXT DEFAULT (datetime('now'))
+    );
+  `);
+};
+
+const insertSentinel = (
+  db: Database.Database,
+  id: string,
+  createdAtExpr: string,
+  taskJson = '{"description":"x"}',
+): void => {
+  // created_at must be a SQL expression (e.g. datetime('now','-10 minutes')),
+  // not a parameter — better-sqlite3's bound parameters are sent as TEXT
+  // and the sweep predicate compares them as ISO strings.
+  db.prepare(
+    `INSERT INTO routing_outcomes
+      (id, task_json, used_agent, followed_recommendation,
+       success, quality_score, duration_ms, error, created_at)
+     VALUES (?, ?, 'qe-test-architect', 1, 0, -1, 0, NULL, ${createdAtExpr})`,
+  ).run(id, taskJson);
+};
+
+const lastJson = () =>
+  (globalThis as unknown as { __lastJson: Record<string, unknown> }).__lastJson;
+
+describe('post-route sweeps stale sentinels (#465)', () => {
+  let tmpDir: string;
+  let db: Database.Database;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aqe-post-route-'));
+    db = new Database(path.join(tmpDir, 'unified.db'));
+    createSchema(db);
+    fakeUnifiedMemoryFactory.mockReturnValue({
+      isInitialized: () => true,
+      initialize: async () => undefined,
+      getDatabase: () => db,
+    });
+    (globalThis as unknown as { __lastJson: unknown }).__lastJson = undefined;
+  });
+
+  afterEach(() => {
+    try { db.close(); } catch { /* ignore */ }
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  const runPostRoute = async (success = true): Promise<void> => {
+    const hooks = new Command('hooks');
+    registerRoutingHooks(hooks);
+    await hooks.parseAsync(
+      ['post-route', '--success', String(success), '--json'],
+      { from: 'user' },
+    );
+  };
+
+  it('closes the fresh sentinel via LIMIT-1 AND sweeps the stale ones', async () => {
+    // 1 fresh sentinel (now-ish) → resolved by LIMIT-1 close
+    // 3 old sentinels (>5 minutes old) → resolved by stale-sweep
+    insertSentinel(db, 'fresh', "datetime('now', '-10 seconds')");
+    insertSentinel(db, 'stale-1', "datetime('now', '-10 minutes')");
+    insertSentinel(db, 'stale-2', "datetime('now', '-1 hour')");
+    insertSentinel(db, 'stale-3', "datetime('now', '-3 days')");
+
+    await runPostRoute(true);
+
+    const json = lastJson();
+    expect(json).toMatchObject({ resolved: true, staleSwept: 3 });
+
+    // Fresh row: closed with successful turn's qualityScore = 0.675
+    const fresh = db
+      .prepare(`SELECT success, quality_score, error FROM routing_outcomes WHERE id = 'fresh'`)
+      .get() as { success: number; quality_score: number; error: string | null };
+    expect(fresh.success).toBe(1);
+    expect(fresh.quality_score).toBeCloseTo(0.675, 5);
+    expect(fresh.error).toBeNull();
+
+    // Stale rows: closed with conservative base (0.325), tagged stale-sentinel
+    const stales = db
+      .prepare(
+        `SELECT id, success, quality_score, error FROM routing_outcomes WHERE id LIKE 'stale-%' ORDER BY id`,
+      )
+      .all() as Array<{ id: string; success: number; quality_score: number; error: string | null }>;
+    for (const row of stales) {
+      expect(row.success).toBe(0);
+      expect(row.quality_score).toBeCloseTo(0.325, 5);
+      expect(row.error).toBe('stale-sentinel');
+    }
+
+    // No row should remain at -1
+    const unresolved = db
+      .prepare(`SELECT COUNT(*) AS n FROM routing_outcomes WHERE quality_score = -1`)
+      .get() as { n: number };
+    expect(unresolved.n).toBe(0);
+  });
+
+  it('reports staleSwept: 0 when no old sentinels exist', async () => {
+    insertSentinel(db, 'only-fresh', "datetime('now', '-10 seconds')");
+
+    await runPostRoute(true);
+
+    expect(lastJson()).toMatchObject({ resolved: true, staleSwept: 0 });
+  });
+
+  it('does not touch already-resolved rows', async () => {
+    // Already resolved with a real quality score
+    db.prepare(
+      `INSERT INTO routing_outcomes
+        (id, task_json, used_agent, followed_recommendation,
+         success, quality_score, duration_ms, error, created_at)
+       VALUES ('resolved-old', '{"description":"x"}', 'qe-test-architect', 1, 1, 0.8, 100, NULL, datetime('now', '-1 day'))`,
+    ).run();
+    insertSentinel(db, 'fresh', "datetime('now', '-10 seconds')");
+
+    await runPostRoute(true);
+
+    const resolved = db
+      .prepare(`SELECT quality_score, error FROM routing_outcomes WHERE id = 'resolved-old'`)
+      .get() as { quality_score: number; error: string | null };
+    expect(resolved.quality_score).toBeCloseTo(0.8, 5);
+    expect(resolved.error).toBeNull();
+  });
+
+  it('skips pre-task sentinels (task_json LIKE %"taskId"%) — those are owned by post-task', async () => {
+    // Pre-task sentinel: task_json carries `"taskId"`. The LIMIT-1 close
+    // discriminator filters these out — but the stale sweep does NOT
+    // filter by taskId because pre-task sentinels are post-task's
+    // responsibility to close (different lifecycle). However, if they
+    // genuinely become orphaned (post-task never fired), the sweep is
+    // still the right place to clean them up. Document the current
+    // behavior: the LIMIT-1 close skips them; the sweep does NOT.
+    insertSentinel(db, 'pre-task-sentinel', "datetime('now', '-10 seconds')", '{"taskId":"abc"}');
+    insertSentinel(db, 'fresh-route', "datetime('now', '-5 seconds')");
+
+    await runPostRoute(true);
+
+    // The route sentinel should be resolved by LIMIT-1
+    const fresh = db
+      .prepare(`SELECT quality_score FROM routing_outcomes WHERE id = 'fresh-route'`)
+      .get() as { quality_score: number };
+    expect(fresh.quality_score).toBeCloseTo(0.675, 5);
+
+    // The pre-task sentinel is still at -1 (too new for sweep, skipped by LIMIT-1)
+    const preTask = db
+      .prepare(`SELECT quality_score FROM routing_outcomes WHERE id = 'pre-task-sentinel'`)
+      .get() as { quality_score: number };
+    expect(preTask.quality_score).toBe(-1);
+  });
+});

--- a/tests/unit/cli/commands/post-route.test.ts
+++ b/tests/unit/cli/commands/post-route.test.ts
@@ -140,6 +140,10 @@ describe('post-route (issue #451)', () => {
   }
 
   it('closes the most-recent route sentinel and leaves pre-task sentinels alone', async () => {
+    // All three rows are seeded with dates >5 minutes in the past, so #465's
+    // stale-sweep is active. The route sentinels are owned by post-route and
+    // both close via the sweep + LIMIT-1; pre-task sentinels are isolated
+    // from both passes by the `task_json NOT LIKE '%"taskId"%'` discriminator.
     insertRouteSentinel(db, 'route-old', '2026-05-12 10:00:00');
     insertPreTaskSentinel(db, 'pre-task-mid', '2026-05-12 10:01:00');
     insertRouteSentinel(db, 'route-new', '2026-05-12 10:02:00');
@@ -152,13 +156,21 @@ describe('post-route (issue #451)', () => {
     expect(out).toMatchObject({ success: true, resolved: true, turnSuccess: true });
     expect(out.qualityScore).toBeCloseTo(0.675, 5);
 
-    const rows = db.prepare('SELECT id, success, quality_score FROM routing_outcomes ORDER BY id').all() as Array<{ id: string; success: number; quality_score: number }>;
+    const rows = db.prepare('SELECT id, success, quality_score, error FROM routing_outcomes ORDER BY id').all() as Array<{ id: string; success: number; quality_score: number; error: string | null }>;
     const byId = Object.fromEntries(rows.map((r) => [r.id, r]));
 
+    // LIMIT-1 path: most-recent route sentinel closed with the turn's qualityScore.
     expect(byId['route-new']).toMatchObject({ success: 1 });
     expect(byId['route-new'].quality_score).toBeCloseTo(0.675, 5);
+    expect(byId['route-new'].error).toBeNull();
 
-    expect(byId['route-old']).toMatchObject({ success: 0, quality_score: -1 });
+    // #465 sweep: older route sentinels close with the conservative base
+    // score and stale-sentinel tag instead of staying at -1 forever.
+    expect(byId['route-old']).toMatchObject({ success: 0, error: 'stale-sentinel' });
+    expect(byId['route-old'].quality_score).toBeCloseTo(0.325, 5);
+
+    // Pre-task sentinels are NEVER touched by post-route — discriminator gates
+    // both LIMIT-1 close and the stale sweep.
     expect(byId['pre-task-mid']).toMatchObject({ success: 0, quality_score: -1 });
   });
 

--- a/tests/unit/cli/commands/post-task-agent-fallback.test.ts
+++ b/tests/unit/cli/commands/post-task-agent-fallback.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Regression: issue #460
+ *
+ * post-task resolves `agent = options.agent || 'unknown'`. The shipped hook
+ * command is `--agent "$TOOL_RESULT_agent_id"` and Claude Code does NOT
+ * expose that env var in PostToolUse context, so options.agent arrives empty
+ * and `agent` always lands on 'unknown'. Every rl_q_values row used
+ * action_key='unknown', and the router could never learn per-agent
+ * differentiation.
+ *
+ * The pre-task bridge payload already carries `agent: routing.recommendedAgent`
+ * which is the correct action key. This test asserts that the post-task
+ * pipeline uses `bridge.agent` when --agent is absent, AND that an explicit
+ * --agent value still wins (so a user override is respected).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Command } from 'commander';
+
+const {
+  persistTaskOutcomeMock,
+  updateHookRouterQValueMock,
+  updateRoutingOutcomeQualityMock,
+  recordOutcomeMock,
+} = vi.hoisted(() => ({
+  persistTaskOutcomeMock: vi.fn(),
+  updateHookRouterQValueMock: vi.fn(),
+  updateRoutingOutcomeQualityMock: vi.fn(),
+  recordOutcomeMock: vi.fn(),
+}));
+
+vi.mock('../../../../src/cli/commands/hooks-handlers/hooks-shared.js', () => ({
+  getHooksSystem: vi.fn().mockResolvedValue({
+    hookRegistry: { emit: vi.fn().mockResolvedValue([]) },
+    reasoningBank: {
+      recordOutcome: recordOutcomeMock,
+      routeTask: vi.fn().mockResolvedValue({ success: false }),
+    },
+  }),
+  applyHookBusyTimeout: vi.fn(),
+  createHybridBackendWithTimeout: vi.fn().mockResolvedValue({
+    store: vi.fn(),
+    retrieve: vi.fn().mockResolvedValue(null),
+    delete: vi.fn(),
+    close: vi.fn(),
+  }),
+  incrementDreamExperience: vi.fn().mockResolvedValue(0),
+  checkAndTriggerDream: vi.fn().mockResolvedValue({ triggered: false }),
+  persistTaskOutcome: persistTaskOutcomeMock,
+  updateHookRouterQValue: updateHookRouterQValueMock,
+  updateRoutingOutcomeQuality: updateRoutingOutcomeQualityMock,
+  printJson: vi.fn(),
+  printSuccess: vi.fn(),
+}));
+
+import { registerTaskHooks } from '../../../../src/cli/commands/hooks-handlers/task-hooks.js';
+
+const baseBridge = {
+  selectedPatternIds: ['p1'],
+  agent: 'qe-test-architect',
+  description: 'd',
+  taskType: 'test-generation',
+  priority: 'normal',
+  domain: 'test-generation',
+  complexityBucket: 3,
+  estimatedTokenSavings: 0,
+  ts: Date.now(),
+};
+
+describe('post-task uses bridge.agent when --agent is absent (#460)', () => {
+  beforeEach(() => {
+    persistTaskOutcomeMock.mockReset();
+    updateHookRouterQValueMock.mockReset();
+    updateRoutingOutcomeQualityMock.mockReset();
+    recordOutcomeMock.mockReset();
+
+    persistTaskOutcomeMock.mockResolvedValue({
+      experienceId: 'exp-test',
+      qualityScore: 0.575,
+      bridge: baseBridge,
+      stitchedSiblings: 0,
+      insightsApplied: 0,
+    });
+    recordOutcomeMock.mockResolvedValue(undefined);
+    updateHookRouterQValueMock.mockResolvedValue(undefined);
+    updateRoutingOutcomeQualityMock.mockResolvedValue(undefined);
+  });
+
+  it('falls back to bridge.agent for Q-learning when --agent is missing', async () => {
+    const hooks = new Command('hooks');
+    registerTaskHooks(hooks);
+
+    await hooks.parseAsync(['post-task', '--success', 'true', '--json'], { from: 'user' });
+
+    expect(updateHookRouterQValueMock).toHaveBeenCalledTimes(1);
+    expect(updateHookRouterQValueMock.mock.calls[0][0].agent).toBe('qe-test-architect');
+    expect(updateRoutingOutcomeQualityMock).toHaveBeenCalledTimes(1);
+    expect(updateRoutingOutcomeQualityMock.mock.calls[0][0].agent).toBe('qe-test-architect');
+  });
+
+  it('falls back to bridge.agent when --agent is the literal empty string', async () => {
+    const hooks = new Command('hooks');
+    registerTaskHooks(hooks);
+
+    await hooks.parseAsync(
+      ['post-task', '--agent', '', '--success', 'true', '--json'],
+      { from: 'user' },
+    );
+
+    expect(updateHookRouterQValueMock.mock.calls[0][0].agent).toBe('qe-test-architect');
+    expect(updateRoutingOutcomeQualityMock.mock.calls[0][0].agent).toBe('qe-test-architect');
+  });
+
+  it('respects an explicit --agent over bridge.agent (user override)', async () => {
+    const hooks = new Command('hooks');
+    registerTaskHooks(hooks);
+
+    await hooks.parseAsync(
+      ['post-task', '--agent', 'qe-coverage-specialist', '--success', 'true', '--json'],
+      { from: 'user' },
+    );
+
+    expect(updateHookRouterQValueMock.mock.calls[0][0].agent).toBe('qe-coverage-specialist');
+    expect(updateRoutingOutcomeQualityMock.mock.calls[0][0].agent).toBe('qe-coverage-specialist');
+  });
+
+  it('stays on "unknown" when neither --agent nor bridge.agent is available', async () => {
+    persistTaskOutcomeMock.mockResolvedValueOnce({
+      experienceId: 'exp-test',
+      qualityScore: 0.575,
+      bridge: { ...baseBridge, agent: '' }, // bridge present but no agent
+      stitchedSiblings: 0,
+      insightsApplied: 0,
+    });
+
+    const hooks = new Command('hooks');
+    registerTaskHooks(hooks);
+
+    await hooks.parseAsync(['post-task', '--success', 'true', '--json'], { from: 'user' });
+
+    expect(updateHookRouterQValueMock.mock.calls[0][0].agent).toBe('unknown');
+    expect(updateRoutingOutcomeQualityMock.mock.calls[0][0].agent).toBe('unknown');
+  });
+});

--- a/tests/unit/cli/commands/post-task-promotion.test.ts
+++ b/tests/unit/cli/commands/post-task-promotion.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Regression: issue #455
+ *
+ * The post-task bridge loop updates qe_patterns.{usage_count, successful_uses,
+ * success_rate, quality_score} for real pattern UUIDs but never promoted
+ * short-term → long-term. recordOutcome() runs with a synthetic
+ * `task:agent:taskId` patternId that never matches qe_patterns.id, so
+ * checkPatternPromotionWithCoherence() was skipped for the real UUIDs.
+ *
+ * Patterns with successful_uses ≥ 3, success_rate ≥ 0.7, confidence ≥ 0.6
+ * accumulated forever at tier='short-term'. This test seeds a row one
+ * success-away from the promotion threshold and asserts the bridge loop
+ * flips its tier to 'long-term' after a successful post-task invocation.
+ */
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const { fakeUnifiedMemoryFactory } = vi.hoisted(() => ({
+  fakeUnifiedMemoryFactory: vi.fn(),
+}));
+
+vi.mock('../../../../src/kernel/unified-memory.js', () => ({
+  getUnifiedMemory: () => fakeUnifiedMemoryFactory(),
+  findProjectRoot: () => process.cwd(),
+}));
+
+import Database from 'better-sqlite3';
+import { persistTaskOutcome } from '../../../../src/cli/commands/hooks-handlers/hooks-dream-learning.js';
+
+describe('post-task bridge loop promotes patterns (#455)', () => {
+  let tmpDir: string;
+  let db: Database.Database;
+
+  const createSchema = (database: Database.Database): void => {
+    database.exec(`
+      CREATE TABLE captured_experiences (
+        id TEXT PRIMARY KEY,
+        task TEXT NOT NULL,
+        agent TEXT,
+        domain TEXT,
+        success INTEGER,
+        quality REAL,
+        duration_ms INTEGER,
+        model_tier TEXT,
+        started_at TEXT,
+        completed_at TEXT,
+        source TEXT,
+        consolidated_into TEXT
+      );
+      CREATE TABLE experience_applications (
+        id TEXT PRIMARY KEY,
+        experience_id TEXT,
+        task TEXT,
+        success INTEGER,
+        tokens_saved INTEGER,
+        feedback TEXT,
+        applied_at TEXT
+      );
+      CREATE TABLE qe_trajectories (
+        id TEXT PRIMARY KEY,
+        task TEXT,
+        agent TEXT,
+        domain TEXT,
+        started_at TEXT,
+        ended_at TEXT,
+        success INTEGER,
+        steps_json TEXT
+      );
+      CREATE TABLE qe_patterns (
+        id TEXT PRIMARY KEY,
+        pattern_type TEXT,
+        qe_domain TEXT,
+        domain TEXT,
+        name TEXT,
+        description TEXT,
+        confidence REAL DEFAULT 0.5,
+        usage_count INTEGER DEFAULT 0,
+        successful_uses INTEGER DEFAULT 0,
+        success_rate REAL DEFAULT 0.0,
+        quality_score REAL DEFAULT 0.0,
+        tier TEXT DEFAULT 'short-term',
+        last_used_at TEXT,
+        created_at TEXT,
+        updated_at TEXT
+      );
+      CREATE TABLE kv_store (
+        key TEXT,
+        namespace TEXT,
+        value TEXT,
+        expires_at INTEGER,
+        created_at INTEGER,
+        PRIMARY KEY (namespace, key)
+      );
+      CREATE TABLE dream_insights (
+        id TEXT PRIMARY KEY,
+        applied INTEGER DEFAULT 0,
+        actionable INTEGER DEFAULT 0,
+        created_at TEXT
+      );
+    `);
+  };
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aqe-promotion-'));
+    db = new Database(path.join(tmpDir, 'unified.db'));
+    createSchema(db);
+
+    fakeUnifiedMemoryFactory.mockReturnValue({
+      isInitialized: () => true,
+      initialize: async () => undefined,
+      getDatabase: () => db,
+    });
+  });
+
+  afterEach(() => {
+    try {
+      db.close();
+    } catch {
+      /* ignore */
+    }
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  const seedBridge = (patternId: string): void => {
+    db.prepare(`
+      INSERT INTO kv_store (key, namespace, value, expires_at, created_at)
+      VALUES (?, ?, ?, ?, ?)
+    `).run(
+      'task:abc',
+      'task-bridge',
+      JSON.stringify({
+        selectedPatternIds: [patternId],
+        agent: 'qe-test-architect',
+        description: 'd',
+        taskType: 'test-generation',
+        priority: 'normal',
+        domain: 'general',
+        complexityBucket: 3,
+        estimatedTokenSavings: 0,
+        ts: Date.now(),
+      }),
+      Date.now() + 600_000,
+      Date.now(),
+    );
+  };
+
+  it('promotes a short-term pattern to long-term when thresholds are met', async () => {
+    // Seed a pattern one success away from promotion. After bridge update:
+    //   usage_count: 2 → 3
+    //   successful_uses: 2 → 3 (PROMOTION_THRESHOLD)
+    //   success_rate: 2/2=1.0 → 3/3=1.0 (≥ 0.7)
+    //   confidence: 0.7 (≥ 0.6)
+    db.prepare(`
+      INSERT INTO qe_patterns
+        (id, pattern_type, qe_domain, domain, name,
+         confidence, usage_count, successful_uses, success_rate, tier)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      'pat-ready',
+      'test-template',
+      'test-generation',
+      'test-generation',
+      'Ready Pattern',
+      0.7,
+      2,
+      2,
+      1.0,
+      'short-term',
+    );
+    seedBridge('pat-ready');
+
+    await persistTaskOutcome({
+      taskId: 'hook-test',
+      agent: 'qe-test-architect',
+      success: true,
+    });
+
+    const row = db
+      .prepare(`SELECT tier, successful_uses, success_rate, confidence FROM qe_patterns WHERE id = ?`)
+      .get('pat-ready') as { tier: string; successful_uses: number; success_rate: number; confidence: number };
+
+    expect(row.successful_uses).toBe(3);
+    expect(row.success_rate).toBeCloseTo(1.0, 5);
+    expect(row.tier).toBe('long-term');
+  });
+
+  it('does NOT promote when success_rate is below threshold', async () => {
+    db.prepare(`
+      INSERT INTO qe_patterns
+        (id, pattern_type, qe_domain, domain, name,
+         confidence, usage_count, successful_uses, success_rate, tier)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      'pat-low-success',
+      'test-template',
+      'test-generation',
+      'test-generation',
+      'Low Success Pattern',
+      0.7,
+      5, // usage_count = 5
+      3, // successful_uses = 3 (meets threshold)
+      0.6, // success_rate = 0.6 (BELOW 0.7 threshold)
+      'short-term',
+    );
+    seedBridge('pat-low-success');
+
+    await persistTaskOutcome({
+      taskId: 'hook-test',
+      agent: 'qe-test-architect',
+      success: false, // failure — drops success_rate further
+    });
+
+    const row = db
+      .prepare(`SELECT tier FROM qe_patterns WHERE id = ?`)
+      .get('pat-low-success') as { tier: string };
+    expect(row.tier).toBe('short-term');
+  });
+
+  it('does NOT promote when confidence is below threshold', async () => {
+    db.prepare(`
+      INSERT INTO qe_patterns
+        (id, pattern_type, qe_domain, domain, name,
+         confidence, usage_count, successful_uses, success_rate, tier)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      'pat-low-conf',
+      'test-template',
+      'test-generation',
+      'test-generation',
+      'Low Conf Pattern',
+      0.4, // confidence BELOW 0.6 threshold
+      2,
+      2,
+      1.0,
+      'short-term',
+    );
+    seedBridge('pat-low-conf');
+
+    await persistTaskOutcome({
+      taskId: 'hook-test',
+      agent: 'qe-test-architect',
+      success: true,
+    });
+
+    const row = db
+      .prepare(`SELECT tier FROM qe_patterns WHERE id = ?`)
+      .get('pat-low-conf') as { tier: string };
+    expect(row.tier).toBe('short-term');
+  });
+
+  it('leaves already-long-term rows untouched (idempotent)', async () => {
+    db.prepare(`
+      INSERT INTO qe_patterns
+        (id, pattern_type, qe_domain, domain, name,
+         confidence, usage_count, successful_uses, success_rate, tier, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      'pat-already-long',
+      'test-template',
+      'test-generation',
+      'test-generation',
+      'Already Long Pattern',
+      0.9,
+      10,
+      9,
+      0.9,
+      'long-term',
+      '2026-01-01 00:00:00',
+    );
+    seedBridge('pat-already-long');
+
+    await persistTaskOutcome({
+      taskId: 'hook-test',
+      agent: 'qe-test-architect',
+      success: true,
+    });
+
+    const row = db
+      .prepare(`SELECT tier FROM qe_patterns WHERE id = ?`)
+      .get('pat-already-long') as { tier: string };
+    expect(row.tier).toBe('long-term');
+  });
+});

--- a/tests/unit/cli/commands/post-task-tokens-saved.test.ts
+++ b/tests/unit/cli/commands/post-task-tokens-saved.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Regression: issue #463
+ *
+ * The post-task hook's base experience_applications insert hardcoded
+ * tokens_saved=0 on every row. The column is intended to measure
+ * learning ROI but was permanently useless. qualityScore is already
+ * computed in the same transaction (0.34 = failure+slow, 0.675 = success+fast),
+ * so scale it by 100 until a real per-task token-delta calculation lands.
+ *
+ *   qualityScore = 0.25*successScore + 0.325 + 0.10*durationTier
+ *   durationTier = 1.0 (<100ms), 0.8 (<500ms), 0.6 (<2000ms),
+ *                  0.4 (<5000ms), 0.2 (<10000ms), 0.1 (>=10000ms)
+ *
+ * This test seeds an isolated unified-memory DB, calls persistTaskOutcome
+ * for several (success, duration) combinations, and asserts the base
+ * experience_applications row carries tokens_saved == round(quality*100).
+ */
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const { fakeUnifiedMemoryFactory } = vi.hoisted(() => ({
+  fakeUnifiedMemoryFactory: vi.fn(),
+}));
+
+vi.mock('../../../../src/kernel/unified-memory.js', () => ({
+  getUnifiedMemory: () => fakeUnifiedMemoryFactory(),
+  findProjectRoot: () => process.cwd(),
+}));
+
+import Database from 'better-sqlite3';
+import { persistTaskOutcome } from '../../../../src/cli/commands/hooks-handlers/hooks-dream-learning.js';
+
+const createSchema = (db: Database.Database): void => {
+  db.exec(`
+    CREATE TABLE captured_experiences (
+      id TEXT PRIMARY KEY,
+      task TEXT NOT NULL,
+      agent TEXT,
+      domain TEXT,
+      success INTEGER,
+      quality REAL,
+      duration_ms INTEGER,
+      model_tier TEXT,
+      started_at TEXT,
+      completed_at TEXT,
+      source TEXT,
+      consolidated_into TEXT
+    );
+    CREATE TABLE experience_applications (
+      id TEXT PRIMARY KEY,
+      experience_id TEXT,
+      task TEXT,
+      success INTEGER,
+      tokens_saved INTEGER,
+      feedback TEXT,
+      applied_at TEXT
+    );
+    CREATE TABLE qe_trajectories (
+      id TEXT PRIMARY KEY,
+      task TEXT,
+      agent TEXT,
+      domain TEXT,
+      started_at TEXT,
+      ended_at TEXT,
+      success INTEGER,
+      steps_json TEXT
+    );
+    CREATE TABLE qe_patterns (
+      id TEXT PRIMARY KEY, pattern_type TEXT, qe_domain TEXT, domain TEXT,
+      name TEXT, description TEXT, confidence REAL DEFAULT 0.5,
+      usage_count INTEGER DEFAULT 0, successful_uses INTEGER DEFAULT 0,
+      success_rate REAL DEFAULT 0.0, quality_score REAL DEFAULT 0.0,
+      tier TEXT DEFAULT 'short-term', last_used_at TEXT,
+      created_at TEXT, updated_at TEXT
+    );
+    CREATE TABLE kv_store (
+      key TEXT, namespace TEXT, value TEXT, expires_at INTEGER,
+      created_at INTEGER, PRIMARY KEY (namespace, key)
+    );
+    CREATE TABLE dream_insights (
+      id TEXT PRIMARY KEY, applied INTEGER DEFAULT 0,
+      actionable INTEGER DEFAULT 0, created_at TEXT
+    );
+  `);
+};
+
+describe('post-task populates tokens_saved with qualityScore * 100 (#463)', () => {
+  let tmpDir: string;
+  let db: Database.Database;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aqe-tokens-saved-'));
+    db = new Database(path.join(tmpDir, 'unified.db'));
+    createSchema(db);
+    fakeUnifiedMemoryFactory.mockReturnValue({
+      isInitialized: () => true,
+      initialize: async () => undefined,
+      getDatabase: () => db,
+    });
+  });
+
+  afterEach(() => {
+    try { db.close(); } catch { /* ignore */ }
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  /**
+   * Pull the base experience_applications row (the first one inserted —
+   * before any per-pattern bridge fan-out). The base row uses the bare
+   * taskField (no `:pattern:` suffix), so we can find it deterministically.
+   */
+  const readBaseRow = (taskField: string) =>
+    db
+      .prepare(
+        `SELECT tokens_saved FROM experience_applications
+         WHERE task = ? ORDER BY applied_at ASC LIMIT 1`,
+      )
+      .get(taskField) as { tokens_saved: number };
+
+  it('success + fast (<100ms): tokens_saved = round(0.675 * 100) = 68', async () => {
+    await persistTaskOutcome({
+      taskId: 'hook-1',
+      agent: 'qe-test-architect',
+      success: true,
+      durationMs: 50,
+    });
+
+    const row = readBaseRow('qe-test-architect:hook-1');
+    // qualityScore = 0.25*1 + 0.325 + 0.10*1.0 = 0.675 → round(67.5) = 68
+    expect(row.tokens_saved).toBe(68);
+  });
+
+  it('failure + slow (>=10000ms): tokens_saved = round(0.335 * 100) = 34', async () => {
+    await persistTaskOutcome({
+      taskId: 'hook-2',
+      agent: 'qe-test-architect',
+      success: false,
+      durationMs: 15000,
+    });
+
+    const row = readBaseRow('qe-test-architect:hook-2');
+    // qualityScore = 0.25*0 + 0.325 + 0.10*0.1 = 0.335 → round(33.5) = 34
+    expect(row.tokens_saved).toBe(34);
+  });
+
+  it('success + mid (<2000ms): tokens_saved = round(0.635 * 100) = 64', async () => {
+    await persistTaskOutcome({
+      taskId: 'hook-3',
+      agent: 'qe-test-architect',
+      success: true,
+      durationMs: 1500,
+    });
+
+    const row = readBaseRow('qe-test-architect:hook-3');
+    // qualityScore = 0.25*1 + 0.325 + 0.10*0.6 = 0.635 → round(63.5) = 64
+    expect(row.tokens_saved).toBe(64);
+  });
+
+  it('is never zero for any (success, duration) combination', async () => {
+    await persistTaskOutcome({
+      taskId: 'hook-zero-check',
+      agent: 'qe-test-architect',
+      success: false,
+      durationMs: 999999, // worst case (>=10000ms)
+    });
+
+    const row = readBaseRow('qe-test-architect:hook-zero-check');
+    expect(row.tokens_saved).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/learning/rvf-pattern-store-orphan-purge.test.ts
+++ b/tests/unit/learning/rvf-pattern-store-orphan-purge.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Regression: issue #462
+ *
+ * patterns.rvf is a persistent HNSW binary that accumulates vectors across
+ * upgrades. When an upgrade rewrites qe_patterns via INSERT OR REPLACE
+ * without calling RvfPatternStore.delete() on the old IDs, orphan vectors
+ * remain in the file forever. They win cosine-similarity matches and route
+ * to non-existent pattern IDs, so getPattern() returns null and learning
+ * writes fail silently.
+ *
+ * RvfPatternStore.initialize() now compares adapter.status().totalVectors
+ * with sqliteStore.getStats().totalPatterns; if RVF > DB, it reads the
+ * idmap.json sidecar, diffs the IDs, and deletes the orphans. This test
+ * exercises that path against a tiny fake adapter + fake sqlite store.
+ */
+
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { RvfPatternStore } from '../../../src/learning/rvf-pattern-store.js';
+import type { RvfNativeAdapter, RvfStatus } from '../../../src/integrations/ruvector/rvf-native-adapter.js';
+
+function makeFakeAdapter(totalVectors: number): {
+  adapter: RvfNativeAdapter;
+  deleteSpy: ReturnType<typeof vi.fn>;
+} {
+  const deleteSpy = vi.fn((_ids: string[]) => _ids.length);
+  const status: RvfStatus = {
+    totalVectors,
+    totalSegments: 1,
+    fileSizeBytes: 0,
+    epoch: 0,
+    witnessValid: true,
+    witnessEntries: 0,
+  };
+  const adapter: Partial<RvfNativeAdapter> = {
+    status: () => status,
+    delete: deleteSpy as RvfNativeAdapter['delete'],
+    close: () => undefined,
+    isOpen: () => true,
+    path: () => '',
+    dimension: () => 384,
+    size: () => totalVectors,
+    compact: () => undefined,
+    fork: vi.fn() as unknown as RvfNativeAdapter['fork'],
+    ingest: () => ({ accepted: 0, rejected: 0 }),
+    search: () => [],
+    embedKernel: () => 0,
+    extractKernel: () => null,
+    verifyWitness: () => ({ verified: true, supported: true, error: null }) as ReturnType<RvfNativeAdapter['verifyWitness']>,
+    sign: () => null,
+    fileId: () => null,
+    parentId: () => null,
+    lineageDepth: () => 0,
+    indexStats: () => ({ layers: 1, nodes: totalVectors, avgConnections: 0, idMapSize: totalVectors }),
+  };
+  return { adapter: adapter as RvfNativeAdapter, deleteSpy };
+}
+
+function makeFakeSqliteStore(totalPatterns: number, ids: string[]) {
+  return {
+    initialize: async () => undefined,
+    getStats: () => ({
+      totalPatterns,
+      byDomain: {} as Record<string, number>,
+      byTier: {} as Record<string, number>,
+    }),
+    getPatterns: (_opts: { limit?: number } = {}) =>
+      ids.map((id) => ({ id }) as unknown),
+  };
+}
+
+describe('RvfPatternStore purges orphan vectors on init (#462)', () => {
+  let tmpDir: string;
+  let rvfPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aqe-rvf-orphan-'));
+    rvfPath = path.join(tmpDir, 'patterns.rvf');
+    // A bare placeholder so any future fs check on the file passes.
+    fs.writeFileSync(rvfPath, '');
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  const writeIdmap = (ids: string[]): void => {
+    fs.writeFileSync(
+      `${rvfPath}.idmap.json`,
+      JSON.stringify({
+        nextLabel: ids.length + 1,
+        entries: ids.map((id, i) => [id, i + 1]),
+      }),
+    );
+  };
+
+  it('deletes RVF IDs that have no matching qe_patterns row', async () => {
+    // Idmap has 5 entries; DB only knows about 3 → 2 orphans expected
+    writeIdmap(['keep-1', 'orphan-a', 'keep-2', 'orphan-b', 'keep-3']);
+
+    const { adapter, deleteSpy } = makeFakeAdapter(5);
+    const store = new RvfPatternStore(() => adapter, { rvfPath });
+    // Inject a fake sqlite store so the init-time auto-attach is skipped.
+    store.setSqliteStore(
+      makeFakeSqliteStore(3, ['keep-1', 'keep-2', 'keep-3']) as unknown as Parameters<
+        typeof store.setSqliteStore
+      >[0],
+    );
+
+    await store.initialize();
+
+    expect(deleteSpy).toHaveBeenCalledTimes(1);
+    const [args] = deleteSpy.mock.calls[0];
+    expect((args as string[]).sort()).toEqual(['orphan-a', 'orphan-b']);
+  });
+
+  it('does NOT call delete when RVF and DB counts match', async () => {
+    writeIdmap(['p1', 'p2', 'p3']);
+    const { adapter, deleteSpy } = makeFakeAdapter(3);
+
+    const store = new RvfPatternStore(() => adapter, { rvfPath });
+    store.setSqliteStore(
+      makeFakeSqliteStore(3, ['p1', 'p2', 'p3']) as unknown as Parameters<
+        typeof store.setSqliteStore
+      >[0],
+    );
+
+    await store.initialize();
+    expect(deleteSpy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call delete when RVF has fewer rows than DB (under-indexed)', async () => {
+    writeIdmap(['p1']);
+    const { adapter, deleteSpy } = makeFakeAdapter(1);
+
+    const store = new RvfPatternStore(() => adapter, { rvfPath });
+    store.setSqliteStore(
+      makeFakeSqliteStore(5, ['p1', 'p2', 'p3', 'p4', 'p5']) as unknown as Parameters<
+        typeof store.setSqliteStore
+      >[0],
+    );
+
+    await store.initialize();
+    expect(deleteSpy).not.toHaveBeenCalled();
+  });
+
+  it('fails open when the idmap file is missing', async () => {
+    // RVF has 5 vectors, DB has 3, but idmap.json doesn't exist.
+    // Purge cannot compute orphans without idmap — skip silently.
+    const { adapter, deleteSpy } = makeFakeAdapter(5);
+
+    const store = new RvfPatternStore(() => adapter, { rvfPath });
+    store.setSqliteStore(
+      makeFakeSqliteStore(3, ['p1', 'p2', 'p3']) as unknown as Parameters<
+        typeof store.setSqliteStore
+      >[0],
+    );
+
+    await store.initialize();
+    expect(deleteSpy).not.toHaveBeenCalled();
+  });
+
+  it('fails open when the idmap is corrupted JSON', async () => {
+    fs.writeFileSync(`${rvfPath}.idmap.json`, '{not-valid-json');
+    const { adapter, deleteSpy } = makeFakeAdapter(5);
+
+    const store = new RvfPatternStore(() => adapter, { rvfPath });
+    store.setSqliteStore(
+      makeFakeSqliteStore(3, ['p1', 'p2', 'p3']) as unknown as Parameters<
+        typeof store.setSqliteStore
+      >[0],
+    );
+
+    await expect(store.initialize()).resolves.toBeUndefined();
+    expect(deleteSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/learning/sqlite-aggregate-stats.test.ts
+++ b/tests/unit/learning/sqlite-aggregate-stats.test.ts
@@ -1,0 +1,127 @@
+/**
+ * SQLitePatternStore.getAggregateOutcomeStats — DB-backed fallback (#454)
+ *
+ * QEReasoningBank.getStats() previously reported only in-memory counters,
+ * which always read zero in hook subprocesses (fresh node = fresh counters).
+ * This regression suite proves the SQL aggregates over routing_outcomes /
+ * qe_pattern_usage / qe_patterns are correct and tolerant of missing tables.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { SQLitePatternStore } from '../../../src/learning/sqlite-persistence.js';
+
+describe('SQLitePatternStore.getAggregateOutcomeStats', () => {
+  let tmpDir: string;
+  let store: SQLitePatternStore;
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aqe-stats-fallback-'));
+    store = new SQLitePatternStore({
+      useUnified: false,
+      dbPath: path.join(tmpDir, 'patterns.db'),
+    });
+    await store.initialize();
+  });
+
+  afterEach(async () => {
+    try {
+      store.close();
+    } catch {
+      /* ignore */
+    }
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('returns all zeros when no rows or tables exist', () => {
+    // Legacy-mode SQLitePatternStore creates qe_pattern_usage but not
+    // routing_outcomes — the safeGet path must swallow the missing table.
+    const agg = store.getAggregateOutcomeStats();
+    expect(agg.routingRequests).toBe(0);
+    expect(agg.avgRoutingConfidence).toBe(0);
+    expect(agg.learningOutcomes).toBe(0);
+    expect(agg.successfulOutcomes).toBe(0);
+    expect(agg.avgPatternSuccessRate).toBe(0);
+  });
+
+  it('aggregates routing_outcomes when the table exists', () => {
+    const db = store.getDatabase();
+    if (!db) throw new Error('expected db');
+
+    db.exec(`
+      CREATE TABLE routing_outcomes (
+        id TEXT PRIMARY KEY,
+        task_json TEXT,
+        decision_json TEXT,
+        used_agent TEXT,
+        followed_recommendation INTEGER,
+        success INTEGER,
+        quality_score REAL,
+        duration_ms INTEGER,
+        error TEXT,
+        created_at TEXT DEFAULT (datetime('now'))
+      );
+    `);
+
+    // 2 closed rows (quality_score >= 0) and 1 sentinel (quality_score = -1).
+    // Sentinel must be counted in total but excluded from avgConfidence.
+    db.prepare(
+      `INSERT INTO routing_outcomes
+       (id, success, quality_score) VALUES (?, ?, ?)`
+    ).run('r1', 1, 0.8);
+    db.prepare(
+      `INSERT INTO routing_outcomes
+       (id, success, quality_score) VALUES (?, ?, ?)`
+    ).run('r2', 0, 0.4);
+    db.prepare(
+      `INSERT INTO routing_outcomes
+       (id, success, quality_score) VALUES (?, ?, ?)`
+    ).run('r3-sentinel', 0, -1);
+
+    const agg = store.getAggregateOutcomeStats();
+    expect(agg.routingRequests).toBe(3);
+    expect(agg.avgRoutingConfidence).toBeCloseTo(0.6, 5); // (0.8 + 0.4) / 2
+    expect(agg.successfulRoutings).toBe(1);
+  });
+
+  it('aggregates qe_pattern_usage success counts', () => {
+    const db = store.getDatabase();
+    if (!db) throw new Error('expected db');
+
+    const insert = db.prepare(
+      `INSERT INTO qe_pattern_usage (pattern_id, success) VALUES (?, ?)`
+    );
+    insert.run('p1', 1);
+    insert.run('p1', 1);
+    insert.run('p1', 0);
+    insert.run('p2', 1);
+
+    const agg = store.getAggregateOutcomeStats();
+    expect(agg.learningOutcomes).toBe(4);
+    expect(agg.successfulOutcomes).toBe(3);
+  });
+
+  it('returns avg(success_rate) from qe_patterns when rows have total_uses > 0', () => {
+    const db = store.getDatabase();
+    if (!db) throw new Error('expected db');
+
+    const insert = db.prepare(`
+      INSERT INTO qe_patterns
+        (id, pattern_type, qe_domain, domain, name, description, success_rate, usage_count)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    insert.run('a', 'test-template', 'test-generation', 'test-generation', 'A', 'd', 0.9, 5);
+    insert.run('b', 'test-template', 'test-generation', 'test-generation', 'B', 'd', 0.7, 5);
+    // Pattern with 0 uses should NOT be included in average
+    insert.run('c', 'test-template', 'test-generation', 'test-generation', 'C', 'd', 0.1, 0);
+
+    const agg = store.getAggregateOutcomeStats();
+    expect(agg.avgPatternSuccessRate).toBeCloseTo(0.8, 5);
+  });
+});


### PR DESCRIPTION
## Summary

Ten learning-pipeline fixes reported by @Jordi-Izquierdo-DDS against v3.9.24. Individually they look like small short-circuits in the post-task hook chain; together they were keeping the end-to-end Stream B/D/F learning loop pinned at zero — experiences tagged `agent='unknown'` and `task='edit: '`, Q-learning buckets all converging on one key, dream insights generated but never applied, patterns crossing the promotion thresholds but staying short-term forever, and stale sentinels inverting the routing-quality metric from a real +0.666 to an observed −0.717.

**Fixes:** #453, #454, #455, #456, #460, #461, #462, #463, #464, #465
**Closes as duplicates:** #457 (→ #454), #458 (→ #455), #459 (→ #456)

See [CHANGELOG.md](CHANGELOG.md) and [docs/releases/v3.9.26.md](docs/releases/v3.9.26.md) for per-issue details.

## Verification

**Build**
```
$ npm run build
CLI bundle built successfully (v3.9.26)
MCP bundle built successfully (v3.9.26)
```

**Typecheck**
```
$ npm run typecheck
(zero errors)
```

**Performance gates**
```
$ npm run performance:gate
Total: 15 | Passed: 15 | Failed: 0 | Warnings: 0
✅ All performance gates PASSED
Exit code: 0
```

**Fast unit suite** (full `test:unit:fast` — covers all 12 new regression suites added in this release)
```
$ npm run test:unit:fast
Test Files  240 passed | 1 skipped (241)
Tests       7497 passed | 5 skipped (7502)
Duration    75.77s
```

**Bundled isolated install** (catches missing externals)
```
$ npm pack && (in clean tmpdir) npm install ./agentic-qe-3.9.26.tgz
$ node node_modules/.bin/aqe --version
3.9.26
EXIT=0
```

**Local `aqe init --auto` in fresh project**
```
- Skills installed: 85
- Agents installed: 60
- Hooks configured: Yes
- Workers started: 1
- Total time: 343ms
```

**12 new regression-test files (58 tests)** verify each fix end-to-end against an in-memory unified DB:

| File | Tests | Issue |
|------|-------|-------|
| `tests/unit/cli/commands/hooks-editing.test.ts` | 10 | #453 |
| `tests/unit/learning/sqlite-aggregate-stats.test.ts` | 4 | #454 |
| `tests/unit/cli/commands/post-task-promotion.test.ts` | 4 | #455 |
| `tests/unit/cli/commands/hooks-dream-apply-insights.test.ts` | 4 | #456 |
| `tests/unit/cli/commands/post-task-agent-fallback.test.ts` | 4 | #460 |
| `tests/unit/cli/commands/hooks-dream-concurrent-guard.test.ts` | 3 | #461 |
| `tests/unit/learning/rvf-pattern-store-orphan-purge.test.ts` | 5 | #462 |
| `tests/unit/cli/commands/post-task-tokens-saved.test.ts` | 4 | #463 |
| `tests/unit/cli/commands/consolidation-cli-hook.test.ts` | 4 | #464 |
| `tests/unit/cli/commands/post-route-sentinel-sweep.test.ts` | 4 | #465 |
| `tests/unit/cli/commands/post-route.test.ts` (updated for #465 sweep) | 4 | #451 + #465 |
| `tests/unit/cli/commands/task-hooks-no-taskid.test.ts` (existing) | 2 | #449 |

## Failure modes

The fixes touch the post-task and post-route hook chains, which are
load-bearing for the self-learning loop. Acknowledged risk surfaces:

1. **`tokens_saved = round(qualityScore * 100)` is a proxy, not a real token-delta.** Downstream analytics that interpret the column as actual saved tokens will read a 34–68 signal-like value instead of zero, but the magnitude isn't measured. A proper per-task token-delta calculation is tracked as a follow-up.
2. **The `dream_cycles` concurrent-start guard fails open** (#461). If the guard query fails — table missing, unified memory not ready — the dream proceeds and we accept the prior `database is locked` failure mode rather than block dreaming entirely. The 60-second window means worst-case duplicate cycles are still bounded.
3. **The orphan-vector purge in RVF init fails open.** If the idmap file is corrupted or unreadable, init proceeds without purging and ghost vectors remain. Tested with corrupted JSON and missing idmap in `rvf-pattern-store-orphan-purge.test.ts`; both paths log and continue.
4. **The stale-sentinel sweep uses the `task_json NOT LIKE '%"taskId"%'` discriminator** (matches the LIMIT-1 close), so it only sweeps route sentinels — pre-task sentinels that orphan still sit at `quality_score=-1`. That's a separate concern (post-task ownership) and would be its own fix; not regressed by this PR.

All four are exercised by tests in this PR.

---

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.** "Unlikely" is not an acceptable substitute. If you wrote "I don't think this can happen but...", that sentence is a failure mode and needs a test or an issue link.

### Optional context

- Linked issues: Fixes #453, #454, #455, #456, #460, #461, #462, #463, #464, #465. Closes-as-dup: #457, #458, #459.
- Trust tier change (if any): none — these are bug-fixes on existing tier-3 surfaces (post-task / post-edit / post-route hooks, RVF pattern store, consolidation pipeline).
- Affects published API or CLI surface: yes — `aqe hooks post-route --json` gains a `staleSwept` field; `aqe hooks post-task --json` gains a `dreamInsightsApplied` field; both are additive and backward-compatible.
- Touches the init flow / `npm-publish.yml` / `tests/fixtures/init-corpus/`: no — only the hook handlers, RVF init, and CHANGELOG/release notes.
  - If yes: did you run `./tests/fixtures/init-corpus/run-gate.sh` locally? not applicable.

See [CHANGELOG](CHANGELOG.md) for details.