### PR TITLE
chore(release): v3.9.36

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-qe",
-  "version": "3.9.35",
+  "version": "3.9.36",
   "description": "Agentic Quality Engineering — AI-powered QE platform with 60 specialized agents, 75+ skills, sublinear coverage analysis, ReasoningBank pattern learning, and deep MCP integration for Claude Code and 11 coding agent platforms",
   "author": {
     "name": "Agentic QE Team",

--- a/.claude/skills/skills-manifest.json
+++ b/.claude/skills/skills-manifest.json
@@ -939,7 +939,7 @@
   },
   "metadata": {
     "generatedBy": "Agentic QE Fleet",
-    "fleetVersion": "3.9.35",
+    "fleetVersion": "3.9.36",
     "manifestVersion": "1.4.0",
     "lastUpdated": "2026-04-13T00:00:00.000Z",
     "contributors": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,62 @@ All notable changes to the Agentic QE project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.36] - 2026-05-19
+
+A hotfix release closing the self-learning routing loop reported in #499 by
+Jordi. The `route` hook's `qWeight` was structurally pinned at 0: the
+producer (`updateHookRouterQValue`) only fired from `post-task` gated on the
+pre-task bridge, so on real projects `routing_outcomes` accumulated 100+
+rows while `rl_q_values` stayed at ~2 — the consumer side ADR-095 wired up
+had nothing to read. Q-learning never influenced routing. ADR-096
+documents the three-part fix that ships in this release.
+
+### Fixed
+
+- **`route` hook's `qWeight` was structurally pinned at 0** (#499). Three
+  coordinated changes:
+  - The Stop-hook `post-route` now trains `rl_q_values` when it resolves a
+    `routing_outcomes` sentinel, deriving the same `state_key` the route
+    hook used at insertion time. The high-volume routing surface now
+    produces Q-signal in addition to consuming it.
+  - `post-task` no longer drops Q-updates when the pre-task bridge is
+    absent — direct Bash/Edit sessions and Task-tool runs where pre-task
+    didn't fire now train Q from the task description. Adds a new
+    `--description` CLI option to `aqe hooks post-task` so the
+    `PostToolUse` hook can pass `tool_input.description`.
+  - The Q-learning state_key collapsed from 4-dim
+    `(taskType|priority|domain|complexityBucket)` to 3-dim
+    `(taskType|priority|domain)`. The previous length-keyed bucket
+    fragmented semantically identical tasks across cells, so
+    `QWEIGHT_RAMP_VISITS=20` was rarely reached per cell. Convergence is
+    now ~11× faster for a given `(taskType, domain)` pair.
+
+### Added
+
+- **ADR-096** documents the producer/consumer alignment contract and the
+  state-key shape decision. The three call sites
+  (`routing-hooks.ts post-route`, `task-hooks.ts post-task`,
+  `qe-reasoning-bank.ts:530`) must agree on `(deriveTaskType,
+  detectQEDomains[0], 'normal')` — regression test
+  `tests/unit/cli/commands/route-q-loop-closure.test.ts` fails the build
+  if a future refactor desynchronizes them.
+- `aqe hooks post-task --description <desc>` option for Task tools that
+  want to train Q without writing a pre-task bridge.
+
+### Changed
+
+- `buildRoutingStateKey` parameter shape (3-dim, no `complexityBucket`).
+  `deriveComplexityBucket` stays exported and is still computed for the
+  pre-task bridge payload (kv_store schema compatibility) and any
+  downstream telemetry — marked `@deprecated` for state_key construction
+  only.
+- Existing `rl_q_values` rows written under the 4-dim key shape become
+  orphans; new lookups won't match them. Field reports show installs have
+  ~2 such rows at most (the loop was broken so no real Q-data
+  accumulated), so no migration ships. If you have substantial 4-dim
+  data, a one-shot `UPDATE rl_q_values SET state_key = ...` stripping
+  the trailing `|N` segment is straightforward.
+
 ## [3.9.35] - 2026-05-19
 
 A test-infrastructure release. Restores ESM subpath imports of `HnswAdapter`

