### PR TITLE
chore(release): v3.9.32

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-qe",
-  "version": "3.9.31",
+  "version": "3.9.32",
   "description": "Agentic Quality Engineering — AI-powered QE platform with 60 specialized agents, 75+ skills, sublinear coverage analysis, ReasoningBank pattern learning, and deep MCP integration for Claude Code and 11 coding agent platforms",
   "author": {
     "name": "Agentic QE Team",

--- a/.claude/skills/skills-manifest.json
+++ b/.claude/skills/skills-manifest.json
@@ -939,7 +939,7 @@
   },
   "metadata": {
     "generatedBy": "Agentic QE Fleet",
-    "fleetVersion": "3.9.31",
+    "fleetVersion": "3.9.32",
     "manifestVersion": "1.4.0",
     "lastUpdated": "2026-04-13T00:00:00.000Z",
     "contributors": [

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -223,18 +223,61 @@ jobs:
       - name: Run fast unit tests
         run: npm run test:unit:fast
 
+  # ============================================================================
+  # Integration tests on tag SHA (issue #491)
+  #
+  # Runs the focused daemon-runtime seam suite — the surfaces that, when
+  # broken, ship as "looks initialized, silently dies" failures users only
+  # discover at runtime. The fast subset (~6s) covers:
+  #   - fleet_init wires the daemon WorkerManager to the kernel (Bug 1)
+  #   - every production worker can reach its declared targetDomains
+  #   - LearningCoordinator's write→read round trip works through the
+  #     real HybridMemoryBackend (Bug 2+3)
+  #   - CapturedExperienceBridge writes the expected kv keys
+  #
+  # Why this is its own gate rather than part of tests-on-tag-sha:
+  # `test:unit:fast` excludes integration/ by design — and the four bugs
+  # in #491 all lived in the daemon-runtime seam that unit tests
+  # explicitly punt on. Until v3.9.31, integration coverage was present
+  # but not run on release; this job closes that loop.
+  # ============================================================================
+  integration-tests-on-tag-sha:
+    name: Integration tests on tag SHA
+    needs: [build]
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.13.0'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run integration seam tests
+        run: npm run test:integration:fast
+
   publish:
     name: Publish to npm
-    needs: [build, pre-publish-gate, tests-on-tag-sha]
-    # tests-on-tag-sha is skipped on workflow_dispatch (it only runs on
-    # release events), so we explicitly accept skipped as a non-blocker.
-    # Without this, the default GH Actions behavior would skip publish
-    # whenever tests-on-tag-sha is skipped — breaking the dry-run path.
+    needs: [build, pre-publish-gate, tests-on-tag-sha, integration-tests-on-tag-sha]
+    # tests-on-tag-sha and integration-tests-on-tag-sha are skipped on
+    # workflow_dispatch (they only run on release events), so we explicitly
+    # accept skipped as a non-blocker. Without this, the default GH Actions
+    # behavior would skip publish whenever either is skipped — breaking the
+    # dry-run path.
     if: >-
       always()
       && needs.build.result == 'success'
       && needs.pre-publish-gate.result == 'success'
       && (needs.tests-on-tag-sha.result == 'success' || needs.tests-on-tag-sha.result == 'skipped')
+      && (needs.integration-tests-on-tag-sha.result == 'success' || needs.integration-tests-on-tag-sha.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: npm-publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,94 @@ All notable changes to the Agentic QE project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.32] - 2026-05-17
+
+Fixes the chain of four bugs reported in #491 (Jordi Izquierdo) that left
+the self-learning consolidation loop dead end-to-end on v3.9.31, plus the
+release-process gaps that let those bugs ship in the first place. After
+this release, `aqe learning loop-health` populates as expected on a
+vanilla install and the `learning-consolidation` worker actually
+consolidates instead of silently failing every tick.
+
+### Fixed
+
+- **Self-learning consolidation loop dead on fresh installs** (#491).
+  Four stacked bugs broke the experience capture → bridge → mine →
+  consolidate pipeline end-to-end:
+  - The MCP-hosted daemon constructed its `WorkerManager` before the
+    kernel existed and was never told about the kernel once
+    `fleet_init` built it — so every domain-dependent worker tick
+    failed with `<domain> not available` (14+/cycle). `setKernel` and
+    a new `setMemory` are now public on the `WorkerManager` interface
+    and `handleFleetInit` wires them in after plugin load.
+  - `LearningCoordinator` wrote experiences with
+    `namespace: 'learning-optimization'` but `HybridBackend`'s read
+    methods hard-coded `defaultNamespace='default'`, so the
+    coordinator could not read its own writes and `mineExperiences`
+    returned 0 for every domain. `MemoryBackend.get/has/delete/search`
+    now accept `RetrieveOptions { namespace? }`, symmetric with the
+    existing `StoreOptions.namespace`; all 15 read sites in
+    `LearningCoordinator` pass the matching namespace.
+  - JSON.stringify serialized `Experience.timestamp` to an ISO string
+    but JSON.parse didn't rehydrate; `TimeRange.contains` did
+    `string >= Date` which coerces to NaN — so even with the
+    namespace fixed, the time-window filter dropped every experience.
+    `getExperiencesByDomainAndTime` now coerces to `Date` at the
+    kv-read boundary.
+  - `LearningConsolidationWorker.doExecute` called
+    `recordLoopHealth(success:true)` *after* `collectPatterns()`, which
+    throws on empty installs — so the dashboard showed `never-ran`
+    permanently. The worker body is now wrapped in try/catch/finally
+    matching the bridge's `drainSafe` pattern; liveness reports on
+    both the success and failure paths.
+
+### Added
+
+- **Daemon-runtime release gate** (#491). The pre-publish flow now runs
+  the daemon-runtime seam test suite alongside the existing fast unit
+  tests. New `test:integration:fast` script runs four focused
+  integration tests in ~6 seconds:
+  - `fleet-init-wires-daemon.test.ts` — proves the kernel→worker
+    wiring is alive after `handleFleetInit`.
+  - `workers-reach-domains.test.ts` — iterates every registered
+    worker and asserts each declared `targetDomain` resolves to a
+    real API. Catches the Bug 1 class for all 11 workers in one
+    test.
+  - `coordinator-roundtrip.test.ts` — full
+    `recordExperience → mineExperiences` round trip through the real
+    `HybridMemoryBackend`. Catches the namespace and timestamp bugs
+    together.
+  - `bridge-end-to-end.test.ts` — existing bridge fan-out coverage.
+
+- **Liveness contract test for `LearningConsolidationWorker`**.
+  Verifies `recordLoopHealth` fires on both success and throw paths,
+  and that a memory-backend hiccup inside the liveness recorder
+  cannot shadow the worker's real error.
+
+- **A23 daemon-liveness assertion in the init-corpus release gate**.
+  Opt-in per fixture via the new `expectDaemonLiveness` manifest
+  flag; spawns the cleanroom daemon post-init, waits the configured
+  window, and asserts zero `domain not available` lines on stderr
+  before killing the daemon. Enabled on the `tiny-ts` fixture with
+  a 15-second window as a pilot. Catches the class of regression
+  that `aqe init` alone cannot surface, since the daemon-runtime
+  seam only opens at daemon startup.
+
+### Changed
+
+- `MemoryBackend.get/has/delete/search` now accept an optional
+  `RetrieveOptions { namespace? }` second argument. Backward-compatible:
+  undefined still routes to `defaultNamespace`. Any caller that was
+  using `InMemoryBackend`'s undocumented positional
+  `namespace?: string` parameter (not on the `MemoryBackend`
+  interface) needs to switch to the options form.
+
+- `package.json` defines `test:integration:fast` (the new release
+  gate's input) and `test:integration` (full integration suite for
+  local development). `.github/workflows/npm-publish.yml` adds a new
+  `integration-tests-on-tag-sha` job wired into the publish
+  `needs`/`if` conditions.
+
 ## [3.9.31] - 2026-05-15
 
 Self-learning loop ships. Closes issues #480, #486, #487, #488 and

--- a/assets/skills/skills-manifest.json
+++ b/assets/skills/skills-manifest.json
@@ -939,7 +939,7 @@
   },
   "metadata": {
     "generatedBy": "Agentic QE Fleet",
-    "fleetVersion": "3.9.31",
+    "fleetVersion": "3.9.32",
     "manifestVersion": "1.4.0",
     "lastUpdated": "2026-04-13T00:00:00.000Z",
     "contributors": [

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -4,6 +4,7 @@ All Agentic QE release notes organized by version.
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| [v3.9.32](v3.9.32.md) | 2026-05-17 | Fix #491 chain — daemon/kernel wiring, namespace-aware reads, timestamp rehydration, loop-health try/finally. Adds daemon-runtime release gate (`test:integration:fast` + A23) |
 | [v3.9.31](v3.9.31.md) | 2026-05-15 | Self-learning loop ships end-to-end: kernel-side dream cycles (ADR-094), three-signal routing with Q-blend + ε-greedy + mincut gate (ADR-095), `aqe learning loop-health` dashboard, retention pruner, daemon pidfile fix (#480, #486, #487, #488) |
 | [v3.9.30](v3.9.30.md) | 2026-05-14 | Six MCP fixes: ESM __dirname polyfill, real ONNX embeddings, coherence_collapse NaN guard, default test phases, session cache wired, test_generate language validation (#467,#469,#470,#472,#473,#474) |
 | [v3.9.29](v3.9.29.md) | 2026-05-14 | Hotfix: bridge publishes learning.ExperienceCaptured with the canonical nested payload shape so handler destructure resolves and recordExperience runs (#482 round 3) |

--- a/docs/releases/v3.9.32.md
+++ b/docs/releases/v3.9.32.md
@@ -1,0 +1,173 @@
+# v3.9.32 Release Notes
+
+**Release Date:** 2026-05-17
+
+## Highlights
+
+Fixes the chain of four bugs reported in
+[#491](https://github.com/proffesor-for-testing/agentic-qe/issues/491)
+(Jordi Izquierdo) that left the self-learning consolidation loop dead
+end-to-end on v3.9.31. On a vanilla v3.9.31 install,
+`LearningConsolidationWorker` ran every cycle but never consolidated
+anything, and `aqe learning loop-health` permanently showed the worker
+as `never-ran`. Tracing the pipeline end-to-end surfaced four
+independent bugs stacked on top of each other — each reproducible on a
+clean install.
+
+This release fixes all four bugs at their root, and closes the
+release-process gap that let them ship: the pre-publish flow now runs
+the daemon-runtime seam test suite alongside the existing fast unit
+tests, so the next regression in this class fails at the release gate
+instead of at users' installs.
+
+## Fixed
+
+- **Self-learning consolidation loop dead on fresh installs** ([#491](https://github.com/proffesor-for-testing/agentic-qe/issues/491)).
+  Four stacked bugs broke the experience capture → bridge → mine →
+  consolidate pipeline end-to-end. Each reproducible on a vanilla
+  `npm install -g agentic-qe@3.9.31`:
+
+  - **Bug 1 — daemon→kernel wiring missing.** The MCP-hosted daemon
+    constructed its `WorkerManager` in `src/mcp/entry.ts` *before* the
+    kernel existed, falling through to a `StubWorkerDomainAccess` whose
+    `getDomainAPI` is a hard `return undefined`. `handleFleetInit`
+    built a complete kernel in the same process but never told the
+    daemon about it. Every domain-dependent worker tick failed with
+    `<domain> not available` (14+ per cycle) for the
+    learning-consolidation, test-health, flaky-detector, and 8 other
+    workers. `setKernel` and a new `setMemory` are now public on the
+    `WorkerManager` interface and `handleFleetInit` wires them in
+    after `pluginLoader.loadAll()`.
+
+  - **Bug 2 — namespace mismatch.** `LearningCoordinator` wrote
+    experiences with explicit `namespace: 'learning-optimization'`,
+    but `HybridBackend`'s read methods hard-coded
+    `defaultNamespace='default'`. The coordinator could not read its
+    own writes — `learning:experience:index:domain:<d>:*` returned 0
+    keys even when the database held 81+ matching rows in the
+    correct namespace. `mineExperiences` returned 0 for every domain.
+    `MemoryBackend.get/has/delete/search` now accept
+    `RetrieveOptions { namespace? }` (symmetric with the existing
+    `StoreOptions.namespace`); all 15 read sites in
+    `LearningCoordinator` pass the matching namespace.
+
+  - **Bug 3 — Date vs ISO-string in time-window filter.**
+    `recordExperience` stores `timestamp: new Date()`, but
+    `JSON.stringify` serializes it to an ISO string and `JSON.parse`
+    doesn't rehydrate. `TimeRange.contains` does `date >= start`; in
+    `string >= Date`, the string coerces to NaN and every comparison
+    returns false — so even with the namespace fixed, the time-window
+    filter silently dropped every experience.
+    `getExperiencesByDomainAndTime` now coerces to `Date` at the
+    kv-read boundary.
+
+  - **Bug 4a — loop-health ping unreachable.** In
+    `LearningConsolidationWorker.doExecute`, `recordLoopHealth(success)`
+    sat *after* `collectPatterns()` — which throws on installs with
+    nothing to consolidate (the common case for fresh users). The
+    error propagated up before the liveness ping could fire, so
+    `aqe learning loop-health` permanently displayed
+    `LearningConsolidationWorker ○ never-ran` even when the worker
+    executed every cycle. The worker body is now wrapped in
+    try/catch/finally matching the bridge's `drainSafe` pattern;
+    liveness reports on both the success and failure paths.
+
+  - **Bug 4b — wrong memory instance.** The worker recorded liveness
+    to `context.memory` (the worker manager's private
+    `InMemoryWorkerMemory`), but the `loop-health` dashboard read
+    from the kernel's `qe-kernel` namespace. Even with 4a fixed, the
+    worker wouldn't appear in the dashboard. The new
+    `WorkerManager.setMemory(kernel.memory)` aligns the two so
+    worker writes reach the dashboard's reads.
+
+## Added
+
+- **Daemon-runtime release gate**
+  ([#491](https://github.com/proffesor-for-testing/agentic-qe/issues/491)).
+  The pre-publish flow now runs the daemon-runtime seam test suite
+  alongside the existing fast unit tests. New `test:integration:fast`
+  npm script runs four focused integration tests in ~6 seconds:
+
+  - `fleet-init-wires-daemon.test.ts` — proves the kernel→worker
+    wiring is alive after `handleFleetInit` (3 assertions including
+    the idempotency case).
+  - `workers-reach-domains.test.ts` — iterates every registered
+    worker dynamically (no hardcoded list — auto-extends to future
+    workers) and asserts each declared `targetDomain` resolves to a
+    real API. Catches the Bug 1 class for all 11 workers in one
+    test.
+  - `coordinator-roundtrip.test.ts` — full
+    `recordExperience → mineExperiences` round trip through the real
+    `HybridMemoryBackend`. Catches the namespace and timestamp bugs
+    together; also asserts a past-window correctly excludes recent
+    writes so the fix doesn't make the filter a no-op.
+  - `bridge-end-to-end.test.ts` — existing bridge fan-out coverage.
+
+  `.github/workflows/npm-publish.yml` adds an
+  `integration-tests-on-tag-sha` job wired into the publish job's
+  `needs`/`if` conditions in the same shape as the existing
+  `tests-on-tag-sha`. A green pre-publish now requires daemon-runtime
+  seam tests to pass, not just `test:unit:fast`.
+
+- **Liveness contract test for `LearningConsolidationWorker`**.
+  Verifies `recordLoopHealth` fires on both success and throw paths,
+  and that a memory-backend hiccup inside the liveness recorder cannot
+  shadow the worker's real error. The third assertion specifically
+  protects the "original error wins" contract — without it, debugging
+  a real worker failure would be confounded by spurious liveness
+  errors.
+
+- **A23 daemon-liveness assertion in the init-corpus release gate**.
+  Opt-in per fixture via the new `expectDaemonLiveness` manifest
+  flag; spawns the cleanroom daemon post-init, waits the configured
+  window (default 20s), and asserts zero `domain not available` lines
+  on stderr before killing the daemon. Enabled on the `tiny-ts`
+  fixture with a 15-second window as a pilot. The same `run-gate.sh`
+  is invoked by `post-publish-canary.yml` against the published npm
+  version, so A23 doubles as a post-publish smoke for any
+  registry/CDN divergence that affects the daemon-runtime path —
+  a class of regression neither the build-job bundle smoke nor
+  `test:unit:fast` could detect.
+
+## Changed
+
+- `MemoryBackend.get/has/delete/search` now accept an optional
+  `RetrieveOptions { namespace? }` second argument.
+  Backward-compatible: undefined still routes to `defaultNamespace`.
+  Any caller that was using `InMemoryBackend`'s undocumented
+  positional `namespace?: string` parameter (which was never on the
+  `MemoryBackend` interface) needs to switch to the options form.
+  Only one test file in the repo used this shape; it's migrated in
+  the same commit.
+
+- `WorkerManager` interface gains `setKernel(kernel)` and
+  `setMemory(memory)` methods. Promoting these from concrete-class-only
+  to the public interface means dropping the wiring becomes a typed
+  interface break rather than a silent regression — exactly the seam
+  that previous releases (per issue #491) had dropped before, on the
+  mistaken assumption that the `CapturedExperienceBridge` superseded
+  worker domain-access wiring.
+
+- `KernelReference` (a structural shape internal to `worker-manager.ts`)
+  hoisted to `interfaces.ts` as `WorkerKernelReference` so the public
+  `WorkerManager` interface can refer to it without re-introducing the
+  kernel↔worker circular dependency the local declaration was
+  avoiding.
+
+## Behind the scenes
+
+Issue #491 also surfaced a structural gap in the release process: every
+one of the four bugs lived in the daemon-runtime seam, not the `aqe init`
+seam. The pre-publish init-corpus gate (added by issue #401) catches
+init regressions before users see them, but it never starts the daemon
+— so a fully-broken learning loop could sail through as "OK". The two
+gating additions in this release (`integration-tests-on-tag-sha` for
+the SOURCE seam tests, A23 in the init corpus for the INSTALLED PACKAGE
+seam check) close that gap from both directions.
+
+The internal gap analysis catalogued five concrete recommendations; four
+are implemented in this release. The fifth (a separate QualityDaemon
+integration test) was de-scoped on inspection — `QualityDaemon.start()`
+takes only a `WorkerMemory` and never reaches `getDomainAPI`, so the
+StubWorkerDomainAccess failure mode cannot reach it. Existing coverage
+(1540 lines across 10 test files) is sufficient.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentic-qe",
-  "version": "3.9.31",
+  "version": "3.9.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentic-qe",
-      "version": "3.9.31",
+      "version": "3.9.32",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-qe",
-  "version": "3.9.31",
+  "version": "3.9.32",
   "description": "Agentic Quality Engineering V3 - Domain-Driven Design Architecture with 13 Bounded Contexts, O(log n) coverage analysis, ReasoningBank learning, 60 specialized QE agents, mathematical Coherence verification, deep Claude Flow integration",
   "type": "module",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
     "test:all": "npm test -- --run",
     "test:mcp": "npm run test:unit:mcp",
     "test:mcp:integration": "npm test -- --run tests/integration/mcp/",
+    "test:integration:fast": "NODE_OPTIONS='--max-old-space-size=2048 --expose-gc' vitest run tests/integration/mcp/fleet-init-wires-daemon.test.ts tests/integration/workers/workers-reach-domains.test.ts tests/integration/learning/coordinator-roundtrip.test.ts tests/integration/bridge/bridge-end-to-end.test.ts",
+    "test:integration": "NODE_OPTIONS='--max-old-space-size=4096 --expose-gc' vitest run tests/integration/ --exclude='**/browser/**' --exclude='**/browser-integration/**' --exclude='**/*.e2e.test.ts'",
     "mcp:validate": "echo 'MCP validation: All tools registered in MCP server' && exit 0",
     "mcp:report": "echo 'MCP Report: uses vitest for test reporting' && exit 0",
     "test:code-intelligence": "npm test -- --run tests/unit/domains/code-intelligence/ tests/unit/coordination/mincut/",

--- a/src/domains/learning-optimization/services/learning-coordinator.ts
+++ b/src/domains/learning-optimization/services/learning-coordinator.ts
@@ -77,6 +77,15 @@ export interface LearningCoordinatorDependencies {
  */
 const logger = LoggerFactory.create('learning-optimization/learning-coordinator');
 
+/**
+ * #491 Bug 2: every read in this file must pass this namespace to match
+ * the writes (which already specify `namespace: 'learning-optimization'`).
+ * Without it, HybridBackend defaults to `default` and the coordinator
+ * cannot read its own data — `mineExperiences` returned 0 for every
+ * domain even on installs with hundreds of indexed experiences.
+ */
+const LEARNING_NS = { namespace: 'learning-optimization' } as const;
+
 export class LearningCoordinatorService
   implements IPatternLearningService, IExperienceMiningService
 {
@@ -363,10 +372,10 @@ Provide:
   ): Promise<Result<LearnedPattern[]>> {
     try {
       const patterns: LearnedPattern[] = [];
-      const keys = await this.memory.search('learning:pattern:*', 100);
+      const keys = await this.memory.search('learning:pattern:*', 100, LEARNING_NS);
 
       for (const key of keys) {
-        const pattern = await this.memory.get<LearnedPattern>(key);
+        const pattern = await this.memory.get<LearnedPattern>(key, LEARNING_NS);
         if (pattern && this.matchesContext(pattern, context)) {
           patterns.push(pattern);
         }
@@ -425,7 +434,7 @@ Provide:
   ): Promise<Result<void>> {
     try {
       const key = `learning:pattern:${patternId}`;
-      const pattern = await this.memory.get<LearnedPattern>(key);
+      const pattern = await this.memory.get<LearnedPattern>(key, LEARNING_NS);
 
       if (!pattern) {
         return err(new Error(`Pattern ${patternId} not found`));
@@ -471,7 +480,8 @@ Provide:
       const patterns: LearnedPattern[] = [];
       for (const id of patternIds) {
         const pattern = await this.memory.get<LearnedPattern>(
-          `learning:pattern:${id}`
+          `learning:pattern:${id}`,
+          LEARNING_NS
         );
         if (pattern) {
           patterns.push(pattern);
@@ -529,11 +539,11 @@ Provide:
    */
   async getPatternStats(domain?: DomainName): Promise<Result<PatternStats>> {
     try {
-      const keys = await this.memory.search('learning:pattern:*', 500);
+      const keys = await this.memory.search('learning:pattern:*', 500, LEARNING_NS);
       const patterns: LearnedPattern[] = [];
 
       for (const key of keys) {
-        const pattern = await this.memory.get<LearnedPattern>(key);
+        const pattern = await this.memory.get<LearnedPattern>(key, LEARNING_NS);
         if (pattern && (!domain || pattern.domain === domain)) {
           patterns.push(pattern);
         }
@@ -713,15 +723,17 @@ Provide:
     try {
       const keys = await this.memory.search(
         `learning:experience:index:agent:${agentId.value}:*`,
-        limit
+        limit,
+        LEARNING_NS
       );
       const experiences: Experience[] = [];
 
       for (const key of keys) {
-        const experienceId = await this.memory.get<string>(key);
+        const experienceId = await this.memory.get<string>(key, LEARNING_NS);
         if (experienceId) {
           const experience = await this.memory.get<Experience>(
-            `learning:experience:${experienceId}`
+            `learning:experience:${experienceId}`,
+            LEARNING_NS
           );
           if (experience) {
             experiences.push(experience);
@@ -807,19 +819,19 @@ Provide:
 
   private async archivePattern(patternId: string): Promise<void> {
     const key = `learning:pattern:${patternId}`;
-    const pattern = await this.memory.get<LearnedPattern>(key);
+    const pattern = await this.memory.get<LearnedPattern>(key, LEARNING_NS);
     if (pattern) {
       await this.memory.set(`learning:pattern:archived:${patternId}`, pattern, {
         namespace: 'learning-optimization',
         persist: true,
       });
-      await this.memory.delete(key);
+      await this.memory.delete(key, LEARNING_NS);
     }
   }
 
   private async updatePatternUsage(patternId: string): Promise<void> {
     const key = `learning:pattern:${patternId}`;
-    const pattern = await this.memory.get<LearnedPattern>(key);
+    const pattern = await this.memory.get<LearnedPattern>(key, LEARNING_NS);
     if (pattern) {
       const updated: LearnedPattern = {
         ...pattern,
@@ -870,18 +882,32 @@ Provide:
   ): Promise<Experience[]> {
     const keys = await this.memory.search(
       `learning:experience:index:domain:${domain}:*`,
-      1000
+      1000,
+      LEARNING_NS
     );
     const experiences: Experience[] = [];
 
     for (const key of keys) {
-      const experienceId = await this.memory.get<string>(key);
+      const experienceId = await this.memory.get<string>(key, LEARNING_NS);
       if (experienceId) {
         const experience = await this.memory.get<Experience>(
-          `learning:experience:${experienceId}`
+          `learning:experience:${experienceId}`,
+          LEARNING_NS
         );
-        if (experience && timeRange.contains(experience.timestamp)) {
-          experiences.push(experience);
+        if (experience) {
+          // #491 Bug 3: kv stores Date via JSON.stringify (→ ISO string)
+          // but JSON.parse does not re-hydrate. `TimeRange.contains` does
+          // `date >= start`; in `string >= Date`, the string coerces to
+          // NaN and every comparison is false — so every experience was
+          // silently dropped by the time-window filter, leaving
+          // `mineExperiences` mining 0 for every domain. Coerce at the
+          // boundary; downstream code expects a real Date.
+          const ts = experience.timestamp instanceof Date
+            ? experience.timestamp
+            : new Date(experience.timestamp as unknown as string);
+          if (timeRange.contains(ts)) {
+            experiences.push({ ...experience, timestamp: ts });
+          }
         }
       }
     }

--- a/src/kernel/hybrid-backend.ts
+++ b/src/kernel/hybrid-backend.ts
@@ -10,7 +10,7 @@
  * backward compatibility with existing MemoryBackend interface.
  */
 
-import { MemoryBackend, StoreOptions, VectorSearchResult } from './interfaces';
+import { MemoryBackend, StoreOptions, RetrieveOptions, VectorSearchResult } from './interfaces';
 import {
   UnifiedMemoryManager,
   getUnifiedMemory,
@@ -168,21 +168,33 @@ export class HybridMemoryBackend implements MemoryBackend {
   }
 
   /**
-   * Retrieve a value
+   * Retrieve a value.
+   *
+   * #491 Bug 2: previously this method hard-coded `defaultNamespace`, so
+   * any caller that wrote with `set(k, v, {namespace:'foo'})` could not
+   * read its own data back. The whole LearningCoordinator read path
+   * (`getExperiencesByDomainAndTime` etc.) was broken by this — writes
+   * landed in `learning-optimization`, reads queried `default`, and
+   * `mineExperiences` mined 0 for every domain even on installs with
+   * hundreds of indexed experiences. Honor the namespace; default
+   * preserves the historical behavior for the many call sites that
+   * still pass no option.
    */
-  async get<T>(key: string): Promise<T | undefined> {
+  async get<T>(key: string, options?: RetrieveOptions): Promise<T | undefined> {
     this.ensureInitialized();
-    return this.unifiedMemory!.kvGet<T>(key, this.config.defaultNamespace);
+    const namespace = options?.namespace ?? this.config.defaultNamespace;
+    return this.unifiedMemory!.kvGet<T>(key, namespace);
   }
 
   /**
    * Delete a value
    */
-  async delete(key: string): Promise<boolean> {
+  async delete(key: string, options?: RetrieveOptions): Promise<boolean> {
     this.ensureInitialized();
+    const namespace = options?.namespace ?? this.config.defaultNamespace;
 
     // Delete from KV store
-    const kvDeleted = await this.unifiedMemory!.kvDelete(key, this.config.defaultNamespace);
+    const kvDeleted = await this.unifiedMemory!.kvDelete(key, namespace);
 
     // Also try to delete from vectors (in case it's a vector key)
     const vectorDeleted = await this.unifiedMemory!.vectorDelete(key);
@@ -193,17 +205,19 @@ export class HybridMemoryBackend implements MemoryBackend {
   /**
    * Check if key exists
    */
-  async has(key: string): Promise<boolean> {
+  async has(key: string, options?: RetrieveOptions): Promise<boolean> {
     this.ensureInitialized();
-    return this.unifiedMemory!.kvExists(key, this.config.defaultNamespace);
+    const namespace = options?.namespace ?? this.config.defaultNamespace;
+    return this.unifiedMemory!.kvExists(key, namespace);
   }
 
   /**
-   * Search for keys matching pattern
+   * Search for keys matching pattern. See `get` for the namespace rationale.
    */
-  async search(pattern: string, limit: number = 100): Promise<string[]> {
+  async search(pattern: string, limit: number = 100, options?: RetrieveOptions): Promise<string[]> {
     this.ensureInitialized();
-    return this.unifiedMemory!.kvSearch(pattern, this.config.defaultNamespace, limit);
+    const namespace = options?.namespace ?? this.config.defaultNamespace;
+    return this.unifiedMemory!.kvSearch(pattern, namespace, limit);
   }
 
   /**

--- a/src/kernel/interfaces.ts
+++ b/src/kernel/interfaces.ts
@@ -279,17 +279,24 @@ export interface MemoryBackend extends Initializable, Disposable {
   /** Store a value */
   set<T>(key: string, value: T, options?: StoreOptions): Promise<void>;
 
-  /** Retrieve a value */
-  get<T>(key: string): Promise<T | undefined>;
+  /**
+   * Retrieve a value.
+   *
+   * `options.namespace` lets callers read from a non-default namespace.
+   * Without this, a caller that wrote with `set(k, v, {namespace:'foo'})`
+   * could not read its own data back — `get` would silently fall through
+   * to the default namespace and return undefined (issue #491 Bug 2).
+   */
+  get<T>(key: string, options?: RetrieveOptions): Promise<T | undefined>;
 
   /** Delete a value */
-  delete(key: string): Promise<boolean>;
+  delete(key: string, options?: RetrieveOptions): Promise<boolean>;
 
   /** Check if key exists */
-  has(key: string): Promise<boolean>;
+  has(key: string, options?: RetrieveOptions): Promise<boolean>;
 
-  /** Search by pattern */
-  search(pattern: string, limit?: number): Promise<string[]>;
+  /** Search by pattern (`options.namespace` mirrors `get`). */
+  search(pattern: string, limit?: number, options?: RetrieveOptions): Promise<string[]>;
 
   /** Vector similarity search (HNSW) */
   vectorSearch(embedding: number[], k: number): Promise<VectorSearchResult[]>;
@@ -316,6 +323,15 @@ export interface StoreOptions {
   ttl?: number;
   namespace?: string;
   persist?: boolean;
+}
+
+/**
+ * Options for memory read operations. Symmetric with `StoreOptions.namespace`
+ * so a caller can read back exactly what it wrote into a non-default
+ * namespace (issue #491 Bug 2).
+ */
+export interface RetrieveOptions {
+  namespace?: string;
 }
 
 export interface VectorSearchResult {

--- a/src/kernel/memory-backend.ts
+++ b/src/kernel/memory-backend.ts
@@ -3,7 +3,7 @@
  * Hybrid memory implementation (in-memory + optional persistence)
  */
 
-import { MemoryBackend, StoreOptions, VectorSearchResult } from './interfaces';
+import { MemoryBackend, StoreOptions, RetrieveOptions, VectorSearchResult } from './interfaces';
 import { cosineSimilarity } from '../shared/utils/vector-math.js';
 import { MEMORY_CONSTANTS } from './constants.js';
 
@@ -55,8 +55,8 @@ export class InMemoryBackend implements MemoryBackend {
     this.store.set(fullKey, entry);
   }
 
-  async get<T>(key: string, namespace?: string): Promise<T | undefined> {
-    const fullKey = this.buildKey(key, namespace);
+  async get<T>(key: string, options?: RetrieveOptions): Promise<T | undefined> {
+    const fullKey = this.buildKey(key, options?.namespace);
     const entry = this.store.get(fullKey);
 
     if (!entry) {
@@ -72,23 +72,34 @@ export class InMemoryBackend implements MemoryBackend {
     return entry.value as T;
   }
 
-  async delete(key: string, namespace?: string): Promise<boolean> {
-    const fullKey = this.buildKey(key, namespace);
+  async delete(key: string, options?: RetrieveOptions): Promise<boolean> {
+    const fullKey = this.buildKey(key, options?.namespace);
     return this.store.delete(fullKey);
   }
 
-  async has(key: string, namespace?: string): Promise<boolean> {
-    const value = await this.get(key, namespace);
+  async has(key: string, options?: RetrieveOptions): Promise<boolean> {
+    const value = await this.get(key, options);
     return value !== undefined;
   }
 
-  async search(pattern: string, limit: number = MEMORY_CONSTANTS.DEFAULT_SEARCH_LIMIT): Promise<string[]> {
+  async search(
+    pattern: string,
+    limit: number = MEMORY_CONSTANTS.DEFAULT_SEARCH_LIMIT,
+    options?: RetrieveOptions
+  ): Promise<string[]> {
     // Escape regex-special chars first, then convert glob wildcards to regex
     const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
     const regex = new RegExp(escaped.replace(/\*/g, '.*'));
     const results: string[] = [];
 
+    // When a namespace is supplied, scope the scan to that prefix. Matches
+    // HybridBackend's namespace-aware search and lets LearningCoordinator's
+    // namespaced reads behave identically under unit tests that swap in the
+    // in-memory backend (#491 Bug 2).
+    const nsPrefix = options?.namespace ? `${options.namespace}:` : undefined;
+
     for (const key of this.store.keys()) {
+      if (nsPrefix && !key.startsWith(nsPrefix)) continue;
       if (regex.test(key)) {
         results.push(key);
         if (results.length >= limit) break;

--- a/src/mcp/handlers/core-handlers.ts
+++ b/src/mcp/handlers/core-handlers.ts
@@ -211,6 +211,29 @@ export async function handleFleetInit(
       }
     }
 
+    // Issue #491 Bug 1 + Bug 4b: the MCP-hosted daemon constructs its
+    // WorkerManager *before* the kernel exists (in src/mcp/entry.ts), so it
+    // starts with StubWorkerDomainAccess (getDomainAPI returns undefined for
+    // every domain) and a private InMemoryWorkerMemory the dashboard never
+    // reads from. Wire both now that kernel + plugins are ready. Without
+    // this, every domain-dependent worker tick fails with "<domain> not
+    // available" and `aqe learning loop-health` shows learningWorker as
+    // never-ran even when it executes every cycle.
+    try {
+      const { getDaemon } = await import('../../workers/daemon.js');
+      const workerManager = getDaemon().getWorkerManager();
+      workerManager.setKernel(state.kernel);
+      workerManager.setMemory(state.kernel.memory);
+    } catch (err) {
+      // Daemon wiring is best-effort: a workless smoke install (e.g. some
+      // unit-test harnesses) may not even bundle the daemon module. Surface
+      // as a warning but don't fail fleet_init — the user still gets a
+      // working kernel + queen for MCP tool calls.
+      console.warn(
+        `[fleet_init] Daemon worker manager wiring skipped: ${toErrorMessage(err)}`
+      );
+    }
+
     // Create Queen Coordinator with domain plugins for direct task execution
     state.queen = createQueenCoordinator(
       state.kernel,

--- a/src/workers/interfaces.ts
+++ b/src/workers/interfaces.ts
@@ -255,6 +255,18 @@ export interface WorkerDomainAccess {
   getDomainHealth(domain: DomainName): { status: string; errors: string[] };
 }
 
+/**
+ * Structural shape of the kernel that worker-side code needs. Declared here
+ * (rather than imported from src/kernel) to avoid a circular dependency between
+ * the kernel and the workers package.
+ */
+export interface WorkerKernelReference {
+  getDomainAPI<T>(domain: DomainName): T | undefined;
+  getHealth(): {
+    domains: Record<string, { status: string; errors?: string[] }>;
+  };
+}
+
 // ============================================================================
 // Worker Health
 // ============================================================================
@@ -330,6 +342,20 @@ export interface WorkerManager {
    * Get manager health status
    */
   getHealth(): WorkerManagerHealth;
+
+  /**
+   * Bind the kernel late, after construction. Without this, workers fall
+   * through to a stub domain-access that returns undefined for every domain,
+   * causing every domain-dependent worker tick to fail (issue #491 Bug 1).
+   */
+  setKernel(kernel: WorkerKernelReference): void;
+
+  /**
+   * Bind the worker manager's memory to a shared instance (e.g. the kernel's
+   * HybridMemoryBackend) so workers and the dashboards that read worker output
+   * resolve to the same kv store (issue #491 Bug 4b).
+   */
+  setMemory(memory: WorkerMemory): void;
 }
 
 export interface WorkerManagerHealth {

--- a/src/workers/worker-manager.ts
+++ b/src/workers/worker-manager.ts
@@ -17,6 +17,7 @@ import {
   WorkerLogger,
   WorkerDomainAccess,
   WorkerEvent,
+  WorkerKernelReference,
 } from './interfaces';
 import { DomainName } from '../shared/types';
 
@@ -166,14 +167,12 @@ class KernelWorkerDomainAccess implements WorkerDomainAccess {
 }
 
 /**
- * Reference interface for kernel (to avoid circular dependency)
+ * Local alias for the shared worker-kernel structural shape. The public type
+ * lives in interfaces.ts so the WorkerManager interface can refer to it
+ * without importing this file (which would re-introduce the circular
+ * dependency the original local declaration was avoiding).
  */
-interface KernelReference {
-  getDomainAPI<T>(domain: DomainName): T | undefined;
-  getHealth(): {
-    domains: Record<string, { status: string; errors?: string[] }>;
-  };
-}
+type KernelReference = WorkerKernelReference;
 
 /**
  * Stub Domain Access (fallback when kernel not available)
@@ -196,7 +195,7 @@ export class WorkerManagerImpl implements IWorkerManager {
   private timers = new Map<string, NodeJS.Timeout>();
   private abortControllers = new Map<string, AbortController>();
   private eventBus: InMemoryWorkerEventBus;
-  private memory: InMemoryWorkerMemory;
+  private memory: WorkerMemory;
   private domainAccess: WorkerDomainAccess;
   private running = false;
   private kernelRef: KernelReference | undefined;
@@ -208,7 +207,7 @@ export class WorkerManagerImpl implements IWorkerManager {
     kernel?: KernelReference;
   }) {
     this.eventBus = (options?.eventBus as InMemoryWorkerEventBus) ?? new InMemoryWorkerEventBus();
-    this.memory = (options?.memory as InMemoryWorkerMemory) ?? new InMemoryWorkerMemory();
+    this.memory = options?.memory ?? new InMemoryWorkerMemory();
     this.kernelRef = options?.kernel;
 
     // Use kernel-based domain access if kernel is provided, otherwise fall back
@@ -231,6 +230,18 @@ export class WorkerManagerImpl implements IWorkerManager {
     if (this.domainAccess instanceof StubWorkerDomainAccess) {
       this.domainAccess = new KernelWorkerDomainAccess(() => this.kernelRef);
     }
+  }
+
+  /**
+   * Replace the worker manager's memory with a shared instance — typically the
+   * kernel's HybridMemoryBackend so dashboards reading worker-emitted keys
+   * (e.g. `learning:loop-health` in the `qe-kernel` namespace) actually see
+   * what workers write. Without this, workers write to the in-process
+   * InMemoryWorkerMemory and the dashboard reads a different kv (issue #491
+   * Bug 4b).
+   */
+  setMemory(memory: WorkerMemory): void {
+    this.memory = memory;
   }
 
   /**

--- a/src/workers/workers/learning-consolidation.ts
+++ b/src/workers/workers/learning-consolidation.ts
@@ -158,121 +158,145 @@ export class LearningConsolidationWorker extends BaseWorker {
     const findings: WorkerFinding[] = [];
     const recommendations: WorkerRecommendation[] = [];
 
-    // Initialize Phase 7 metrics
-    let experiencesProcessed = 0;
-    let patternCandidatesFound = 0;
-    let patternsPromoted = 0;
-    let patternsDeprecated = 0;
-    let confidenceDecayApplied = 0;
-    let patternsMined = 0;
-    let domainsMined = 0;
-    let dreamInsightsPruned = 0;
+    // #491 Bug 4a: liveness must be reported on every tick, including the
+    // failure path. Before this fix, `recordLoopHealth(success:true)` sat
+    // *after* `collectPatterns()`, which throws on installs with nothing
+    // to consolidate — so loop-health permanently showed `never-ran`
+    // even when the worker executed every cycle. Track success in a flag
+    // and emit the ping in `finally` (matches the
+    // CapturedExperienceBridge.drainSafe pattern that ships correctly).
+    let liveness: { success: boolean; error?: string } = { success: false };
+    try {
+      // Initialize Phase 7 metrics
+      let experiencesProcessed = 0;
+      let patternCandidatesFound = 0;
+      let patternsPromoted = 0;
+      let patternsDeprecated = 0;
+      let confidenceDecayApplied = 0;
+      let patternsMined = 0;
+      let domainsMined = 0;
+      let dreamInsightsPruned = 0;
 
-    // Phase 7: Run continuous learning loop
-    const lifecycleManager = await this.getLifecycleManager();
-    if (lifecycleManager) {
-      const lifecycleResult = await this.runContinuousLearningLoop(
-        context,
-        lifecycleManager,
+      // Phase 7: Run continuous learning loop
+      const lifecycleManager = await this.getLifecycleManager();
+      if (lifecycleManager) {
+        const lifecycleResult = await this.runContinuousLearningLoop(
+          context,
+          lifecycleManager,
+          findings,
+          recommendations
+        );
+        experiencesProcessed = lifecycleResult.experiencesProcessed;
+        patternCandidatesFound = lifecycleResult.patternCandidatesFound;
+        patternsPromoted = lifecycleResult.patternsPromoted;
+        patternsDeprecated = lifecycleResult.patternsDeprecated;
+        confidenceDecayApplied = lifecycleResult.confidenceDecayApplied;
+        patternsMined = lifecycleResult.patternsMined;
+        domainsMined = lifecycleResult.domainsMined;
+        dreamInsightsPruned = lifecycleResult.dreamInsightsPruned;
+      }
+
+      // Collect patterns from all domains
+      const patterns = await this.collectPatterns(context);
+
+      // Consolidate and analyze
+      const result = await this.consolidatePatterns(context, patterns);
+
+      // Add Phase 7 metrics to result
+      result.experiencesProcessed = experiencesProcessed;
+      result.patternCandidatesFound = patternCandidatesFound;
+      result.patternsPromoted = patternsPromoted;
+      result.patternsDeprecated = patternsDeprecated;
+      result.confidenceDecayApplied = confidenceDecayApplied;
+      result.patternsMined = patternsMined;
+      result.domainsMined = domainsMined;
+      result.dreamInsightsPruned = dreamInsightsPruned;
+
+      // Identify cross-domain patterns
+      this.identifyCrossDomainPatterns(patterns, findings, recommendations);
+
+      // Prune ineffective patterns
+      this.pruneIneffectivePatterns(patterns, findings, recommendations);
+
+      // Generate optimization recommendations
+      this.generateOptimizations(patterns, findings, recommendations);
+
+      // ADR-046: Run dream cycle for pattern discovery
+      const dreamResult = await this.runDreamCycle(context, patterns, findings, recommendations);
+      result.dreamInsights = dreamResult.insights;
+      result.dreamPatternsCreated = dreamResult.patternsCreated;
+
+      // Store consolidated results
+      await context.memory.set('learning:lastConsolidation', result);
+      await context.memory.set('learning:consolidatedPatterns', patterns);
+
+      // Reached the end without throwing — this tick is a real success.
+      liveness = { success: true };
+
+      // Update last run timestamp for decay calculation
+      this.lastRunTimestamp = Date.now();
+
+      const healthScore = this.calculateHealthScore(result, patterns);
+
+      context.logger.info('Learning consolidation complete', {
+        healthScore,
+        patternsAnalyzed: result.patternsAnalyzed,
+        newInsights: result.newInsights,
+        // Phase 7 metrics
+        experiencesProcessed,
+        patternsPromoted,
+        patternsDeprecated,
+      });
+
+      return this.createResult(
+        Date.now() - startTime,
+        {
+          itemsAnalyzed: result.patternsAnalyzed,
+          issuesFound: result.patternsPruned + result.patternsDeprecated,
+          healthScore,
+          trend: this.determineTrend(result),
+          domainMetrics: {
+            patternsAnalyzed: result.patternsAnalyzed,
+            patternsPruned: result.patternsPruned,
+            patternsConsolidated: result.patternsConsolidated,
+            newInsights: result.newInsights,
+            crossDomainPatterns: result.crossDomainPatterns,
+            // ADR-046: Dream cycle metrics
+            dreamInsights: result.dreamInsights,
+            dreamPatternsCreated: result.dreamPatternsCreated,
+            // Phase 7: Continuous Learning Loop metrics
+            experiencesProcessed: result.experiencesProcessed,
+            patternCandidatesFound: result.patternCandidatesFound,
+            patternsPromoted: result.patternsPromoted,
+            patternsDeprecated: result.patternsDeprecated,
+            confidenceDecayApplied: result.confidenceDecayApplied,
+            // #486 Gap A: mineExperiences auto-trigger
+            patternsMined: result.patternsMined,
+            domainsMined: result.domainsMined,
+            // #488 C.2: dream_insights retention pruning
+            dreamInsightsPruned: result.dreamInsightsPruned,
+          },
+        },
         findings,
         recommendations
       );
-      experiencesProcessed = lifecycleResult.experiencesProcessed;
-      patternCandidatesFound = lifecycleResult.patternCandidatesFound;
-      patternsPromoted = lifecycleResult.patternsPromoted;
-      patternsDeprecated = lifecycleResult.patternsDeprecated;
-      confidenceDecayApplied = lifecycleResult.confidenceDecayApplied;
-      patternsMined = lifecycleResult.patternsMined;
-      domainsMined = lifecycleResult.domainsMined;
-      dreamInsightsPruned = lifecycleResult.dreamInsightsPruned;
+    } catch (error) {
+      // Record the failure shape and rethrow — BaseWorker handles
+      // worker-level retry/error tracking via this throw.
+      liveness = { success: false, error: error instanceof Error ? error.message : String(error) };
+      throw error;
+    } finally {
+      // #491 Bug 4a: liveness must always reach the dashboard, even when
+      // collectPatterns throws on empty installs. Best-effort — must not
+      // throw or it would shadow the original error.
+      try {
+        await recordLoopHealth(context.memory, 'learningWorker', liveness);
+      } catch (recordErr) {
+        context.logger.warn('recordLoopHealth failed (non-fatal)', {
+          error: recordErr instanceof Error ? recordErr.message : String(recordErr),
+        });
+      }
     }
-
-    // Collect patterns from all domains
-    const patterns = await this.collectPatterns(context);
-
-    // Consolidate and analyze
-    const result = await this.consolidatePatterns(context, patterns);
-
-    // Add Phase 7 metrics to result
-    result.experiencesProcessed = experiencesProcessed;
-    result.patternCandidatesFound = patternCandidatesFound;
-    result.patternsPromoted = patternsPromoted;
-    result.patternsDeprecated = patternsDeprecated;
-    result.confidenceDecayApplied = confidenceDecayApplied;
-    result.patternsMined = patternsMined;
-    result.domainsMined = domainsMined;
-    result.dreamInsightsPruned = dreamInsightsPruned;
-
-    // Identify cross-domain patterns
-    this.identifyCrossDomainPatterns(patterns, findings, recommendations);
-
-    // Prune ineffective patterns
-    this.pruneIneffectivePatterns(patterns, findings, recommendations);
-
-    // Generate optimization recommendations
-    this.generateOptimizations(patterns, findings, recommendations);
-
-    // ADR-046: Run dream cycle for pattern discovery
-    const dreamResult = await this.runDreamCycle(context, patterns, findings, recommendations);
-    result.dreamInsights = dreamResult.insights;
-    result.dreamPatternsCreated = dreamResult.patternsCreated;
-
-    // Store consolidated results
-    await context.memory.set('learning:lastConsolidation', result);
-    await context.memory.set('learning:consolidatedPatterns', patterns);
-
-    // #488 B.2: record loop-health so `aqe learning loop-health` can show
-    // the consolidation worker as alive. Records success even for empty
-    // ticks — "ran the loop, found nothing" is still a liveness signal.
-    await recordLoopHealth(context.memory, 'learningWorker', { success: true });
-
-    // Update last run timestamp for decay calculation
-    this.lastRunTimestamp = Date.now();
-
-    const healthScore = this.calculateHealthScore(result, patterns);
-
-    context.logger.info('Learning consolidation complete', {
-      healthScore,
-      patternsAnalyzed: result.patternsAnalyzed,
-      newInsights: result.newInsights,
-      // Phase 7 metrics
-      experiencesProcessed,
-      patternsPromoted,
-      patternsDeprecated,
-    });
-
-    return this.createResult(
-      Date.now() - startTime,
-      {
-        itemsAnalyzed: result.patternsAnalyzed,
-        issuesFound: result.patternsPruned + result.patternsDeprecated,
-        healthScore,
-        trend: this.determineTrend(result),
-        domainMetrics: {
-          patternsAnalyzed: result.patternsAnalyzed,
-          patternsPruned: result.patternsPruned,
-          patternsConsolidated: result.patternsConsolidated,
-          newInsights: result.newInsights,
-          crossDomainPatterns: result.crossDomainPatterns,
-          // ADR-046: Dream cycle metrics
-          dreamInsights: result.dreamInsights,
-          dreamPatternsCreated: result.dreamPatternsCreated,
-          // Phase 7: Continuous Learning Loop metrics
-          experiencesProcessed: result.experiencesProcessed,
-          patternCandidatesFound: result.patternCandidatesFound,
-          patternsPromoted: result.patternsPromoted,
-          patternsDeprecated: result.patternsDeprecated,
-          confidenceDecayApplied: result.confidenceDecayApplied,
-          // #486 Gap A: mineExperiences auto-trigger
-          patternsMined: result.patternsMined,
-          domainsMined: result.domainsMined,
-          // #488 C.2: dream_insights retention pruning
-          dreamInsightsPruned: result.dreamInsightsPruned,
-        },
-      },
-      findings,
-      recommendations
-    );
   }
 
   /**

--- a/tests/fixtures/init-corpus/MANIFEST.json
+++ b/tests/fixtures/init-corpus/MANIFEST.json
@@ -1,12 +1,13 @@
 {
   "$schema": "./MANIFEST.schema.json",
-  "schemaVersion": 3,
+  "schemaVersion": 4,
   "description": "Pinned real-public-repo fixtures for the aqe init release gate. See README.md for the rationale and update procedure.",
   "issue": "https://github.com/proffesor-for-testing/agentic-qe/issues/401",
   "schemaChangelog": {
     "1": "Initial schema with per-fixture timeout, expectMinKgEntries floor",
     "2": "Snapshot-based KG threshold (expectedKgEntries + tolerance), mustContainFileSha256, mirror URL field, devils-advocate review fixes from #401",
-    "3": "expectedElapsedSec for subthreshold stall detection, doubleInit flag for delta-path coverage"
+    "3": "expectedElapsedSec for subthreshold stall detection, doubleInit flag for delta-path coverage",
+    "4": "expectDaemonLiveness + daemonLivenessWaitSec — A23 starts the daemon post-init and asserts zero 'domain not available' lines. Catches the issue #491 class of bug where init looks fine but the daemon-runtime seam is broken."
   },
   "fixtures": [
     {
@@ -33,7 +34,9 @@
         "expectedSkillsInstalled": 1,
         "expectedAgentsInstalled": 1,
         "expectMcpConfigured": true,
-        "doubleInit": true
+        "doubleInit": true,
+        "expectDaemonLiveness": true,
+        "daemonLivenessWaitSec": 15
       }
     },
     {

--- a/tests/fixtures/init-corpus/run-gate.sh
+++ b/tests/fixtures/init-corpus/run-gate.sh
@@ -176,6 +176,14 @@ skipped=0
 #       (exercises the incremental delta-scan code path of phase 06 — the
 #        actual surface that hung in v3.9.1 ruview, which the first init
 #        of any cleanroom never touches)
+#   A23 if expectDaemonLiveness: start the background daemon, wait
+#       daemonLivenessWaitSec (default 20s), assert ZERO "domain not
+#       available" / "not available for" lines on stderr, then kill the
+#       daemon. Catches the class of bug in issue #491 that `aqe init`
+#       alone cannot surface — every Bug 1-style "worker can't reach
+#       its domain" failure lives in the daemon-startup seam, not in
+#       init. Opt-in per fixture; default false so existing fixtures
+#       keep their ~5s budget.
 #
 # Each assertion writes its verdict to the summary line for the fixture.
 # ---------------------------------------------------------------------------
@@ -193,6 +201,8 @@ run_one() {
   local double_init="${10}"
   local must_contain_file="${11}"
   local must_contain_file_sha256="${12}"
+  local expect_daemon_liveness="${13:-false}"
+  local daemon_liveness_wait_sec="${14:-20}"
 
   local log="${LOG_DIR}/${id}.log"
   local json="${LOG_DIR}/${id}.json"
@@ -624,6 +634,80 @@ run_one() {
     echo "[gate]   second init OK (${elapsed2}s, delta-scan path exercised)" | tee -a "${log}"
   fi
 
+  # ----- A23: daemon liveness -----------------------------------------
+  # Spawn the daemon, wait `daemon_liveness_wait_sec`, assert zero
+  # "domain not available" / worker-wiring-failure lines on stderr.
+  # Catches the class of bug in issue #491 that `aqe init` alone CANNOT
+  # surface (the seam between MCP server, kernel, and worker manager
+  # opens during fleet_init, which only happens at daemon start —
+  # never during init). Opt-in per fixture; default off so existing
+  # fixtures keep their current ~5s budget. See MANIFEST.schema.json.
+  if [[ "${expect_daemon_liveness}" == "true" ]]; then
+    echo "[gate]   --- daemon liveness check (waiting ${daemon_liveness_wait_sec}s) ---" | tee -a "${log}"
+
+    local daemon_script="${tmpdir}/.agentic-qe/workers/start-daemon.cjs"
+    if [[ ! -f "${daemon_script}" ]]; then
+      echo "[gate]   FAIL A23: start-daemon.cjs not found at ${daemon_script}" | tee -a "${log}"
+      echo "${id} FAIL A23-no-daemon-script" >> "${SUMMARY}"
+      popd >/dev/null
+      [[ "${AQE_GATE_KEEP_TMPDIRS:-0}" == "1" ]] || rm -rf "${tmpdir}"
+      return 1
+    fi
+
+    local daemon_log="${tmpdir}/.agentic-qe/workers/daemon.log"
+    : > "${daemon_log}"
+
+    # Run the daemon detached and capture stderr (which is where workers
+    # log their domain-resolution failures).
+    (
+      cd "${tmpdir}"
+      # PATH-prepend the host install so npx fallback inside the helper
+      # resolves to the same binary every other gate assertion uses.
+      PATH="${HOST_DIR}/node_modules/.bin:${PATH}" \
+        node "${daemon_script}" >"${daemon_log}" 2>&1 &
+      echo $! >"${tmpdir}/.daemon.pid"
+    )
+
+    local daemon_pid
+    daemon_pid=$(cat "${tmpdir}/.daemon.pid" 2>/dev/null || echo "")
+    if [[ -z "${daemon_pid}" ]] || ! kill -0 "${daemon_pid}" 2>/dev/null; then
+      echo "[gate]   FAIL A23: daemon did not stay alive" | tee -a "${log}"
+      tail -20 "${daemon_log}" 2>/dev/null | sed 's/^/      | /' | tee -a "${log}" || true
+      echo "${id} FAIL A23-daemon-died-on-start" >> "${SUMMARY}"
+      popd >/dev/null
+      [[ "${AQE_GATE_KEEP_TMPDIRS:-0}" == "1" ]] || rm -rf "${tmpdir}"
+      return 1
+    fi
+
+    sleep "${daemon_liveness_wait_sec}"
+
+    # Cleanup the daemon — best effort, since the gate continues regardless.
+    if kill -0 "${daemon_pid}" 2>/dev/null; then
+      kill -TERM "${daemon_pid}" 2>/dev/null || true
+      sleep 2
+      kill -KILL "${daemon_pid}" 2>/dev/null || true
+    fi
+
+    # Grep for the failure shapes from #491. A live daemon with the
+    # kernel correctly wired produces zero matches; a broken daemon
+    # produces 14+ per cycle.
+    local not_avail_count
+    not_avail_count=$(grep -c -E "domain not available|Domain not available|not available for" "${daemon_log}" 2>/dev/null || true)
+    if [[ -z "${not_avail_count}" ]]; then not_avail_count=0; fi
+
+    if (( not_avail_count > 0 )); then
+      echo "[gate]   FAIL A23: ${not_avail_count} 'domain not available' lines in daemon.log" | tee -a "${log}"
+      grep -E "domain not available|Domain not available|not available for" "${daemon_log}" 2>/dev/null \
+        | head -5 | sed 's/^/      | /' | tee -a "${log}"
+      echo "${id} FAIL A23-domain-not-available (${not_avail_count} occurrences)" >> "${SUMMARY}"
+      popd >/dev/null
+      [[ "${AQE_GATE_KEEP_TMPDIRS:-0}" == "1" ]] || rm -rf "${tmpdir}"
+      return 1
+    fi
+
+    echo "[gate]   daemon liveness OK (0 'not available' lines after ${daemon_liveness_wait_sec}s)" | tee -a "${log}"
+  fi
+
   echo "[gate]   PASS (${elapsed}s, kg=${kg_entries}, skills=${skills_installed}, agents=${agents_installed}, agentsOnDisk=${agents_on_disk}, skillsOnDisk=${skills_on_disk}, workers=${workers_max})" | tee -a "${log}"
   echo "${id} PASS ${elapsed}s kg=${kg_entries} skills=${skills_max} agents=${agents_max} workers=${workers_max}" >> "${SUMMARY}"
 
@@ -658,6 +742,8 @@ for i in $(seq 0 $((fixture_count - 1))); do
   double_init=$(jq -r ".fixtures[${i}].gate.doubleInit // false" "${MANIFEST}")
   must_contain=$(jq -r ".fixtures[${i}].gate.mustContainFile // empty" "${MANIFEST}")
   must_contain_sha=$(jq -r ".fixtures[${i}].gate.mustContainFileSha256 // empty" "${MANIFEST}")
+  expect_daemon_liveness=$(jq -r ".fixtures[${i}].gate.expectDaemonLiveness // false" "${MANIFEST}")
+  daemon_liveness_wait=$(jq -r ".fixtures[${i}].gate.daemonLivenessWaitSec // 20" "${MANIFEST}")
 
   if [[ "${has_tarball}" == "true" ]]; then
     extracted_dir=$(jq -r ".fixtures[${i}].extractedDir" "${MANIFEST}")
@@ -677,7 +763,8 @@ for i in $(seq 0 $((fixture_count - 1))); do
     "${expected_kg}" "${kg_tolerance}" "${expected_elapsed}" \
     "${expected_skills}" "${expected_agents}" "${expect_mcp}" \
     "${double_init}" \
-    "${must_contain}" "${must_contain_sha}"; then
+    "${must_contain}" "${must_contain_sha}" \
+    "${expect_daemon_liveness}" "${daemon_liveness_wait}"; then
     passes=$((passes + 1))
   else
     failures=$((failures + 1))

--- a/tests/integration/learning/coordinator-roundtrip.test.ts
+++ b/tests/integration/learning/coordinator-roundtrip.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Issue #491 Bug 2 + Bug 3 — LearningCoordinator write→read round trip.
+ *
+ * This is the test that was missing. The existing bridge-end-to-end test
+ * exercises only the *write* side and queries the DB directly via SQLite,
+ * so it never noticed that:
+ *
+ *   - Bug 2: LearningCoordinator writes with `namespace:'learning-optimization'`
+ *     but HybridBackend's `get`/`search` hard-coded `defaultNamespace='default'`.
+ *     The coordinator could not read back its own writes — `mineExperiences`
+ *     returned 0 for every domain on installs with hundreds of indexed
+ *     experiences.
+ *
+ *   - Bug 3: kv stores `Date` via JSON.stringify (→ ISO string), but
+ *     deserialization returns the string verbatim. `TimeRange.contains`
+ *     compares `date >= start`; in `string >= Date`, the string coerces to
+ *     NaN — so every window check returned false even after Bug 2 was
+ *     fixed.
+ *
+ * This test runs the full path: same kernel, same HybridBackend instance,
+ * recordExperience → mineExperiences. If either bug regresses, this fails.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { QEKernelImpl } from '../../../src/kernel/kernel';
+import {
+  initializeUnifiedMemory,
+  resetUnifiedMemory,
+} from '../../../src/kernel/unified-memory';
+import { createLearningCoordinatorService } from '../../../src/domains/learning-optimization/services/learning-coordinator';
+import { TimeRange } from '../../../src/shared/value-objects/index.js';
+import type { ExperienceResult, StateSnapshot } from '../../../src/domains/learning-optimization/interfaces.js';
+
+describe('Issue #491 Bug 2 + Bug 3 — LearningCoordinator round trip', () => {
+  let dataDir: string;
+  let kernel: QEKernelImpl;
+
+  beforeEach(async () => {
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aqe-roundtrip-'));
+    fs.mkdirSync(path.join(dataDir, '.agentic-qe'), { recursive: true });
+    await initializeUnifiedMemory({
+      dbPath: path.join(dataDir, '.agentic-qe', 'memory.db'),
+    });
+
+    kernel = new QEKernelImpl({
+      memoryBackend: 'hybrid',
+      dataDir: path.join(dataDir, '.agentic-qe'),
+      enabledDomains: ['learning-optimization'],
+    });
+    await kernel.initialize();
+  });
+
+  afterEach(async () => {
+    if (kernel) await kernel.dispose();
+    resetUnifiedMemory();
+    if (fs.existsSync(dataDir)) fs.rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it('recordExperience followed by mineExperiences finds the experience back', async () => {
+    const coordinator = createLearningCoordinatorService(kernel.memory);
+
+    const state: StateSnapshot = {
+      context: { task: 'integration-test' },
+      metrics: { latencyMs: 12 },
+    };
+    const result: ExperienceResult = {
+      success: true,
+      outcome: { latencyMs: 12 },
+      duration: 12,
+    };
+
+    const recorded = await coordinator.recordExperience({
+      agentId: { value: 'agent-1', domain: 'learning-optimization', type: 'tester' },
+      domain: 'learning-optimization',
+      action: 'run-test',
+      state,
+      result,
+      reward: 1,
+    });
+    expect(recorded.success).toBe(true);
+
+    // Window centered on now, generous enough to catch the just-written
+    // experience even with sub-second clock skew between writes and the
+    // TimeRange construction.
+    const now = Date.now();
+    const window = TimeRange.create(new Date(now - 60_000), new Date(now + 60_000));
+
+    const mined = await coordinator.mineExperiences('learning-optimization', window);
+    expect(mined.success).toBe(true);
+    if (mined.success) {
+      // Pre-fix: experienceCount was always 0 here (Bug 2: read in wrong
+      // namespace → no keys found at all). Even with namespaces aligned,
+      // Bug 3 would still drop every row because the string timestamp
+      // fails the TimeRange contains() check.
+      expect(mined.value.experienceCount).toBeGreaterThan(0);
+    }
+  });
+
+  it('mined experience has a real Date timestamp (not a serialized string)', async () => {
+    const coordinator = createLearningCoordinatorService(kernel.memory);
+
+    await coordinator.recordExperience({
+      agentId: { value: 'agent-1', domain: 'learning-optimization', type: 'tester' },
+      domain: 'learning-optimization',
+      action: 'run-test',
+      state: { context: {}, metrics: {} },
+      result: { success: true, outcome: {}, duration: 1 },
+      reward: 1,
+    });
+
+    // Reach behind the public API to verify the timestamp re-hydration at
+    // the kv boundary. We rely on the internal helper exposed for tests
+    // through structural access, since mineExperiences aggregates and
+    // doesn't return raw experiences.
+    const now = Date.now();
+    const window = TimeRange.create(new Date(now - 60_000), new Date(now + 60_000));
+    const internal = coordinator as unknown as {
+      getExperiencesByDomainAndTime: (
+        d: string,
+        r: TimeRange
+      ) => Promise<Array<{ timestamp: unknown }>>;
+    };
+    const rows = await internal.getExperiencesByDomainAndTime('learning-optimization', window);
+
+    expect(rows.length).toBeGreaterThan(0);
+    // Bug 3 regression marker: this MUST be a real Date object after the
+    // kv round-trip. Before the fix it would be a string here, which made
+    // every downstream TimeRange.contains() comparison return false.
+    expect(rows[0]!.timestamp).toBeInstanceOf(Date);
+  });
+
+  it('time window EXCLUDES experiences recorded outside it (sanity)', async () => {
+    const coordinator = createLearningCoordinatorService(kernel.memory);
+
+    await coordinator.recordExperience({
+      agentId: { value: 'agent-1', domain: 'learning-optimization', type: 'tester' },
+      domain: 'learning-optimization',
+      action: 'run-test',
+      state: { context: {}, metrics: {} },
+      result: { success: true, outcome: {}, duration: 1 },
+      reward: 1,
+    });
+
+    // Window deliberately in the past — must return zero hits, proving the
+    // window filter still works (we want to fix Bug 3 without making
+    // TimeRange.contains a no-op).
+    const pastWindow = TimeRange.create(
+      new Date(Date.now() - 2 * 86400_000),
+      new Date(Date.now() - 86400_000)
+    );
+
+    const mined = await coordinator.mineExperiences('learning-optimization', pastWindow);
+    expect(mined.success).toBe(true);
+    if (mined.success) {
+      expect(mined.value.experienceCount).toBe(0);
+    }
+  });
+});

--- a/tests/integration/mcp/fleet-init-wires-daemon.test.ts
+++ b/tests/integration/mcp/fleet-init-wires-daemon.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Integration test for issue #491 Bug 1 + Bug 4b.
+ *
+ * The MCP-hosted daemon constructs its WorkerManager *before* the kernel
+ * exists (src/mcp/entry.ts calls daemon.start() with no kernel) and is
+ * given no late hook to learn about the kernel. Until v3.9.30, that meant
+ * every domain-dependent worker tick failed with "<domain> not available"
+ * and `aqe learning loop-health` showed `learningWorker: never-ran` even
+ * when the worker ran every cycle.
+ *
+ * This test pins the contract: after handleFleetInit returns, the global
+ * daemon's WorkerManager:
+ *   1. resolves a real domain API (not undefined from StubWorkerDomainAccess)
+ *   2. holds the same memory instance the kernel holds (so worker writes
+ *      reach the dashboard's reads)
+ *
+ * If anyone ever drops the setKernel / setMemory wiring from handleFleetInit
+ * again — as #491 documents has happened before — this test fails before
+ * users ever see it.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  handleFleetInit,
+  disposeFleet,
+  getFleetState,
+} from '../../../src/mcp/handlers/core-handlers';
+import { getDaemon, resetDaemon } from '../../../src/workers/daemon';
+
+describe('Issue #491 — fleet_init wires daemon WorkerManager', () => {
+  beforeEach(async () => {
+    // Both globals must be reset so each test sees a fresh wiring path.
+    await disposeFleet();
+    resetDaemon();
+  });
+
+  afterEach(async () => {
+    await disposeFleet();
+    resetDaemon();
+  });
+
+  it('exposes a non-undefined domain API from the daemon worker manager', async () => {
+    // Pre-init the daemon to reproduce the production sequence (entry.ts
+    // creates the daemon before the kernel exists).
+    const daemon = getDaemon();
+    const workerManager = daemon.getWorkerManager();
+
+    // Sanity: with no kernel, the worker manager's domain access returns
+    // undefined for every domain. This is the StubWorkerDomainAccess
+    // failure mode from Bug 1.
+    const beforeCtx = (workerManager as unknown as {
+      createContext: (id: string, signal: AbortSignal) => {
+        domains: { getDomainAPI: <T>(d: string) => T | undefined };
+      };
+    }).createContext('test-pre', new AbortController().signal);
+    expect(beforeCtx.domains.getDomainAPI('learning-optimization')).toBeUndefined();
+
+    // Now call handleFleetInit — this is the seam where the wiring must happen.
+    const result = await handleFleetInit({
+      memoryBackend: 'memory',
+      maxAgents: 2,
+      lazyLoading: false, // load every plugin so domain APIs resolve
+    });
+    expect(result.success).toBe(true);
+
+    // Post-init: the worker manager must resolve a real domain API.
+    const afterCtx = (workerManager as unknown as {
+      createContext: (id: string, signal: AbortSignal) => {
+        domains: { getDomainAPI: <T>(d: string) => T | undefined };
+      };
+    }).createContext('test-post', new AbortController().signal);
+
+    const learningAPI = afterCtx.domains.getDomainAPI('learning-optimization');
+    expect(learningAPI).toBeDefined();
+  });
+
+  it('shares the kernel memory instance with workers (Bug 4b)', async () => {
+    // Pre-init the daemon and grab its initial memory.
+    const daemon = getDaemon();
+    const workerManager = daemon.getWorkerManager();
+
+    // Initialise the fleet.
+    const result = await handleFleetInit({
+      memoryBackend: 'memory',
+      maxAgents: 2,
+      lazyLoading: false,
+    });
+    expect(result.success).toBe(true);
+
+    // After init, the worker manager's memory must be the kernel's memory.
+    // If they diverge, anything a worker writes (e.g. learning:loop-health)
+    // never lands in the kv the dashboard reads from.
+    const kernelMemory = getFleetState().kernel?.memory;
+    expect(kernelMemory).toBeDefined();
+
+    const afterCtx = (workerManager as unknown as {
+      createContext: (id: string, signal: AbortSignal) => {
+        memory: unknown;
+      };
+    }).createContext('test-mem', new AbortController().signal);
+
+    expect(afterCtx.memory).toBe(kernelMemory);
+  });
+
+  it('still surfaces a domain API after a second fleet_init (idempotency guard)', async () => {
+    const daemon = getDaemon();
+    const workerManager = daemon.getWorkerManager();
+
+    const first = await handleFleetInit({
+      memoryBackend: 'memory',
+      maxAgents: 2,
+      lazyLoading: false,
+    });
+    expect(first.success).toBe(true);
+
+    // Second call — handleFleetInit early-returns when already initialized.
+    // The wiring established by the first call must survive.
+    const second = await handleFleetInit({
+      memoryBackend: 'memory',
+      maxAgents: 2,
+      lazyLoading: false,
+    });
+    expect(second.success).toBe(true);
+
+    const ctx = (workerManager as unknown as {
+      createContext: (id: string, signal: AbortSignal) => {
+        domains: { getDomainAPI: <T>(d: string) => T | undefined };
+      };
+    }).createContext('test-second', new AbortController().signal);
+
+    expect(ctx.domains.getDomainAPI('learning-optimization')).toBeDefined();
+  });
+});

--- a/tests/integration/workers/workers-reach-domains.test.ts
+++ b/tests/integration/workers/workers-reach-domains.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Issue #491 follow-up — generalize Bug 1 protection to every worker.
+ *
+ * The original Bug 1 fix wired the daemon's WorkerManager to the kernel
+ * in `handleFleetInit`, and one targeted integration test pins that the
+ * `learning-optimization` API is reachable post-init. But the same
+ * StubWorkerDomainAccess failure mode applies to every other worker that
+ * declares `targetDomains` — `test-health`, `flaky-detector`,
+ * `coverage-tracker`, etc. — and the worker-level unit tests all
+ * explicitly punt on this with comments like *"complex dependencies …
+ * require integration tests for full coverage. Unit tests focus on
+ * instantiation."* That punt is what let Bug 1 ship.
+ *
+ * This test iterates every registered production worker, builds the
+ * exact WorkerContext the daemon scheduler hands to `doExecute`, and
+ * asserts that each of the worker's declared targetDomains resolves to
+ * a real domain API. If the kernel→worker wiring ever breaks again —
+ * for ANY of the 11 workers, not just learning-consolidation — this
+ * test fails before the daemon ticks for users.
+ *
+ * Notes on scope:
+ *   - We do NOT call `runWorker()` to run each worker's full body.
+ *     Most workers raise legitimate "no data yet" errors on fresh
+ *     installs (test-health, flaky-detector etc.) and asserting
+ *     completion would couple this test to each worker's empty-state
+ *     behaviour. The contract we want is structural — *"the seam to
+ *     the kernel is alive"* — not behavioural.
+ *   - This is the structural complement to the existing
+ *     fleet-init-wires-daemon test (which proves the seam exists);
+ *     this proves EVERY worker can traverse it.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { handleFleetInit, disposeFleet } from '../../../src/mcp/handlers/core-handlers';
+import { getDaemon, resetDaemon } from '../../../src/workers/daemon';
+import type { DomainName } from '../../../src/shared/types';
+
+describe('Issue #491 — every production worker can reach its targetDomains', () => {
+  beforeAll(async () => {
+    await disposeFleet();
+    resetDaemon();
+
+    // lazyLoading:false so EVERY domain plugin is loaded — required for
+    // workers whose target domains are not on the lazy-init hot path.
+    const result = await handleFleetInit({
+      memoryBackend: 'memory',
+      maxAgents: 4,
+      lazyLoading: false,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  afterAll(async () => {
+    await disposeFleet();
+    resetDaemon();
+  });
+
+  // Enumerate the registered workers AT TEST TIME so we don't have to
+  // keep this list in sync with src/workers/daemon.ts. If a new worker
+  // is added, this test automatically extends to cover it.
+  it('every registered worker declares at least one targetDomain', () => {
+    const workers = getDaemon().getWorkerManager().list();
+    expect(workers.length).toBeGreaterThan(0);
+
+    for (const w of workers) {
+      expect(
+        w.config.targetDomains.length,
+        `worker ${w.config.id} has no targetDomains — that's almost certainly a misconfig`
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it('each worker resolves a non-undefined API for every targetDomain', () => {
+    const workerManager = getDaemon().getWorkerManager();
+    const workers = workerManager.list();
+
+    // Reach behind the public interface for the context the scheduler
+    // would hand to doExecute. The shape is identical to what
+    // BaseWorker.execute receives every tick.
+    const createContext = (workerManager as unknown as {
+      createContext: (id: string, signal: AbortSignal) => {
+        domains: { getDomainAPI: <T>(d: DomainName) => T | undefined };
+      };
+    }).createContext.bind(workerManager);
+
+    const failures: Array<{ worker: string; domain: DomainName }> = [];
+
+    for (const worker of workers) {
+      const ctx = createContext(worker.config.id, new AbortController().signal);
+
+      for (const domain of worker.config.targetDomains) {
+        const api = ctx.domains.getDomainAPI(domain);
+        if (api === undefined) {
+          failures.push({ worker: worker.config.id, domain });
+        }
+      }
+    }
+
+    // Format the failure list explicitly — when this test fails we want
+    // the maintainer to see exactly which seam broke, not just a count.
+    expect(
+      failures,
+      `Workers that cannot reach their target domains (StubWorkerDomainAccess regression):\n` +
+        failures.map((f) => `  - ${f.worker} → ${f.domain}`).join('\n')
+    ).toEqual([]);
+  });
+
+  it('the worker manager memory is the kernel memory (Bug 4b regression guard)', () => {
+    const workerManager = getDaemon().getWorkerManager();
+    const ctx = (workerManager as unknown as {
+      createContext: (id: string, signal: AbortSignal) => { memory: unknown };
+    }).createContext('memory-check', new AbortController().signal);
+
+    // Touching state.kernel through the handler's getFleetState would
+    // be cleaner, but the existing fleet-init-wires-daemon test already
+    // asserts identity directly; here we just check the memory isn't
+    // the in-process InMemoryWorkerMemory stub (which would mean Bug 4b
+    // has regressed and the dashboard would be reading from a
+    // different kv than workers write to).
+    expect(ctx.memory).toBeDefined();
+    // The in-process worker memory exposes no `vectorSearch`; the
+    // kernel's HybridMemoryBackend does. This is a cheap, structural
+    // way to detect the regression without importing internals.
+    const memoryShape = ctx.memory as { vectorSearch?: unknown };
+    expect(typeof memoryShape.vectorSearch).toBe('function');
+  });
+});

--- a/tests/unit/kernel/memory-backend.test.ts
+++ b/tests/unit/kernel/memory-backend.test.ts
@@ -168,7 +168,7 @@ describe('InMemoryBackend', () => {
       expect(await backend.count('test-ns')).toBe(1);
 
       // Verify remaining entry
-      const value = await backend.get('key2', 'test-ns');
+      const value = await backend.get('key2', { namespace: 'test-ns' });
       expect(value).toBe('value2');
     });
 

--- a/tests/unit/workers/workers/learning-consolidation-liveness.test.ts
+++ b/tests/unit/workers/workers/learning-consolidation-liveness.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Issue #491 Bug 4a — liveness contract for LearningConsolidationWorker.
+ *
+ * Before this fix, `recordLoopHealth(success:true)` sat *after*
+ * `collectPatterns()`. `collectPatterns()` throws on installs with nothing
+ * to consolidate (the common case for fresh users), so the liveness ping
+ * was never reached and `aqe learning loop-health` permanently displayed
+ * `LearningConsolidationWorker ○ never-ran` even when the worker ran
+ * every cycle. The bridge has the right shape (drainSafe uses try/finally)
+ * and shows up correctly — the worker did not.
+ *
+ * The contract this test pins:
+ *   1. A throw inside the worker body MUST still result in
+ *      recordLoopHealth being called (with success:false).
+ *   2. A successful run records success:true.
+ *   3. A throw inside recordLoopHealth itself MUST be swallowed (it must
+ *      never shadow the worker's real error or crash the daemon).
+ *
+ * If any of these regresses, the dashboard goes blind again.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { LearningConsolidationWorker } from '../../../../src/workers/workers/learning-consolidation';
+import * as loopHealthModule from '../../../../src/learning/loop-health';
+import type { WorkerContext, WorkerMemory } from '../../../../src/workers/interfaces';
+
+function makeMemory(): WorkerMemory {
+  const store = new Map<string, unknown>();
+  return {
+    async get<T>(key: string): Promise<T | undefined> {
+      return store.get(key) as T | undefined;
+    },
+    async set<T>(key: string, value: T): Promise<void> {
+      store.set(key, value);
+    },
+    async search(pattern: string): Promise<string[]> {
+      const prefix = pattern.replace(/\*+$/, '');
+      return Array.from(store.keys()).filter((k) => k.startsWith(prefix));
+    },
+  };
+}
+
+function makeContext(memory: WorkerMemory): WorkerContext {
+  const logCalls: Array<{ level: string; message: string; meta?: unknown }> = [];
+  const logger = {
+    debug: (m: string, meta?: unknown) => logCalls.push({ level: 'debug', message: m, meta }),
+    info: (m: string, meta?: unknown) => logCalls.push({ level: 'info', message: m, meta }),
+    warn: (m: string, meta?: unknown) => logCalls.push({ level: 'warn', message: m, meta }),
+    error: (m: string, meta?: unknown) => logCalls.push({ level: 'error', message: m, meta }),
+  };
+  return {
+    eventBus: {
+      publish: vi.fn(),
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+    } as unknown as WorkerContext['eventBus'],
+    memory,
+    logger,
+    domains: {
+      getDomainAPI: () => undefined,
+      getDomainHealth: () => ({ status: 'healthy', errors: [] }),
+    },
+    signal: new AbortController().signal,
+  };
+}
+
+describe('Issue #491 Bug 4a — LearningConsolidationWorker liveness contract', () => {
+  let worker: LearningConsolidationWorker;
+  let recordSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    worker = new LearningConsolidationWorker();
+    recordSpy = vi.spyOn(loopHealthModule, 'recordLoopHealth');
+    recordSpy.mockClear();
+  });
+
+  it('records loop-health with success:false when collectPatterns throws', async () => {
+    // collectPatterns is the documented throw site from the issue — on an
+    // empty install it raises `No learning patterns to consolidate yet`.
+    const collectErr = new Error('No learning patterns to consolidate yet');
+    vi.spyOn(
+      worker as unknown as { collectPatterns: () => Promise<unknown> },
+      'collectPatterns'
+    ).mockRejectedValueOnce(collectErr);
+
+    const memory = makeMemory();
+    const ctx = makeContext(memory);
+
+    // doExecute is protected — we go through it via reflection since the
+    // public entrypoint also rolls up retry/error tracking we don't want
+    // to assert on here.
+    await expect(
+      (worker as unknown as { doExecute: (ctx: WorkerContext) => Promise<unknown> }).doExecute(ctx)
+    ).rejects.toThrow('No learning patterns to consolidate yet');
+
+    // The contract: even on throw, liveness was recorded.
+    expect(recordSpy).toHaveBeenCalledTimes(1);
+    const [callMemory, component, status] = recordSpy.mock.calls[0]!;
+    expect(callMemory).toBe(memory);
+    expect(component).toBe('learningWorker');
+    expect(status).toMatchObject({ success: false });
+    expect((status as { error?: string }).error).toContain('No learning patterns');
+  });
+
+  it('records loop-health with success:true on a successful tick', async () => {
+    // Stub the inner phases so a real DB / domain isn't needed — we only
+    // want to assert the happy-path liveness signal.
+    vi.spyOn(
+      worker as unknown as { collectPatterns: () => Promise<unknown[]> },
+      'collectPatterns'
+    ).mockResolvedValue([]);
+    vi.spyOn(
+      worker as unknown as { consolidatePatterns: () => Promise<unknown> },
+      'consolidatePatterns'
+    ).mockResolvedValue({
+      patternsAnalyzed: 0,
+      patternsPruned: 0,
+      patternsConsolidated: 0,
+      patternsDeprecated: 0,
+      newInsights: 0,
+      crossDomainPatterns: 0,
+    });
+    vi.spyOn(
+      worker as unknown as { runDreamCycle: () => Promise<unknown> },
+      'runDreamCycle'
+    ).mockResolvedValue({ insights: 0, patternsCreated: 0 });
+
+    const memory = makeMemory();
+    const ctx = makeContext(memory);
+
+    await (worker as unknown as { doExecute: (ctx: WorkerContext) => Promise<unknown> }).doExecute(ctx);
+
+    expect(recordSpy).toHaveBeenCalledTimes(1);
+    const [, component, status] = recordSpy.mock.calls[0]!;
+    expect(component).toBe('learningWorker');
+    expect(status).toMatchObject({ success: true });
+  });
+
+  it('does not shadow the original error when recordLoopHealth itself throws', async () => {
+    // Worker throws AND the liveness recorder throws. The user must see
+    // the original error, not the bookkeeping error.
+    const collectErr = new Error('original worker failure');
+    vi.spyOn(
+      worker as unknown as { collectPatterns: () => Promise<unknown> },
+      'collectPatterns'
+    ).mockRejectedValueOnce(collectErr);
+
+    recordSpy.mockRejectedValueOnce(new Error('memory backend is on fire'));
+
+    const ctx = makeContext(makeMemory());
+
+    await expect(
+      (worker as unknown as { doExecute: (ctx: WorkerContext) => Promise<unknown> }).doExecute(ctx)
+    ).rejects.toThrow('original worker failure');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the chain of four bugs reported in [#491](https://github.com/proffesor-for-testing/agentic-qe/issues/491) (Jordi Izquierdo) that left the self-learning consolidation loop dead end-to-end on v3.9.31. On a vanilla install, `LearningConsolidationWorker` ran every cycle but never consolidated anything, and `aqe learning loop-health` permanently showed the worker as `never-ran`.

This release fixes all four bugs at their root, and closes the release-process gap that let them ship: the pre-publish flow now runs a daemon-runtime seam test suite alongside the existing fast unit tests, so the next regression in this class fails at the release gate instead of at users' installs.

Full details in [CHANGELOG.md](CHANGELOG.md) and [docs/releases/v3.9.32.md](docs/releases/v3.9.32.md).

## What's in this PR

Six bug-fix and test commits stacked on top of v3.9.31, plus the release-bump:

```
c6794202  chore(release): bump version to v3.9.32
1d1190ca  test(release-gate): add A23 daemon-liveness assertion (#491)
2f39f221  ci(release): gate publish on daemon-runtime integration tests (#491)
dd22dbdd  test(workers): generalize #491 Bug 1 protection to all 11 workers
358990cc  fix(kernel,learning): namespace-aware reads + timestamp rehydration (#491 Bug 2+3)
7f13f129  fix(workers): always emit loop-health from learning worker (#491 Bug 4a)
eca8d86b  fix(mcp,workers): wire daemon to kernel after fleet_init (#491 Bug 1+4b)
```

Each bug fix ships with a regression test verified red→green by reverting the patch and confirming the new test fails with the exact symptom from the issue, then restoring and confirming green.

## Verification

```
$ npm run typecheck
> tsc --noEmit
(zero errors)

$ npm run build
Building CLI with version: 3.9.32
CLI bundle built successfully (v3.9.32)
Building MCP with version: 3.9.32
MCP bundle built successfully (v3.9.32)

$ npm run test:unit:fast
Test Files  251 passed | 1 skipped (253)
Tests       7586 passed | 5 skipped (7597)
Duration    124.74s

$ npm run test:integration:fast
Test Files  4 passed (4)
Tests       12 passed (12)
Duration    6.49s

$ node dist/cli/bundle.js --version
3.9.32

$ # Isolated install via npm pack into clean tmpdir
$ node node_modules/.bin/aqe --version
3.9.32 (exit 0)

$ # aqe init --auto in clean tmpdir
AQE v3 initialized successfully!
Patterns loaded: 0, Skills installed: 85, Agents installed: 60
Total time: 212ms

$ # User-perspective smoke: MCP bundle, fleet_init, observe workers tick
$ # (the actual repro Jordi shipped in #491)
not_available_count: 0  ←  was 14+/cycle in v3.9.31
```

## Failure modes

This PR is a bug-fix release for runtime regressions, not a feature release, so the failure modes are primarily about whether the four fixes are complete and whether the new tests catch what they claim to catch.

- **Each of the four bug fixes has a regression test verified red→green.** The verification methodology — `git stash` or `git checkout HEAD~N -- file` the fix, rerun the test, confirm the assertion that fires matches the symptom Jordi reported, restore, confirm green — is documented in each commit message. The commit messages cite the specific assertion line that flips.

- **The new public `WorkerManager.setKernel` / `setMemory` interface methods are a typed contract.** Dropping them again becomes a typed-interface break, not a silent regression. Previous releases per #491 had dropped the equivalent private-method call before. The interface promotion is the structural fix; the test is the runtime guard.

- **The `RetrieveOptions` interface widening is backward-compatible.** Undefined still routes to `defaultNamespace`. The only caller in the tree that used `InMemoryBackend`'s undocumented positional `namespace?: string` parameter (one unit test) is migrated in the same commit. External consumers of `MemoryBackend` who only ever passed one argument are unaffected.

- **The A23 daemon-liveness assertion is opt-in per fixture, default false.** Only `tiny-ts` has it enabled at a 15-second window in this release. If the pilot is unstable in CI (e.g. the cleanroom daemon flakes on a runner), we can flip the flag off without a code change. Existing fixtures keep their current ~5s budget.

- **`test:integration:fast` is a new release-gate input.** If any of the four tests it runs becomes flaky on CI, it would block publishes. The four tests are tight (12 assertions total, ~6s), all green on three local runs across the day. If a flake does appear, the right move is to fix the test, not bypass the gate.

- **What this PR does NOT cover**: QualityDaemon. The original gap analysis flagged it as "same shape, same risk" as the production workers, but on inspection it takes only `WorkerMemory` and never calls `getDomainAPI`, so the StubWorkerDomainAccess failure mode cannot reach it. Existing 1540-line test surface across 10 files is sufficient. Documented in the v3.9.32 release notes under "Behind the scenes".

---

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.** "Unlikely" is not an acceptable substitute. If you wrote "I don't think this can happen but...", that sentence is a failure mode and needs a test or an issue link.

### Optional context

- Linked issues: closes #491
- Trust tier change (if any): none
- Affects published API or CLI surface: yes — `WorkerManager` interface gains `setKernel`/`setMemory`; `MemoryBackend.get/has/delete/search` gain optional `RetrieveOptions`. Both backward-compatible (see Failure modes above).
- Touches the init flow / `npm-publish.yml` / `tests/fixtures/init-corpus/`: yes
  - If yes: did you run `./tests/fixtures/init-corpus/run-gate.sh` locally? not applicable — the gate requires a host npm install of agentic-qe and a downloaded corpus tarball that take ~5min on CI; the syntax of the new A23 assertion was sanity-checked with `bash -n` and the manifest JSON validated with `jq`. Full corpus run executes on the release tag in CI.

See [CHANGELOG](CHANGELOG.md) for details.