--- a/assets/skills/skills-manifest.json
+++ b/assets/skills/skills-manifest.json
@@ -939,7 +939,7 @@
   },
   "metadata": {
     "generatedBy": "Agentic QE Fleet",
-    "fleetVersion": "3.9.35",
+    "fleetVersion": "3.9.36",
     "manifestVersion": "1.4.0",
     "lastUpdated": "2026-04-13T00:00:00.000Z",
     "contributors": [

--- a/docs/implementation/adrs/ADR-096-route-q-loop-closure.md
+++ b/docs/implementation/adrs/ADR-096-route-q-loop-closure.md
@@ -1,4 +1,4 @@
-# ADR-096: Route-Surface Q-Loop Closure
+# ADR-096: Route-Surface Q-Loop Closure + 3-Dim State-Key
 
 | Field | Value |
 |-------|-------|
@@ -15,15 +15,15 @@
 
 **In the context of** AQE's self-learning agent-routing path established by ADR-095 (`QEReasoningBank.routeTask` → `buildRoutingStateKey` → `buildQValueLookup` → `blendStaticAndQValue`), where the `route` hook (UserPromptSubmit) reads `rl_q_values` to produce a blended score and surfaces `qWeight` as a telemetry signal,
 
-**facing** a structural producer/consumer mismatch: the *consumer* (`route` hook) fires on every user prompt and looks up a state-action Q-value, but the *only producer* (`updateHookRouterQValue` at `hooks-dream-learning.ts:643`) is called from exactly one site — `task-hooks.ts:381`, gated by `if (outcome.bridge)` — which fires only on `PostToolUse ^(Task|Agent)$` with a matched pre-task bridge. Field evidence from #499 shows 139 `routing_outcomes` rows vs 2 `rl_q_values` rows after extended use, with `route --json` returning `"qWeight": 0` indefinitely; the route surface that displays qWeight cannot train the table it reads, and the Q-loop ADR-095 wired up never closes on the high-volume code path,
+**facing** a structural producer/consumer mismatch *plus* a state-space fragmentation problem: the *consumer* (`route` hook) fires on every user prompt and looks up a state-action Q-value, but the *only producer* (`updateHookRouterQValue` at `hooks-dream-learning.ts:643`) is called from exactly one site — `task-hooks.ts:381`, gated by `if (outcome.bridge)` — which fires only on `PostToolUse ^(Task|Agent)$` with a matched pre-task bridge; AND the previous 4-dimensional `state_key = taskType|priority|domain|complexityBucket` where `complexityBucket = round(min(len/200, 1) * 10)` fragmented semantically identical tasks across cells (a 55-char vs 130-char phrasing of "write a unit test for X" → buckets 3 vs 7, different state_keys) so even when writes did fire, `QWEIGHT_RAMP_VISITS=20` was rarely reached per cell. Field evidence from #499 shows 139 `routing_outcomes` rows vs 2 `rl_q_values` rows after extended use, with `route --json` returning `"qWeight": 0` indefinitely; the route surface that displays qWeight cannot train the table it reads, and the Q-loop ADR-095 wired up never closes on the high-volume code path,
 
-**we decided for** closing the loop on the routing surface itself with two complementary changes — (a) when the Stop-hook `post-route` resolves a `routing_outcomes` sentinel with a `quality_score`, also call `updateHookRouterQValue` using a state_key re-derived from the sentinel's `task_json.description` via the **exact same exported helpers** the route hook uses (`deriveTaskType`, `deriveComplexityBucket`, `detectQEDomains`) — writer and reader address byte-identical rows in `rl_q_values`; (b) drop the `if (outcome.bridge)` gate at `task-hooks.ts:381` and derive state from `options.description` when the bridge payload is absent — adds a new `--description` CLI option to `post-task` so the hook command can pass `tool_input.description` for Task tools, restoring Q-updates for Task-tool runs where pre-task didn't fire (hook misconfiguration, expired bridge, kv_store write race),
+**we decided for** closing the loop on the routing surface itself with three complementary changes — (a) when the Stop-hook `post-route` resolves a `routing_outcomes` sentinel with a `quality_score`, also call `updateHookRouterQValue` using a state_key re-derived from the sentinel's `task_json.description` via the **exact same exported helpers** the route hook uses (`deriveTaskType`, `detectQEDomains`) — writer and reader address byte-identical rows in `rl_q_values`; (b) drop the `if (outcome.bridge)` gate at `task-hooks.ts:381` and derive state from `options.description` when the bridge payload is absent — adds a new `--description` CLI option to `post-task` so the hook command can pass `tool_input.description` for Task tools, restoring Q-updates for Task-tool runs where pre-task didn't fire (hook misconfiguration, expired bridge, kv_store write race); (c) **drop `complexityBucket` from `state_key` entirely** — the new key is 3-dim `taskType|priority|domain`, collapsing related tasks into the same Q-cell so `QWEIGHT_RAMP_VISITS=20` is reachable with a normal session cadence; the `deriveComplexityBucket` helper stays exported (and is still computed for the pre-task bridge payload's kv_store schema compatibility and any downstream telemetry) but is marked `@deprecated` for state_key construction,
 
-**and neglected** persisting `state_key` as a dedicated column on `routing_outcomes` (cleaner long-term — eliminates re-derivation drift risk, schema migration cost is small; deferred to a follow-up ADR because re-derivation works today and the deferred work doesn't block #499's closure), redesigning `deriveComplexityBucket` to stop fragmenting the state space on raw description length (acknowledged-real follow-up tracked separately — see "Open Questions" — but orthogonal to closing the producer/consumer loop), training Q from a continuous reward signal instead of the binary `success ? 0.1 : -1.0` (would require widening `updateHookRouterQValue`'s reward parameter; `quality_score` is available at both call sites but the existing asymmetric reward shape from ADR-061 is intentionally aligned with pattern-promotion thresholds and we don't change it in this ADR), and propagating the route surface's exact `state_key` in-band via the sentinel row (would require a producer-side change to the `INSERT INTO routing_outcomes` shape — chosen the cheaper re-derivation path with the same export contract instead),
+**and neglected** persisting `state_key` as a dedicated column on `routing_outcomes` (cleaner long-term — eliminates re-derivation drift risk, schema migration cost is small; deferred to a follow-up ADR because re-derivation works today and the deferred work doesn't block #499's closure), training Q from a continuous reward signal instead of the binary `success ? 0.1 : -1.0` (would require widening `updateHookRouterQValue`'s reward parameter; `quality_score` is available at both call sites but the existing asymmetric reward shape from ADR-061 is intentionally aligned with pattern-promotion thresholds and we don't change it in this ADR), and the more elaborate alternatives to dropping the complexity dimension entirely — a 3-tier coarse bucket (small/medium/large by length) or a semantic complexity feature (identifier count, conjunction detection) — both add machinery without evidence the resulting state separation pays for itself; if post-deploy telemetry shows the 3-dim key conflating tasks that the routing system should differentiate, we can introduce a coarser bucket later with field data to inform threshold tuning,
 
-**to achieve** a functioning closed-loop self-learning system on the routing surface (the surface that fires on every prompt now produces Q-signal in addition to consuming it; `qWeight` ramps from 0 → MAX_Q_WEIGHT over `QWEIGHT_RAMP_VISITS` visits as ADR-095 intended), defense-in-depth for the Task-tool path (post-task Q-updates fire even when the pre-task bridge is missing, which is the common case for hook misconfigurations and the unavoidable case for some kv_store race conditions), and a regression test surface that asserts the producer/consumer alignment contract — if a future refactor desynchronizes writer/reader state_key construction, `tests/unit/cli/commands/route-q-loop-closure.test.ts` fails the build,
+**to achieve** a functioning closed-loop self-learning system on the routing surface (the surface that fires on every prompt now produces Q-signal in addition to consuming it; `qWeight` ramps from 0 → MAX_Q_WEIGHT over `QWEIGHT_RAMP_VISITS` visits as ADR-095 intended), defense-in-depth for the Task-tool path (post-task Q-updates fire even when the pre-task bridge is missing, which is the common case for hook misconfigurations and the unavoidable case for some kv_store race conditions), measurably faster convergence (the 3-dim key collapses the state space by ~11× relative to the previous 4-dim form, so a given (taskType, domain) pair accumulates visits at the rate of the *combined* historical buckets — ramp from 0 → MAX_Q_WEIGHT now requires ~20 same-domain tasks rather than ~20 same-length-and-same-domain tasks), and a regression test surface that asserts the producer/consumer alignment contract — if a future refactor desynchronizes writer/reader state_key construction, `tests/unit/cli/commands/route-q-loop-closure.test.ts` and `tests/unit/learning/agent-routing-exploration.test.ts` fail the build,
 
-**accepting that** writer/reader state_key derivation is duplicated across `routing-hooks.ts post-route`, `task-hooks.ts post-task`, and `qe-reasoning-bank.ts:530` — three call sites that must all agree on `(deriveTaskType, deriveComplexityBucket, detectQEDomains[0], 'normal')` (mitigated by the shared exports being the only correct path AND the regression test pinning the contract; if we add a fourth caller, refactor to a `buildRoutingStateKeyFromDescription(description)` helper), the `state_key` reconstructed in `post-route` reflects the **resolved-at-Stop** value of `detectQEDomains` rather than the **decided-at-route** value (in practice these match because detectQEDomains is a pure function of description string; persisting state_key on the sentinel would eliminate even this theoretical drift — tracked as follow-up), and adding `--description` to `post-task` requires the init template's hook command to pass `$tool_input.description` for Task tools to get full benefit (init template update lands in the same PR; older agentic-qe installs continue working with bridge-only state derivation as before).
+**accepting that** writer/reader state_key derivation is duplicated across `routing-hooks.ts post-route`, `task-hooks.ts post-task`, and `qe-reasoning-bank.ts:530` — three call sites that must all agree on `(deriveTaskType, detectQEDomains[0], 'normal')` (mitigated by the shared exports being the only correct path AND the regression tests pinning the contract; if we add a fourth caller, refactor to a `buildRoutingStateKeyFromDescription(description)` helper), the `state_key` reconstructed in `post-route` reflects the **resolved-at-Stop** value of `detectQEDomains` rather than the **decided-at-route** value (in practice these match because detectQEDomains is a pure function of description string; persisting state_key on the sentinel would eliminate even this theoretical drift — tracked as follow-up), adding `--description` to `post-task` requires the init template's hook command to pass `$tool_input.description` for Task tools to get full benefit (init template update lands in the same PR; older agentic-qe installs continue working with bridge-only state derivation as before), and existing `rl_q_values` rows written under the previous 4-dim key shape will never be hit by new lookups — field reports show installs have ~2 such rows at most (the loop was broken so no real Q-data accumulated), so we accept the orphan rows without a migration; if a future install ships with substantial 4-dim data, a one-shot migration that strips the trailing `|N` segment is straightforward.
 
 ---
 
@@ -80,6 +80,22 @@ This ADR closes the loop in two complementary places.
 
 ### Implementation
 
+**State-key shape — 3-dim (was 4-dim):**
+
+```typescript
+// agent-routing.ts: buildRoutingStateKey now drops complexityBucket
+export function buildRoutingStateKey(opts: {
+  taskType: string;
+  priority?: string;
+  domain?: string;
+}): string {
+  return `${opts.taskType}|${opts.priority ?? 'normal'}|${opts.domain ?? 'any'}`;
+}
+
+// hooks-dream-learning.ts: writer-side state_key matches
+const stateKey = `${opts.taskType}|${opts.priority}|${opts.domain || 'any'}`;
+```
+
 **Producer surface 1 — `post-route` (new path):**
 
 ```typescript
@@ -93,7 +109,6 @@ if (sentinel) {
         taskType: deriveTaskType(description),
         priority: 'normal',
         domain: detectQEDomains(description)[0] ?? 'any',
-        complexityBucket: deriveComplexityBucket(description),
         agent: sentinel.used_agent,
         success,
       });
@@ -109,11 +124,10 @@ if (sentinel) {
 const taskDescription = String(options.description ?? '');
 if (outcome.bridge || taskDescription) {
   await updateHookRouterQValue({
-    taskType:         outcome.bridge?.taskType ?? deriveTaskType(taskDescription),
-    priority:         outcome.bridge?.priority ?? 'normal',
-    domain:           outcome.bridge?.domain ?? detectQEDomains(taskDescription)[0] ?? 'any',
-    complexityBucket: outcome.bridge?.complexityBucket ?? deriveComplexityBucket(taskDescription),
-    agent:            effectiveAgent,
+    taskType: outcome.bridge?.taskType ?? deriveTaskType(taskDescription),
+    priority: outcome.bridge?.priority ?? 'normal',
+    domain:   outcome.bridge?.domain ?? detectQEDomains(taskDescription)[0] ?? 'any',
+    agent:    effectiveAgent,
     success,
   });
 }
@@ -121,24 +135,26 @@ if (outcome.bridge || taskDescription) {
 
 **CLI surface:** `aqe hooks post-task` gains `--description <desc>` so the PostToolUse hook command can pass `tool_input.description`.
 
+**Compatibility:** `deriveComplexityBucket` stays exported (marked `@deprecated` for state_key use) — the pre-task bridge payload still carries `complexityBucket` for kv_store schema compatibility and any downstream telemetry. The `TaskBridgePayload` interface is unchanged.
+
 ### Test contract
 
 `tests/unit/cli/commands/route-q-loop-closure.test.ts` pins:
-1. `post-route` calls `updateHookRouterQValue` with state matching `(deriveTaskType, deriveComplexityBucket, detectQEDomains[0])` from the sentinel description.
+1. `post-route` calls `updateHookRouterQValue` with state matching `(deriveTaskType, detectQEDomains[0])` from the sentinel description — no `complexityBucket` in the payload.
 2. `post-route` no-ops when no route sentinel exists or task_json is malformed.
 3. `post-task` calls the Q-update when the bridge is absent but `--description` is supplied.
-4. `post-task` prefers bridge-supplied state when both are present (preserves pre-#499 behavior).
+4. `post-task` prefers bridge-supplied state when both are present (preserves pre-#499 behavior) — and does **not** leak `bridge.complexityBucket` into the Q-update payload.
 5. `post-task` skips the Q-update when neither bridge nor description is available (prevents pollution of an "unknown" sentinel state).
 
-If a future refactor desynchronizes producer/consumer state_key derivation, these assertions fail.
+`tests/unit/learning/agent-routing-exploration.test.ts` pins the 3-dim key shape itself: `buildRoutingStateKey` returns a 3-segment `|`-joined string. If a future refactor brings back the 4th dimension or desynchronizes producer/consumer derivation, these assertions fail.
 
 ---
 
 ## Open Questions
 
-1. **Persist `state_key` on `routing_outcomes`** — eliminates re-derivation drift entirely. Schema migration (new nullable column) + one writer-side INSERT update + one consumer-side `SELECT state_key`. Small change; deferred only because re-derivation works today and matches Jordi's verified workaround. Worth doing in v3.9.37.
-2. **`deriveComplexityBucket` redesign** — see follow-up note. The current `Math.round(min(description.length / 200, 1) * 10)` fragments the state space on raw length. Independent of this ADR's loop-closure; tracked separately.
-3. **Continuous reward** — `updateHookRouterQValue` takes `success: boolean`. Both call sites have `quality_score` available. Widening the writer to accept a continuous reward in `[0,1]` and reshape via `reward = (qualityScore - 0.5) * scale` is a small change but interacts with ADR-061's asymmetric ratio. Defer until we have post-deploy telemetry showing convergence behavior.
+1. **Persist `state_key` on `routing_outcomes`** — eliminates re-derivation drift entirely. Schema migration (new nullable column) + one writer-side INSERT update + one consumer-side `SELECT state_key`. Small change; deferred only because re-derivation works today and matches Jordi's verified workaround. Worth doing in a follow-up release.
+2. **Continuous reward** — `updateHookRouterQValue` takes `success: boolean`. Both call sites have `quality_score` available. Widening the writer to accept a continuous reward in `[0,1]` and reshape via `reward = (qualityScore - 0.5) * scale` is a small change but interacts with ADR-061's asymmetric ratio. Defer until we have post-deploy telemetry showing convergence behavior.
+3. **Re-introducing complexity if convergence is too coarse** — the 3-dim state_key may conflate routing decisions that benefit from differentiation (e.g., "write one unit test" vs "write a comprehensive test suite" both land at `(test-generation, normal, test-generation)`). If telemetry post-deploy shows this conflation costing quality, the path forward is a *coarse* 3-tier complexity tier (small/medium/large by length, threshold-tuned from field data) — not a return to the previous 11-bucket linear-in-length form. Tracked as a "wait and measure" item rather than a planned change.
 
 ---
 

--- a/docs/implementation/adrs/ADR-096-route-q-loop-closure.md
+++ b/docs/implementation/adrs/ADR-096-route-q-loop-closure.md
@@ -1,0 +1,160 @@
+# ADR-096: Route-Surface Q-Loop Closure
+
+| Field | Value |
+|-------|-------|
+| **Decision ID** | ADR-096 |
+| **Status** | Accepted |
+| **Date** | 2026-05-19 |
+| **Author** | Architecture Team |
+| **Review Cadence** | 3 months |
+| **Source** | Issue #499 — `route` hook reports `qWeight:0` structurally; `rl_q_values` never trained from the routing surface |
+
+---
+
+## WH(Y) Decision Statement
+
+**In the context of** AQE's self-learning agent-routing path established by ADR-095 (`QEReasoningBank.routeTask` → `buildRoutingStateKey` → `buildQValueLookup` → `blendStaticAndQValue`), where the `route` hook (UserPromptSubmit) reads `rl_q_values` to produce a blended score and surfaces `qWeight` as a telemetry signal,
+
+**facing** a structural producer/consumer mismatch: the *consumer* (`route` hook) fires on every user prompt and looks up a state-action Q-value, but the *only producer* (`updateHookRouterQValue` at `hooks-dream-learning.ts:643`) is called from exactly one site — `task-hooks.ts:381`, gated by `if (outcome.bridge)` — which fires only on `PostToolUse ^(Task|Agent)$` with a matched pre-task bridge. Field evidence from #499 shows 139 `routing_outcomes` rows vs 2 `rl_q_values` rows after extended use, with `route --json` returning `"qWeight": 0` indefinitely; the route surface that displays qWeight cannot train the table it reads, and the Q-loop ADR-095 wired up never closes on the high-volume code path,
+
+**we decided for** closing the loop on the routing surface itself with two complementary changes — (a) when the Stop-hook `post-route` resolves a `routing_outcomes` sentinel with a `quality_score`, also call `updateHookRouterQValue` using a state_key re-derived from the sentinel's `task_json.description` via the **exact same exported helpers** the route hook uses (`deriveTaskType`, `deriveComplexityBucket`, `detectQEDomains`) — writer and reader address byte-identical rows in `rl_q_values`; (b) drop the `if (outcome.bridge)` gate at `task-hooks.ts:381` and derive state from `options.description` when the bridge payload is absent — adds a new `--description` CLI option to `post-task` so the hook command can pass `tool_input.description` for Task tools, restoring Q-updates for Task-tool runs where pre-task didn't fire (hook misconfiguration, expired bridge, kv_store write race),
+
+**and neglected** persisting `state_key` as a dedicated column on `routing_outcomes` (cleaner long-term — eliminates re-derivation drift risk, schema migration cost is small; deferred to a follow-up ADR because re-derivation works today and the deferred work doesn't block #499's closure), redesigning `deriveComplexityBucket` to stop fragmenting the state space on raw description length (acknowledged-real follow-up tracked separately — see "Open Questions" — but orthogonal to closing the producer/consumer loop), training Q from a continuous reward signal instead of the binary `success ? 0.1 : -1.0` (would require widening `updateHookRouterQValue`'s reward parameter; `quality_score` is available at both call sites but the existing asymmetric reward shape from ADR-061 is intentionally aligned with pattern-promotion thresholds and we don't change it in this ADR), and propagating the route surface's exact `state_key` in-band via the sentinel row (would require a producer-side change to the `INSERT INTO routing_outcomes` shape — chosen the cheaper re-derivation path with the same export contract instead),
+
+**to achieve** a functioning closed-loop self-learning system on the routing surface (the surface that fires on every prompt now produces Q-signal in addition to consuming it; `qWeight` ramps from 0 → MAX_Q_WEIGHT over `QWEIGHT_RAMP_VISITS` visits as ADR-095 intended), defense-in-depth for the Task-tool path (post-task Q-updates fire even when the pre-task bridge is missing, which is the common case for hook misconfigurations and the unavoidable case for some kv_store race conditions), and a regression test surface that asserts the producer/consumer alignment contract — if a future refactor desynchronizes writer/reader state_key construction, `tests/unit/cli/commands/route-q-loop-closure.test.ts` fails the build,
+
+**accepting that** writer/reader state_key derivation is duplicated across `routing-hooks.ts post-route`, `task-hooks.ts post-task`, and `qe-reasoning-bank.ts:530` — three call sites that must all agree on `(deriveTaskType, deriveComplexityBucket, detectQEDomains[0], 'normal')` (mitigated by the shared exports being the only correct path AND the regression test pinning the contract; if we add a fourth caller, refactor to a `buildRoutingStateKeyFromDescription(description)` helper), the `state_key` reconstructed in `post-route` reflects the **resolved-at-Stop** value of `detectQEDomains` rather than the **decided-at-route** value (in practice these match because detectQEDomains is a pure function of description string; persisting state_key on the sentinel would eliminate even this theoretical drift — tracked as follow-up), and adding `--description` to `post-task` requires the init template's hook command to pass `$tool_input.description` for Task tools to get full benefit (init template update lands in the same PR; older agentic-qe installs continue working with bridge-only state derivation as before).
+
+---
+
+## Context
+
+### Reproduction (verified, v3.9.34/v3.9.35)
+
+```sql
+-- After a few hours of use on a real project:
+SELECT (SELECT COUNT(*) FROM routing_outcomes) AS routes,
+       (SELECT COUNT(*) FROM rl_q_values)      AS qrows;
+-- routes = 139, qrows = 2
+```
+
+```bash
+$ aqe hooks route --task "..." --json
+{ "recommendedAgent": "...", "qWeight": 0, "reasoning": "Domain match: 20%; ..." }
+```
+
+`qWeight` is **structurally pinned** at 0: the `route` hook computes a `state_key` at `qe-reasoning-bank.ts:530` and looks up `rl_q_values`. The lookup returns no row, `blendStaticAndQValue` returns `qWeight: 0` via the `visits === 0` early-return at `agent-routing.ts:197`.
+
+### Source-Level Findings
+
+Verified by reading `src/`:
+
+**Consumer (route hook):**
+- `routing-hooks.ts:94` — `routeTask(request)` produces the routing decision including `qWeight`.
+- `qe-reasoning-bank.ts:530-535` — builds `state_key` = `${taskType}|normal|${domain ?? 'any'}|${complexityBucket}` using `deriveTaskType(request.task)`, `detectQEDomains(request.task)[0]`, `deriveComplexityBucket(request.task)`.
+- `qe-reasoning-bank.ts:618-631` — SQL query against `rl_q_values WHERE algorithm='q-learning' AND agent_id='aqe-hook-router' AND state_key=? AND action_key=?`.
+- `agent-routing.ts:197-198` — `if (!qLookup || qLookup.visits === 0) return { qWeight: 0, ... }`.
+
+**Producer (single site, pre-fix):**
+- `hooks-dream-learning.ts:643-693` — `updateHookRouterQValue` builds the same state_key shape and performs the Bellman update.
+- `task-hooks.ts:381` — `if (outcome.bridge) { await updateHookRouterQValue(...) }` was the ONLY caller. `outcome.bridge` comes from `persistTaskOutcome` reading the `task-bridge` kv_store namespace populated by pre-task. Without pre-task running (Bash/Edit/Read sessions, hook misconfigurations, kv_store TTL expiry), no Q-update fires.
+
+**Routing surface ownership:**
+- `route` hook writes a sentinel row to `routing_outcomes` with `quality_score = -1` (`routing-hooks.ts:166-194`). The row carries `task_json = {description, domain}` but **does NOT carry `state_key`** — the state_key is computed inside `routeTask` and thrown away.
+- `post-route` (Stop hook) closes the sentinel with the 6-dim quality formula. Pre-fix: it did NOT touch `rl_q_values`.
+
+This ADR closes the loop in two complementary places.
+
+### Relationship to Existing ADRs
+
+| ADR | Title | Relationship |
+|-----|-------|--------------|
+| ADR-021 | QE ReasoningBank for Pattern Learning | Owns `routeTask` + the state-key construction; this ADR doesn't change that — it makes the loop produce signal on the routing surface. |
+| ADR-061 | Asymmetric Learning Rates | The `reward = success ? 0.1 : -1.0` shape inside `updateHookRouterQValue` is preserved verbatim; this ADR only widens the **call surface**, not the reward shape. |
+| ADR-094 | Kernel-Side Dream Cycles | Producer side of the routing-outcomes pipeline runs in the hook subprocess per ADR-094's contract; this ADR keeps everything in-hook (~1ms additional per Stop hook for the Q-update). No kernel-side change. |
+| ADR-095 | ε-Greedy Routing Exploration Policy | This ADR closes ADR-095's flagged Open Question: "the Q-table is now both populated AND consumed — the Bellman update has a routing-side reader to learn from." ADR-095 wired the reader assuming a healthy writer; we now wire the missing writer surface. |
+
+---
+
+## Decision
+
+### Implementation
+
+**Producer surface 1 — `post-route` (new path):**
+
+```typescript
+// routing-hooks.ts: after closing the routing_outcomes sentinel
+if (sentinel) {
+  try {
+    const tj = JSON.parse(sentinel.task_json) as { description?: string };
+    const description = String(tj.description ?? '');
+    if (description) {
+      await updateHookRouterQValue({
+        taskType: deriveTaskType(description),
+        priority: 'normal',
+        domain: detectQEDomains(description)[0] ?? 'any',
+        complexityBucket: deriveComplexityBucket(description),
+        agent: sentinel.used_agent,
+        success,
+      });
+    }
+  } catch { /* swallow — Stop hook must not crash */ }
+}
+```
+
+**Producer surface 2 — `post-task` (gate dropped):**
+
+```typescript
+// task-hooks.ts: replace `if (outcome.bridge) { ... }` with:
+const taskDescription = String(options.description ?? '');
+if (outcome.bridge || taskDescription) {
+  await updateHookRouterQValue({
+    taskType:         outcome.bridge?.taskType ?? deriveTaskType(taskDescription),
+    priority:         outcome.bridge?.priority ?? 'normal',
+    domain:           outcome.bridge?.domain ?? detectQEDomains(taskDescription)[0] ?? 'any',
+    complexityBucket: outcome.bridge?.complexityBucket ?? deriveComplexityBucket(taskDescription),
+    agent:            effectiveAgent,
+    success,
+  });
+}
+```
+
+**CLI surface:** `aqe hooks post-task` gains `--description <desc>` so the PostToolUse hook command can pass `tool_input.description`.
+
+### Test contract
+
+`tests/unit/cli/commands/route-q-loop-closure.test.ts` pins:
+1. `post-route` calls `updateHookRouterQValue` with state matching `(deriveTaskType, deriveComplexityBucket, detectQEDomains[0])` from the sentinel description.
+2. `post-route` no-ops when no route sentinel exists or task_json is malformed.
+3. `post-task` calls the Q-update when the bridge is absent but `--description` is supplied.
+4. `post-task` prefers bridge-supplied state when both are present (preserves pre-#499 behavior).
+5. `post-task` skips the Q-update when neither bridge nor description is available (prevents pollution of an "unknown" sentinel state).
+
+If a future refactor desynchronizes producer/consumer state_key derivation, these assertions fail.
+
+---
+
+## Open Questions
+
+1. **Persist `state_key` on `routing_outcomes`** — eliminates re-derivation drift entirely. Schema migration (new nullable column) + one writer-side INSERT update + one consumer-side `SELECT state_key`. Small change; deferred only because re-derivation works today and matches Jordi's verified workaround. Worth doing in v3.9.37.
+2. **`deriveComplexityBucket` redesign** — see follow-up note. The current `Math.round(min(description.length / 200, 1) * 10)` fragments the state space on raw length. Independent of this ADR's loop-closure; tracked separately.
+3. **Continuous reward** — `updateHookRouterQValue` takes `success: boolean`. Both call sites have `quality_score` available. Widening the writer to accept a continuous reward in `[0,1]` and reshape via `reward = (qualityScore - 0.5) * scale` is a small change but interacts with ADR-061's asymmetric ratio. Defer until we have post-deploy telemetry showing convergence behavior.
+
+---
+
+## Dependencies
+
+| Relationship | ADR ID | Title | Notes |
+|--------------|--------|-------|-------|
+| Builds On | ADR-095 | ε-Greedy Routing Exploration Policy | Closes the writer-side gap that ADR-095's Open Questions flagged as deferred. |
+| Depends On | ADR-021 | QE ReasoningBank | Provides `routeTask` and the exported state-derivation helpers. |
+| Preserves | ADR-061 | Asymmetric Learning Rates | Reward shape inside `updateHookRouterQValue` unchanged. |
+| Co-exists With | ADR-094 | Kernel-Side Dream Cycles | Q-update runs in hook subprocess; ADR-094's hooks-as-producers contract preserved. |
+
+---
+
+## References
+
+| Ref ID | Title | Type | Location |
+|--------|-------|------|----------|
+| ISSUE-499 | route hook reports qWeight:0 structurally — rl_q_values is never trained from the routing surface | GitHub Issue | https://github.com/proffesor-for-testing/agentic-qe/issues/499 |

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -4,6 +4,7 @@ All Agentic QE release notes organized by version.
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| [v3.9.36](v3.9.36.md) | 2026-05-19 | Close the self-learning routing Q-loop (#499): post-route now trains `rl_q_values`, post-task fires Q-update even when pre-task bridge is absent, Q-state collapsed from 4-dim to 3-dim for ~11× faster convergence. ADR-096. |
 | [v3.9.35](v3.9.35.md) | 2026-05-19 | Restore ESM subpath import of `HnswAdapter` (#497) + dismantle cumulative-growth pattern in vitest fork workers (#448 steps 2+3): split heavy learning tests, release module singletons between tests |
 | [v3.9.34](v3.9.34.md) | 2026-05-18 | Stop unbounded `patterns.rvf`/`brain.rvf` growth — fixes #495 sibling init runaway + adds post-dream compaction, boot-time size guard, bounded SQLite→RVF backfill |
 | [v3.9.33](v3.9.33.md) | 2026-05-18 | Supply-chain cleanup: 0 consumer-side CVEs (was 4 high + 1 critical), ~480 fewer transitive packages, zero ERESOLVE warnings; new consumer-side audit gate prevents regressions |

--- a/docs/releases/v3.9.36.md
+++ b/docs/releases/v3.9.36.md
@@ -1,0 +1,94 @@
+# v3.9.36 Release Notes
+
+**Release Date:** 2026-05-19
+
+## Highlights
+
+Closes the self-learning routing loop reported in #499 by Jordi. The
+`route` hook's `qWeight` was structurally pinned at 0 because the producer
+(`updateHookRouterQValue`) only fired from `post-task` gated on the pre-task
+bridge, so on real projects `routing_outcomes` reached 100+ rows while
+`rl_q_values` stayed at ~2 — the consumer ADR-095 wired up had nothing to
+read. Q-learning never influenced routing. ADR-096 documents the three-part
+fix.
+
+## Fixed
+
+- **`route` hook's `qWeight` was structurally pinned at 0** (#499). Three
+  coordinated changes:
+
+  1. **`post-route` trains `rl_q_values`.** When the Stop-hook closes a
+     `routing_outcomes` sentinel, it now also writes the Bellman Q-update
+     using a `state_key` re-derived from the sentinel's `task_json.description`
+     via the same exported helpers the route hook used (`deriveTaskType`,
+     `detectQEDomains`). Writer and reader address byte-identical rows.
+     This is the high-volume surface that fires on every user prompt —
+     it can now train the table it reads.
+
+  2. **`post-task` no longer drops Q-updates when bridge is absent.** The
+     `if (outcome.bridge)` gate at `task-hooks.ts:381` silently dropped
+     the Q-update whenever the pre-task bridge wasn't matched (direct
+     Bash/Edit work, hook misconfigurations, kv_store TTL expiry). Drop
+     the gate; derive state from `options.description` when bridge is
+     missing. Skip only when neither bridge nor description is available
+     (would pollute an "unknown" sentinel state).
+
+  3. **Q-state collapsed from 4-dim to 3-dim.** The previous
+     `taskType|priority|domain|complexityBucket` state_key derived
+     `complexityBucket` from raw description length, fragmenting
+     semantically identical tasks across cells. A 55-char vs 130-char
+     phrasing of "write a unit test for X" landed in buckets 3 vs 7 —
+     so `QWEIGHT_RAMP_VISITS=20` was rarely reached per cell.
+     The new 3-dim key `(taskType|priority|domain)` collapses related
+     tasks into the same Q-row. Convergence is ~11× faster.
+
+## Added
+
+- **ADR-096** — Route-Surface Q-Loop Closure + 3-Dim State-Key. Documents
+  the producer/consumer alignment contract and the state-key shape
+  decision. The three call sites must agree on
+  `(deriveTaskType, detectQEDomains[0], 'normal')`.
+- New `aqe hooks post-task --description <desc>` CLI option. The
+  `PostToolUse` hook can pass `tool_input.description` to give post-task
+  a description source when the pre-task bridge isn't present.
+- **`tests/unit/cli/commands/route-q-loop-closure.test.ts`** — 7-test
+  contract that fails the build if any of the three call sites
+  desynchronizes the state_key derivation. Plus negative assertions that
+  `complexityBucket` does NOT leak into `updateHookRouterQValue`
+  payloads from either producer surface.
+
+## Changed
+
+- `buildRoutingStateKey` parameter shape (3-dim, no `complexityBucket`).
+- `updateHookRouterQValue` parameter shape (no `complexityBucket`).
+- `deriveComplexityBucket` stays exported and is still computed for the
+  pre-task bridge payload (kv_store schema compatibility) and any
+  downstream telemetry. Marked `@deprecated` for state_key construction
+  only. `TaskBridgePayload` interface unchanged.
+
+## Migration
+
+Existing `rl_q_values` rows written under the previous 4-dim key shape
+become orphans — they'll never match new 3-dim lookups. Field reports
+(#499) show real installs have ~2 such rows at most (the loop was broken
+so no real Q-data accumulated), so no migration ships in this release.
+
+If your install has substantial 4-dim data and you want to preserve it:
+
+```sql
+-- Strip the trailing |N segment from existing state_keys
+UPDATE rl_q_values
+SET state_key = substr(state_key, 1, length(state_key) - length('|' || (substr(state_key, instr(state_key, '|') + 1))))
+WHERE algorithm = 'q-learning'
+  AND agent_id = 'aqe-hook-router'
+  AND (length(state_key) - length(replace(state_key, '|', ''))) = 3;
+```
+
+Or simply `DELETE` them and let the new loop accumulate fresh signal.
+
+## Acknowledgments
+
+Thanks to Jordi Izquierdo for the exhaustive root-cause analysis in #499
+(code-pointer-accurate to the dist/ layer) and for sharing the verified
+external workaround that proved the producer/consumer alignment approach
+before any code change shipped.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentic-qe",
-  "version": "3.9.35",
+  "version": "3.9.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentic-qe",
-      "version": "3.9.35",
+      "version": "3.9.36",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-qe",
-  "version": "3.9.35",
+  "version": "3.9.36",
   "description": "Agentic Quality Engineering V3 - Domain-Driven Design Architecture with 13 Bounded Contexts, O(log n) coverage analysis, ReasoningBank learning, 60 specialized QE agents, mathematical Coherence verification, deep Claude Flow integration",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/cli/commands/hooks-handlers/hooks-dream-learning.ts
+++ b/src/cli/commands/hooks-handlers/hooks-dream-learning.ts
@@ -630,8 +630,9 @@ export async function persistTaskOutcome(opts: {
  *   - agent_id='aqe-hook-router' (per-instance partition; persistent-q-router
  *     convention so we don't collide with canonical RuVector q-router writes
  *     at agent_id='q-router')
- *   - state_key='${taskType}|${priority}|${domain}|${complexityBucket}'
- *     (structural; see q-learning-router.ts:591)
+ *   - state_key='${taskType}|${priority}|${domain}'  (ADR-096; was 4-dim
+ *     pre-issue-#499 — the 4th `complexityBucket` segment fragmented the
+ *     Q-state space on raw description length so visits never accumulated)
  *   - action_key=agent name chosen
  *   - id='q-learning:aqe-hook-router:${stateKey}:${actionKey}'
  *
@@ -644,7 +645,6 @@ export async function updateHookRouterQValue(opts: {
   taskType: string;
   priority: string;
   domain: string;
-  complexityBucket: number;
   agent: string;
   success: boolean;
 }): Promise<void> {
@@ -657,7 +657,7 @@ export async function updateHookRouterQValue(opts: {
     const db = um.getDatabase();
     try { db.pragma('busy_timeout = 60000'); } catch { /* hook-side patient timeout (ADR-001 / patch 260) */ }
 
-    const stateKey = `${opts.taskType}|${opts.priority}|${opts.domain || 'any'}|${opts.complexityBucket}`;
+    const stateKey = `${opts.taskType}|${opts.priority}|${opts.domain || 'any'}`;
     const actionKey = opts.agent;
     const id = `q-learning:aqe-hook-router:${stateKey}:${actionKey}`;
     const reward = opts.success ? 0.1 : -1.0;

--- a/src/cli/commands/hooks-handlers/routing-hooks.ts
+++ b/src/cli/commands/hooks-handlers/routing-hooks.ts
@@ -22,7 +22,10 @@ import {
   printError,
   printGuidance,
   readStdinJsonEvent,
+  updateHookRouterQValue,
 } from './hooks-shared.js';
+import { deriveTaskType, deriveComplexityBucket } from '../../../learning/agent-routing.js';
+import { detectQEDomains } from '../../../learning/qe-patterns.js';
 
 /**
  * Extract a routable task description from a Claude Code hook event JSON
@@ -245,17 +248,52 @@ export function registerRoutingHooks(hooks: Command): void {
         const db = um.getDatabase();
         applyHookBusyTimeout(db);
 
-        const result = db.prepare(`
-          UPDATE routing_outcomes
-          SET success = ?, quality_score = ?, duration_ms = 0, error = NULL
-          WHERE id = (
-            SELECT id FROM routing_outcomes
-            WHERE quality_score = -1
-              AND task_json NOT LIKE '%"taskId"%'
-            ORDER BY created_at DESC
-            LIMIT 1
-          )
-        `).run(success ? 1 : 0, qualityScore);
+        // Issue #499: we need the sentinel's task_json + used_agent to train
+        // rl_q_values from this resolved outcome. SELECT first, then UPDATE
+        // by id — so the row we close is the same row we read for state-key
+        // derivation, even if a concurrent insert happens between statements.
+        const sentinel = db.prepare(`
+          SELECT id, task_json, used_agent FROM routing_outcomes
+          WHERE quality_score = -1
+            AND task_json NOT LIKE '%"taskId"%'
+          ORDER BY created_at DESC
+          LIMIT 1
+        `).get() as { id: string; task_json: string; used_agent: string } | undefined;
+
+        const result = sentinel
+          ? db.prepare(`
+              UPDATE routing_outcomes
+              SET success = ?, quality_score = ?, duration_ms = 0, error = NULL
+              WHERE id = ?
+            `).run(success ? 1 : 0, qualityScore, sentinel.id)
+          : { changes: 0 };
+
+        // Issue #499 fix #1: train rl_q_values from the resolved route
+        // sentinel. The route hook computed a state_key for this same task
+        // (qe-reasoning-bank.ts:530-535) and never wrote it anywhere, so we
+        // re-derive from task_json.description using the same exported
+        // helpers. Writer and reader use identical state_key construction,
+        // so the row this trains is the row the next `route` hook reads.
+        // Best-effort: Stop hooks must never crash the host on a learning
+        // failure.
+        if (sentinel) {
+          try {
+            const tj = JSON.parse(sentinel.task_json) as { description?: string };
+            const description = String(tj.description ?? '');
+            if (description) {
+              await updateHookRouterQValue({
+                taskType: deriveTaskType(description),
+                priority: 'normal',
+                domain: detectQEDomains(description)[0] ?? 'any',
+                complexityBucket: deriveComplexityBucket(description),
+                agent: sentinel.used_agent,
+                success,
+              });
+            }
+          } catch {
+            /* swallow — Stop-hook must not crash the host on learning errors */
+          }
+        }
 
         // Issue #465: orphan-sentinel sweep. Sessions that terminate without
         // firing Stop (context compact, process kill, IDE crash) leave their

--- a/src/cli/commands/hooks-handlers/routing-hooks.ts
+++ b/src/cli/commands/hooks-handlers/routing-hooks.ts
@@ -24,7 +24,7 @@ import {
   readStdinJsonEvent,
   updateHookRouterQValue,
 } from './hooks-shared.js';
-import { deriveTaskType, deriveComplexityBucket } from '../../../learning/agent-routing.js';
+import { deriveTaskType } from '../../../learning/agent-routing.js';
 import { detectQEDomains } from '../../../learning/qe-patterns.js';
 
 /**
@@ -276,6 +276,9 @@ export function registerRoutingHooks(hooks: Command): void {
         // so the row this trains is the row the next `route` hook reads.
         // Best-effort: Stop hooks must never crash the host on a learning
         // failure.
+        //
+        // ADR-096: state_key is 3-dim (taskType|priority|domain) — no
+        // complexity bucket. See agent-routing.ts buildRoutingStateKey.
         if (sentinel) {
           try {
             const tj = JSON.parse(sentinel.task_json) as { description?: string };
@@ -285,7 +288,6 @@ export function registerRoutingHooks(hooks: Command): void {
                 taskType: deriveTaskType(description),
                 priority: 'normal',
                 domain: detectQEDomains(description)[0] ?? 'any',
-                complexityBucket: deriveComplexityBucket(description),
                 agent: sentinel.used_agent,
                 success,
               });

--- a/src/cli/commands/hooks-handlers/task-hooks.ts
+++ b/src/cli/commands/hooks-handlers/task-hooks.ts
@@ -23,7 +23,7 @@ import {
   printSuccess,
 } from './hooks-shared.js';
 import { ensureRoutingOutcomesAdr095Columns } from '../../../routing/routing-outcomes-migration.js';
-import { deriveTaskType, deriveComplexityBucket } from '../../../learning/agent-routing.js';
+import { deriveTaskType } from '../../../learning/agent-routing.js';
 import { detectQEDomains } from '../../../learning/qe-patterns.js';
 
 // ============================================================================
@@ -393,6 +393,10 @@ export function registerTaskHooks(hooks: Command): void {
             // same row in `rl_q_values`. Skip only when we have no description
             // to work from (would land every update at a single "unknown"
             // sentinel state, polluting the table).
+            //
+            // ADR-096: state_key is 3-dim (taskType|priority|domain); the
+            // bridge still carries `complexityBucket` for kv_store schema
+            // compatibility but we don't read it here.
             const taskDescription = String(options.description ?? '');
             if (outcome.bridge || taskDescription) {
               const taskType =
@@ -402,14 +406,10 @@ export function registerTaskHooks(hooks: Command): void {
                 outcome.bridge?.domain ??
                 detectQEDomains(taskDescription)[0] ??
                 'any';
-              const complexityBucket =
-                outcome.bridge?.complexityBucket ??
-                deriveComplexityBucket(taskDescription);
               await updateHookRouterQValue({
                 taskType,
                 priority,
                 domain,
-                complexityBucket,
                 agent: effectiveAgent,
                 success,
               });

--- a/src/cli/commands/hooks-handlers/task-hooks.ts
+++ b/src/cli/commands/hooks-handlers/task-hooks.ts
@@ -23,7 +23,8 @@ import {
   printSuccess,
 } from './hooks-shared.js';
 import { ensureRoutingOutcomesAdr095Columns } from '../../../routing/routing-outcomes-migration.js';
-import { deriveTaskType } from '../../../learning/agent-routing.js';
+import { deriveTaskType, deriveComplexityBucket } from '../../../learning/agent-routing.js';
+import { detectQEDomains } from '../../../learning/qe-patterns.js';
 
 // ============================================================================
 // Constants — task-bridge / routing-quality / q-learning
@@ -300,6 +301,7 @@ export function registerTaskHooks(hooks: Command): void {
     .option('--success <bool>', 'Whether task succeeded', 'true')
     .option('--agent <name>', 'Agent that executed the task')
     .option('--duration <ms>', 'Task duration in milliseconds')
+    .option('-d, --description <desc>', 'Task description — fallback Q-state source when pre-task bridge is absent (issue #499)')
     .option('--json', 'Output as JSON')
     .action(async (options) => {
       try {
@@ -377,13 +379,37 @@ export function registerTaskHooks(hooks: Command): void {
             });
 
             // Stream F (patch 280): Bellman Q-update for the hook-router state.
-            // Bridge payload carries the structural state derivation.
-            if (outcome.bridge) {
+            //
+            // Issue #499: the original `if (outcome.bridge)` gate silently
+            // dropped the Q-update whenever the pre-task bridge wasn't matched
+            // (direct Bash/Edit work without a Task tool spawn, or pre-task
+            // hook didn't fire). On real projects, `rl_q_values` stayed at ~2
+            // rows while `routing_outcomes` reached 139, so the consumer side
+            // ADR-095 wired up (qe-reasoning-bank.ts:530) had nothing to read.
+            //
+            // When bridge is absent, derive the state_key components from the
+            // task description directly — same derivation the route hook uses
+            // (qe-reasoning-bank.ts:530-535) so writer and reader address the
+            // same row in `rl_q_values`. Skip only when we have no description
+            // to work from (would land every update at a single "unknown"
+            // sentinel state, polluting the table).
+            const taskDescription = String(options.description ?? '');
+            if (outcome.bridge || taskDescription) {
+              const taskType =
+                outcome.bridge?.taskType ?? deriveTaskType(taskDescription);
+              const priority = outcome.bridge?.priority ?? 'normal';
+              const domain =
+                outcome.bridge?.domain ??
+                detectQEDomains(taskDescription)[0] ??
+                'any';
+              const complexityBucket =
+                outcome.bridge?.complexityBucket ??
+                deriveComplexityBucket(taskDescription);
               await updateHookRouterQValue({
-                taskType: outcome.bridge.taskType,
-                priority: outcome.bridge.priority,
-                domain: outcome.bridge.domain,
-                complexityBucket: outcome.bridge.complexityBucket,
+                taskType,
+                priority,
+                domain,
+                complexityBucket,
                 agent: effectiveAgent,
                 success,
               });

--- a/src/learning/agent-routing.ts
+++ b/src/learning/agent-routing.ts
@@ -294,19 +294,31 @@ export function deriveTaskType(description: string): string {
  * Build the canonical Q-learning state_key. Must match the format used by
  * `updateHookRouterQValue` in hooks-dream-learning.ts — the writer and
  * reader must agree on the key shape.
+ *
+ * ADR-096 (issue #499): dropped `complexityBucket` from the state_key.
+ * The previous 4-dim key fragmented the state space on raw description
+ * length (a ~55-char vs ~130-char phrasing of the same task landed in
+ * different buckets), so `QWEIGHT_RAMP_VISITS=20` was rarely reached per
+ * cell and Q-values never converged. The 3-dim key collapses related
+ * tasks into the same state, letting Q-learning actually generalize.
  */
 export function buildRoutingStateKey(opts: {
   taskType: string;
   priority?: string;
   domain?: string;
-  complexityBucket: number;
 }): string {
-  return `${opts.taskType}|${opts.priority ?? 'normal'}|${opts.domain ?? 'any'}|${opts.complexityBucket}`;
+  return `${opts.taskType}|${opts.priority ?? 'normal'}|${opts.domain ?? 'any'}`;
 }
 
 /**
  * Compute the complexity bucket [0, 10] from a task description length.
  * Mirrors the formula in task-hooks.ts pre-task bridge.
+ *
+ * @deprecated ADR-096: no longer used for state_key construction (the
+ * length-keyed bucket fragmented the Q-state space). Retained for the
+ * pre-task bridge payload (kv_store schema compatibility) and any
+ * downstream telemetry that wants a coarse complexity signal. Do NOT use
+ * for new Q-routing surfaces.
  */
 export function deriveComplexityBucket(description: string): number {
   return Math.max(0, Math.min(10, Math.round(Math.min(description.length / 200, 1) * 10)));

--- a/src/learning/qe-reasoning-bank.ts
+++ b/src/learning/qe-reasoning-bank.ts
@@ -74,7 +74,6 @@ import {
   resolveExplorationRate,
   deriveTaskType,
   buildRoutingStateKey,
-  deriveComplexityBucket,
   type QValueLookup,
 } from './agent-routing.js';
 import { resolveTopologyCriticalFromSharedMincut } from './routing-topology-gate.js';
@@ -527,11 +526,13 @@ export class QEReasoningBank implements IQEReasoningBank {
       // ADR-095: build the Q-value lookup closure from the task's state_key.
       // The state_key MUST match what `updateHookRouterQValue` writes from
       // post-task — buildRoutingStateKey enforces that.
+      // ADR-096 (issue #499): state_key dropped `complexityBucket` — the
+      // length-keyed bucket fragmented identical tasks across cells so
+      // QWEIGHT_RAMP_VISITS=20 was never reached. 3-dim key now.
       const stateKey = buildRoutingStateKey({
         taskType: deriveTaskType(request.task),
         priority: 'normal',
         domain: detectedDomains[0],
-        complexityBucket: deriveComplexityBucket(request.task),
       });
       const qValueLookup = this.buildQValueLookup(stateKey);
 

--- a/tests/unit/cli/commands/route-q-loop-closure.test.ts
+++ b/tests/unit/cli/commands/route-q-loop-closure.test.ts
@@ -7,9 +7,11 @@
  *   Fix #1 (post-route side): when post-route resolves a route sentinel in
  *     `routing_outcomes`, it must also call `updateHookRouterQValue` with a
  *     state_key derived from the sentinel's task description — using the
- *     SAME helpers (`deriveTaskType`, `deriveComplexityBucket`,
- *     `detectQEDomains`) the route hook used at insertion time. Writer and
- *     reader address the identical row in `rl_q_values`.
+ *     SAME helpers (`deriveTaskType`, `detectQEDomains`) the route hook used
+ *     at insertion time. Writer and reader address the identical row in
+ *     `rl_q_values`. ADR-096 collapsed the state_key to 3 dims (no
+ *     complexity bucket) so the Q-state space stops fragmenting on raw
+ *     description length.
  *
  *   Fix #2 (post-task side): the `if (outcome.bridge)` gate at
  *     task-hooks.ts:381 silently dropped the Bellman Q-update whenever the
@@ -140,22 +142,19 @@ describe('post-route trains rl_q_values from resolved route sentinels (issue #49
 
   it('calls updateHookRouterQValue with state derived from the sentinel description', async () => {
     // Mirror the route hook's exact derivation order (qe-reasoning-bank.ts:530-535):
-    //   taskType:        deriveTaskType(description)
-    //   priority:        'normal'
-    //   domain:          detectQEDomains(description)[0] ?? 'any'
-    //   complexityBucket: deriveComplexityBucket(description)
-    // Asserting on the helpers' outputs directly keeps the test robust to
-    // heuristic tuning while still pinning the alignment contract.
+    //   taskType: deriveTaskType(description)
+    //   priority: 'normal'
+    //   domain:   detectQEDomains(description)[0] ?? 'any'
+    // ADR-096: no complexityBucket — state_key is 3-dim. Asserting on the
+    // helpers' outputs directly keeps the test robust to heuristic tuning
+    // while still pinning the alignment contract.
     const description = 'Write unit tests for the UserService class';
     insertRouteSentinel(db, 'route-1', description, 'qe-test-architect', '2026-05-19 10:00:00');
 
-    const { deriveTaskType, deriveComplexityBucket } = await import(
-      '../../../../src/learning/agent-routing.js'
-    );
+    const { deriveTaskType } = await import('../../../../src/learning/agent-routing.js');
     const { detectQEDomains } = await import('../../../../src/learning/qe-patterns.js');
     const expectedTaskType = deriveTaskType(description);
     const expectedDomain = detectQEDomains(description)[0] ?? 'any';
-    const expectedBucket = deriveComplexityBucket(description);
 
     const hooks = new Command('hooks');
     registerRoutingHooks(hooks);
@@ -166,7 +165,6 @@ describe('post-route trains rl_q_values from resolved route sentinels (issue #49
       taskType: expectedTaskType,
       priority: 'normal',
       domain: expectedDomain,
-      complexityBucket: expectedBucket,
       agent: 'qe-test-architect',
       success: true,
     });
@@ -257,7 +255,8 @@ describe('post-task trains rl_q_values even when outcome.bridge is absent (issue
     // suite above where it actually matters.
     expect(typeof call.taskType).toBe('string');
     expect(typeof call.domain).toBe('string');
-    expect(typeof call.complexityBucket).toBe('number');
+    // ADR-096: state_key is 3-dim — no `complexityBucket` in the payload.
+    expect(call).not.toHaveProperty('complexityBucket');
   });
 
   it('prefers the bridge-supplied state when bridge IS present', async () => {
@@ -298,8 +297,10 @@ describe('post-task trains rl_q_values even when outcome.bridge is absent (issue
       taskType: 'coverage-analysis',
       priority: 'high',
       domain: 'security-compliance',
-      complexityBucket: 7,
     });
+    // ADR-096: bridge.complexityBucket=7 in the test data must NOT leak
+    // into the Q-update payload — state_key is 3-dim.
+    expect(updateHookRouterQValueMock.mock.calls[0][0]).not.toHaveProperty('complexityBucket');
   });
 
   it('still skips Q-update when neither bridge nor description is available', async () => {

--- a/tests/unit/cli/commands/route-q-loop-closure.test.ts
+++ b/tests/unit/cli/commands/route-q-loop-closure.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Regression: issue #499 — `rl_q_values` is never trained from the routing
+ * surface, so the `route` hook's `qWeight` is structurally pinned at 0.
+ *
+ * Two complementary fixes verified here:
+ *
+ *   Fix #1 (post-route side): when post-route resolves a route sentinel in
+ *     `routing_outcomes`, it must also call `updateHookRouterQValue` with a
+ *     state_key derived from the sentinel's task description — using the
+ *     SAME helpers (`deriveTaskType`, `deriveComplexityBucket`,
+ *     `detectQEDomains`) the route hook used at insertion time. Writer and
+ *     reader address the identical row in `rl_q_values`.
+ *
+ *   Fix #2 (post-task side): the `if (outcome.bridge)` gate at
+ *     task-hooks.ts:381 silently dropped the Bellman Q-update whenever the
+ *     pre-task bridge wasn't matched. Direct Bash/Edit sessions never spawn
+ *     Task tools, so `outcome.bridge` was almost always absent on real
+ *     projects (Jordi's reproduction: 139 routing_outcomes rows vs 2
+ *     rl_q_values rows). Drop the gate; derive state_key from
+ *     `options.description` when bridge is absent.
+ *
+ * If either fix regresses, the corresponding spy assertions fail and the
+ * `route` hook returns to `qWeight: 0` indefinitely.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Command } from 'commander';
+import Database from 'better-sqlite3';
+
+const {
+  umMock,
+  updateHookRouterQValueMock,
+  persistTaskOutcomeMock,
+  updateRoutingOutcomeQualityMock,
+  recordOutcomeMock,
+} = vi.hoisted(() => ({
+  umMock: {
+    isInitialized: vi.fn().mockReturnValue(true),
+    initialize: vi.fn().mockResolvedValue(undefined),
+    getDatabase: vi.fn(),
+  },
+  updateHookRouterQValueMock: vi.fn().mockResolvedValue(undefined),
+  persistTaskOutcomeMock: vi.fn(),
+  updateRoutingOutcomeQualityMock: vi.fn().mockResolvedValue(undefined),
+  recordOutcomeMock: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+vi.mock('../../../../src/kernel/unified-memory.js', () => ({
+  findProjectRoot: vi.fn(() => '/tmp/route-q-loop-test'),
+  getUnifiedMemory: vi.fn(() => umMock),
+}));
+
+vi.mock('../../../../src/cli/commands/hooks-handlers/hooks-shared.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../src/cli/commands/hooks-handlers/hooks-shared.js')>();
+  return {
+    ...actual,
+    getHooksSystem: vi.fn().mockResolvedValue({
+      hookRegistry: { emit: vi.fn().mockResolvedValue([]) },
+      reasoningBank: {
+        recordOutcome: recordOutcomeMock,
+        routeTask: vi.fn().mockResolvedValue({ success: false }),
+      },
+    }),
+    createHybridBackendWithTimeout: vi.fn().mockResolvedValue({
+      store: vi.fn(),
+      retrieve: vi.fn().mockResolvedValue(null),
+      delete: vi.fn(),
+      close: vi.fn(),
+    }),
+    incrementDreamExperience: vi.fn().mockResolvedValue(0),
+    checkAndTriggerDream: vi.fn().mockResolvedValue({ triggered: false }),
+    applyHookBusyTimeout: vi.fn(),
+    persistTaskOutcome: persistTaskOutcomeMock,
+    updateHookRouterQValue: updateHookRouterQValueMock,
+    updateRoutingOutcomeQuality: updateRoutingOutcomeQualityMock,
+  };
+});
+
+import { registerRoutingHooks } from '../../../../src/cli/commands/hooks-handlers/routing-hooks.js';
+import { registerTaskHooks } from '../../../../src/cli/commands/hooks-handlers/task-hooks.js';
+
+function seedRoutingOutcomes(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE routing_outcomes (
+      id TEXT PRIMARY KEY,
+      task_json TEXT NOT NULL,
+      decision_json TEXT NOT NULL,
+      used_agent TEXT NOT NULL,
+      followed_recommendation INTEGER NOT NULL,
+      success INTEGER NOT NULL,
+      quality_score REAL NOT NULL,
+      duration_ms REAL NOT NULL,
+      error TEXT,
+      created_at TEXT DEFAULT (datetime('now'))
+    )
+  `);
+}
+
+function insertRouteSentinel(
+  db: Database.Database,
+  id: string,
+  description: string,
+  usedAgent: string,
+  createdAt: string,
+) {
+  db.prepare(`
+    INSERT INTO routing_outcomes
+      (id, task_json, decision_json, used_agent, followed_recommendation, success, quality_score, duration_ms, error, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    id,
+    JSON.stringify({ description, domain: null }),
+    JSON.stringify({ recommended: usedAgent, confidence: 0.5 }),
+    usedAgent,
+    1,
+    0,
+    -1,
+    0,
+    null,
+    createdAt,
+  );
+}
+
+describe('post-route trains rl_q_values from resolved route sentinels (issue #499 fix #1)', () => {
+  let db: Database.Database;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    seedRoutingOutcomes(db);
+    umMock.getDatabase.mockReturnValue(db);
+    updateHookRouterQValueMock.mockReset().mockResolvedValue(undefined);
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    db.close();
+  });
+
+  it('calls updateHookRouterQValue with state derived from the sentinel description', async () => {
+    // Mirror the route hook's exact derivation order (qe-reasoning-bank.ts:530-535):
+    //   taskType:        deriveTaskType(description)
+    //   priority:        'normal'
+    //   domain:          detectQEDomains(description)[0] ?? 'any'
+    //   complexityBucket: deriveComplexityBucket(description)
+    // Asserting on the helpers' outputs directly keeps the test robust to
+    // heuristic tuning while still pinning the alignment contract.
+    const description = 'Write unit tests for the UserService class';
+    insertRouteSentinel(db, 'route-1', description, 'qe-test-architect', '2026-05-19 10:00:00');
+
+    const { deriveTaskType, deriveComplexityBucket } = await import(
+      '../../../../src/learning/agent-routing.js'
+    );
+    const { detectQEDomains } = await import('../../../../src/learning/qe-patterns.js');
+    const expectedTaskType = deriveTaskType(description);
+    const expectedDomain = detectQEDomains(description)[0] ?? 'any';
+    const expectedBucket = deriveComplexityBucket(description);
+
+    const hooks = new Command('hooks');
+    registerRoutingHooks(hooks);
+    await hooks.parseAsync(['post-route', '--success', 'true', '--json'], { from: 'user' });
+
+    expect(updateHookRouterQValueMock).toHaveBeenCalledTimes(1);
+    expect(updateHookRouterQValueMock.mock.calls[0][0]).toEqual({
+      taskType: expectedTaskType,
+      priority: 'normal',
+      domain: expectedDomain,
+      complexityBucket: expectedBucket,
+      agent: 'qe-test-architect',
+      success: true,
+    });
+  });
+
+  it('does not call updateHookRouterQValue when no route sentinel exists', async () => {
+    const hooks = new Command('hooks');
+    registerRoutingHooks(hooks);
+    await hooks.parseAsync(['post-route', '--success', 'true', '--json'], { from: 'user' });
+
+    expect(updateHookRouterQValueMock).not.toHaveBeenCalled();
+  });
+
+  it('passes the resolved success bit through to the Q-update', async () => {
+    insertRouteSentinel(db, 'route-fail', 'Analyze coverage gaps', 'qe-coverage-analyzer', '2026-05-19 10:00:00');
+
+    const hooks = new Command('hooks');
+    registerRoutingHooks(hooks);
+    await hooks.parseAsync(['post-route', '--success', 'false', '--json'], { from: 'user' });
+
+    expect(updateHookRouterQValueMock).toHaveBeenCalledTimes(1);
+    expect(updateHookRouterQValueMock.mock.calls[0][0]).toMatchObject({
+      agent: 'qe-coverage-analyzer',
+      success: false,
+    });
+  });
+
+  it('swallows malformed task_json without crashing the Stop hook', async () => {
+    // Insert a sentinel with task_json that doesn't parse — Stop hooks must
+    // never crash the host shell.
+    db.prepare(`
+      INSERT INTO routing_outcomes
+        (id, task_json, decision_json, used_agent, followed_recommendation, success, quality_score, duration_ms, error, created_at)
+      VALUES ('route-bad', 'not-json-{{', '{}', 'qe-test-architect', 1, 0, -1, 0, NULL, '2026-05-19 10:00:00')
+    `).run();
+
+    const hooks = new Command('hooks');
+    registerRoutingHooks(hooks);
+    await expect(
+      hooks.parseAsync(['post-route', '--success', 'true', '--json'], { from: 'user' }),
+    ).resolves.not.toThrow();
+
+    // Sentinel still got resolved (the UPDATE happens before the Q-derivation
+    // try/catch), but no Q-update fired since description couldn't be parsed.
+    expect(updateHookRouterQValueMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('post-task trains rl_q_values even when outcome.bridge is absent (issue #499 fix #2)', () => {
+  beforeEach(() => {
+    updateHookRouterQValueMock.mockReset().mockResolvedValue(undefined);
+    persistTaskOutcomeMock.mockReset();
+    recordOutcomeMock.mockReset().mockResolvedValue({ success: true });
+    updateRoutingOutcomeQualityMock.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('fires Q-update with state derived from --description when bridge missing', async () => {
+    // Direct Bash/Edit work: pre-task didn't fire, so persistTaskOutcome
+    // returns no bridge. Before the fix, the `if (outcome.bridge)` gate
+    // swallowed the Q-update entirely. After the fix, we derive from
+    // options.description.
+    persistTaskOutcomeMock.mockResolvedValue({
+      experienceId: 'exp-1',
+      qualityScore: 0.675,
+      bridge: undefined,
+    });
+
+    const hooks = new Command('hooks');
+    registerTaskHooks(hooks);
+    await hooks.parseAsync(
+      [
+        'post-task',
+        '--agent', 'qe-test-architect',
+        '--success', 'true',
+        '--description', 'Generate vitest unit tests for the auth module',
+        '--json',
+      ],
+      { from: 'user' },
+    );
+
+    expect(updateHookRouterQValueMock).toHaveBeenCalledTimes(1);
+    const call = updateHookRouterQValueMock.mock.calls[0][0];
+    expect(call.agent).toBe('qe-test-architect');
+    expect(call.success).toBe(true);
+    expect(call.priority).toBe('normal');
+    // Don't pin the heuristic outputs — assert they're well-formed and the
+    // call fires; alignment with the reader side is tested in the post-route
+    // suite above where it actually matters.
+    expect(typeof call.taskType).toBe('string');
+    expect(typeof call.domain).toBe('string');
+    expect(typeof call.complexityBucket).toBe('number');
+  });
+
+  it('prefers the bridge-supplied state when bridge IS present', async () => {
+    // Bridge present (pre-task ran): use its structural derivation verbatim
+    // so this code path stays bit-identical to the pre-#499 behavior when
+    // the bridge wins.
+    persistTaskOutcomeMock.mockResolvedValue({
+      experienceId: 'exp-2',
+      qualityScore: 0.675,
+      bridge: {
+        selectedPatternIds: ['p1'],
+        agent: 'qe-test-architect',
+        description: 'bridge desc',
+        taskType: 'coverage-analysis',
+        priority: 'high',
+        domain: 'security-compliance',
+        complexityBucket: 7,
+        estimatedTokenSavings: 0,
+        ts: Date.now(),
+      },
+    });
+
+    const hooks = new Command('hooks');
+    registerTaskHooks(hooks);
+    await hooks.parseAsync(
+      [
+        'post-task',
+        '--agent', 'qe-test-architect',
+        '--success', 'true',
+        '--description', 'this description must lose to the bridge',
+        '--json',
+      ],
+      { from: 'user' },
+    );
+
+    expect(updateHookRouterQValueMock).toHaveBeenCalledTimes(1);
+    expect(updateHookRouterQValueMock.mock.calls[0][0]).toMatchObject({
+      taskType: 'coverage-analysis',
+      priority: 'high',
+      domain: 'security-compliance',
+      complexityBucket: 7,
+    });
+  });
+
+  it('still skips Q-update when neither bridge nor description is available', async () => {
+    persistTaskOutcomeMock.mockResolvedValue({
+      experienceId: 'exp-3',
+      qualityScore: 0.675,
+      bridge: undefined,
+    });
+
+    const hooks = new Command('hooks');
+    registerTaskHooks(hooks);
+    await hooks.parseAsync(
+      ['post-task', '--agent', 'qe-test-architect', '--success', 'true', '--json'],
+      { from: 'user' },
+    );
+
+    // Without bridge AND without description we have no signal to derive
+    // state from; firing the update would land every entry at a single
+    // "unknown" state and pollute the table.
+    expect(updateHookRouterQValueMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/learning/agent-routing-exploration.test.ts
+++ b/tests/unit/learning/agent-routing-exploration.test.ts
@@ -217,24 +217,39 @@ describe('deriveTaskType', () => {
   });
 });
 
-describe('buildRoutingStateKey', () => {
+describe('buildRoutingStateKey (ADR-096: 3-dim, issue #499)', () => {
   it('produces the canonical Q-table state_key format', () => {
     const k = buildRoutingStateKey({
       taskType: 'test-generation',
       priority: 'normal',
       domain: 'coverage-analysis',
-      complexityBucket: 3,
     });
-    expect(k).toBe('test-generation|normal|coverage-analysis|3');
+    expect(k).toBe('test-generation|normal|coverage-analysis');
   });
 
   it('defaults priority to "normal" and domain to "any"', () => {
-    const k = buildRoutingStateKey({ taskType: 'unknown', complexityBucket: 0 });
-    expect(k).toBe('unknown|normal|any|0');
+    const k = buildRoutingStateKey({ taskType: 'unknown' });
+    expect(k).toBe('unknown|normal|any');
+  });
+
+  it('matches the writer-side format in hooks-dream-learning.ts (3-dim key)', () => {
+    // Pins the producer/consumer contract: if a future refactor splits these,
+    // rl_q_values writes and reads stop addressing the same row.
+    const k = buildRoutingStateKey({
+      taskType: 'coverage-analysis',
+      priority: 'normal',
+      domain: 'test-generation',
+    });
+    expect(k.split('|')).toHaveLength(3);
   });
 });
 
-describe('deriveComplexityBucket', () => {
+describe('deriveComplexityBucket (legacy — ADR-096 deprecated for state_key)', () => {
+  // The helper is no longer used for Q-state construction (issue #499) but
+  // remains exported for the pre-task bridge payload (kv_store schema compat)
+  // and any downstream telemetry that wants a coarse complexity signal. Tests
+  // pin the historical formula so existing consumers keep getting stable
+  // outputs.
   it('returns 0 for empty / short descriptions', () => {
     expect(deriveComplexityBucket('')).toBe(0);
     expect(deriveComplexityBucket('hi')).toBe(0);


### PR DESCRIPTION
## Summary

Hotfix release closing the self-learning routing loop reported in #499
by Jordi. The `route` hook's `qWeight` was structurally pinned at 0
because the producer (`updateHookRouterQValue`) only fired from
`post-task` gated on the pre-task bridge — so on real projects
`routing_outcomes` reached 100+ rows while `rl_q_values` stayed at ~2,
and the consumer ADR-095 wired up had nothing to read. ADR-096
documents the three-part fix.

## What's in this release

Two commits from the issue investigation, plus the release commit:

- `d41bbc22` fix(routing): close Q-loop on routing surface (#499) —
  post-route now trains `rl_q_values`; post-task fires Q-update even
  when `outcome.bridge` is absent; new `--description` CLI option;
  ADR-096 v1; 7 new contract tests.
- `d698c587` fix(routing): collapse Q-state to 3-dim (drop
  complexityBucket) (#499) — the previous 4-dim state_key fragmented
  semantically identical tasks across cells; convergence is now ~11×
  faster for a given `(taskType, domain)` pair.
- `eea53fcd` chore(release): bump version to v3.9.36.

## Verification

Local on this branch:

```
$ node -p "require('./package.json').version"
3.9.36

$ npm run build
> tsc && build:cli && build:mcp
CLI bundle built successfully (v3.9.36)
MCP bundle built successfully (v3.9.36)

$ npx tsc --noEmit -p .
(no output — clean)

$ NODE_OPTIONS='--max-old-space-size=4096' npm run test:unit:fast
Test Files  258 passed | 1 skipped (260)
Tests       7651 passed | 5 skipped (7662)

$ npm run performance:gate
All performance gates passed!
Total: 15 | Passed: 15 | Failed: 0 | Warnings: 0

$ node dist/cli/bundle.js --version
3.9.36

# Fresh-project init
$ aqe init --auto
.agentic-qe/  .claude/  .mcp.json  (created)

# Isolated tarball install (catches missing externals)
$ npm pack && cd $(mktemp -d) && npm install <tarball>
found 0 vulnerabilities
$ node node_modules/.bin/aqe --version
3.9.36 (exit 0)
```

## Failure modes

- **Existing `rl_q_values` rows under the 4-dim key shape become
  orphans** — they will never match new 3-dim lookups. Field reports
  (#499) show real installs have ~2 such rows at most because the loop
  was broken, so no migration ships. Customers with substantial 4-dim
  data can run a one-shot UPDATE documented in `docs/releases/v3.9.36.md`
  or simply `DELETE` the orphans. Tracking: #499.
- **`post-route` re-derives state_key from `task_json.description` at
  Stop-hook time** rather than reading it from the route-hook write.
  In practice these match (both pass the description through
  `deriveTaskType` + `detectQEDomains`, which are pure functions), but
  if a future refactor changes either helper, writer and reader could
  desynchronize. Mitigated by `tests/unit/cli/commands/route-q-loop-closure.test.ts`
  and `tests/unit/learning/agent-routing-exploration.test.ts` pinning
  the alignment contract. Cleaner long-term fix (persist `state_key`
  on the sentinel row) is noted in ADR-096 Open Questions, tracked
  for a follow-up release. Tracking: #499.
- **Adding `--description` to `post-task` requires the init template's
  hook command to pass `$tool_input.description` for Task tools to get
  full benefit.** Older agentic-qe installs continue working with
  bridge-only state derivation; the gain only lands when re-init'd.
  Init template update lands separately in a follow-up to avoid
  bundling unrelated risk into this hotfix. Tracking: #499.

## Acknowledgments

Thanks to Jordi Izquierdo for the exhaustive root-cause analysis in
#499 (code-pointer-accurate to the dist/ layer) and the verified
external workaround that confirmed the producer/consumer alignment
approach before any code change shipped.

---

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.** "Unlikely" is not an acceptable substitute. If you wrote "I don't think this can happen but...", that sentence is a failure mode and needs a test or an issue link.

### Optional context

- Linked issues: closes #499
- Trust tier change (if any): none
- Affects published API or CLI surface: yes — new `aqe hooks post-task --description` option; internal `buildRoutingStateKey` / `updateHookRouterQValue` signatures changed (project-internal)
- Touches the init flow / `npm-publish.yml` / `tests/fixtures/init-corpus/`: no

See [CHANGELOG](CHANGELOG.md) for details.