### PR TITLE
feat(embeddings): optional external embedder endpoint

### DIFF
--- a/src/learning/embedder-endpoint.ts
+++ b/src/learning/embedder-endpoint.ts
@@ -1,0 +1,130 @@
+/**
+ * External Embedder Endpoint Client
+ *
+ * When `embedding.endpoint` is configured (see EmbeddingConfig in
+ * real-embeddings.ts), AQE routes feature-extraction to an external embedder
+ * service instead of loading its own in-process @huggingface/transformers
+ * model. This lets a co-deployed toolchain (e.g. ruflo / ruvector, which
+ * embeds with the identical all-MiniLM-L6-v2 stack) share a single warm model
+ * rather than every AQE hook process cold-loading its own copy.
+ *
+ * Endpoint forms:
+ *   http(s)://host:port   - POST application/json
+ *   unix:/path/to.sock    - one newline-terminated JSON line
+ *
+ * Wire protocol (identical JSON in both directions):
+ *   request : { "texts": string[] }
+ *   response: { "embeddings": number[][] }   // mean-pooled, L2-normalized, 384-d
+ *
+ * The endpoint owns pooling/normalization; AQE only sends raw text.
+ */
+import net from 'node:net';
+
+/** Feature-extraction tensor output — mirrors the @huggingface/transformers shape. */
+export interface EmbeddingOutput {
+  data: Float32Array;
+  dims?: number[];
+}
+
+/** Drop-in replacement for the @huggingface/transformers feature-extraction pipeline. */
+export interface FeatureExtractionPipeline {
+  (
+    input: string | string[],
+    options?: { pooling?: string; normalize?: boolean }
+  ): Promise<EmbeddingOutput>;
+}
+
+const REQUEST_TIMEOUT_MS = 120_000;
+
+interface EmbeddingsReply {
+  embeddings?: number[][];
+}
+
+async function requestHttp(endpoint: string, texts: string[]): Promise<number[][]> {
+  const res = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ texts }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new Error(`embedder endpoint returned HTTP ${res.status}`);
+  }
+  const json = (await res.json()) as EmbeddingsReply;
+  if (!Array.isArray(json.embeddings)) {
+    throw new Error('embedder endpoint reply missing "embeddings" array');
+  }
+  return json.embeddings;
+}
+
+function requestUnixSocket(socketPath: string, texts: string[]): Promise<number[][]> {
+  return new Promise<number[][]>((resolve, reject) => {
+    const conn = net.connect(socketPath);
+    let buf = '';
+    let settled = false;
+    const finish = (err: Error | null, value?: number[][]): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      conn.destroy();
+      if (err) reject(err);
+      else resolve(value as number[][]);
+    };
+    const timer = setTimeout(
+      () => finish(new Error('embedder endpoint timed out')),
+      REQUEST_TIMEOUT_MS
+    );
+    conn.on('connect', () => conn.write(JSON.stringify({ texts }) + '\n'));
+    conn.on('data', (chunk: Buffer) => {
+      buf += chunk.toString('utf8');
+      const nl = buf.indexOf('\n');
+      if (nl < 0) return;
+      try {
+        const json = JSON.parse(buf.slice(0, nl)) as EmbeddingsReply;
+        if (!Array.isArray(json.embeddings)) {
+          throw new Error('embedder endpoint reply missing "embeddings" array');
+        }
+        finish(null, json.embeddings);
+      } catch (e) {
+        finish(e as Error);
+      }
+    });
+    conn.on('error', (e: Error) => finish(e));
+  });
+}
+
+/** Send texts to the configured endpoint and return their embeddings. */
+async function requestEmbeddings(endpoint: string, texts: string[]): Promise<number[][]> {
+  if (endpoint.startsWith('unix:')) {
+    return requestUnixSocket(endpoint.slice('unix:'.length), texts);
+  }
+  if (/^https?:\/\//.test(endpoint)) {
+    return requestHttp(endpoint, texts);
+  }
+  throw new Error(
+    `unsupported embedder endpoint "${endpoint}" (expected http(s):// or unix:<path>)`
+  );
+}
+
+/**
+ * Build a feature-extraction pipeline backed by an external embedder endpoint.
+ * The returned function matches the @huggingface/transformers extractor
+ * signature, so it is a drop-in for the in-process model.
+ */
+export function createEndpointPipeline(endpoint: string): FeatureExtractionPipeline {
+  return async (input: string | string[]): Promise<EmbeddingOutput> => {
+    const texts = Array.isArray(input) ? input : [input];
+    const embeddings = await requestEmbeddings(endpoint, texts);
+    if (embeddings.length !== texts.length) {
+      throw new Error(
+        `embedder endpoint returned ${embeddings.length} embeddings for ${texts.length} texts`
+      );
+    }
+    const dim = embeddings[0]?.length ?? 384;
+    const data = new Float32Array(texts.length * dim);
+    for (let i = 0; i < texts.length; i++) {
+      data.set(embeddings[i], i * dim);
+    }
+    return { data, dims: [texts.length, dim] };
+  };
+}

--- a/src/learning/real-embeddings.ts
+++ b/src/learning/real-embeddings.ts
@@ -9,6 +9,7 @@
 // Re-export cosineSimilarity from shared utility for backward compatibility
 export { cosineSimilarity } from '../shared/utils/vector-math.js';
 import { toErrorMessage } from '../shared/error-utils.js';
+import { createEndpointPipeline } from './embedder-endpoint.js';
 
 /**
  * Type for the @xenova/transformers pipeline function
@@ -58,6 +59,15 @@ export interface EmbeddingConfig {
 
   /** Maximum cache size */
   maxCacheSize: number;
+
+  /**
+   * Optional external embedder endpoint. When set, AQE routes
+   * feature-extraction to this service instead of loading an in-process
+   * model — letting a co-deployed toolchain (e.g. ruflo/ruvector) share a
+   * single warm model. Forms: `http(s)://host:port` or `unix:/path/to.sock`.
+   * Defaults to the `AQE_EMBEDDER_ENDPOINT` env var; unset = in-process model.
+   */
+  endpoint?: string;
 }
 
 export const DEFAULT_EMBEDDING_CONFIG: EmbeddingConfig = {
@@ -65,6 +75,7 @@ export const DEFAULT_EMBEDDING_CONFIG: EmbeddingConfig = {
   quantized: true,
   enableCache: true,
   maxCacheSize: 10000,
+  endpoint: process.env.AQE_EMBEDDER_ENDPOINT,
 };
 
 // Embedding cache (LRU)
@@ -109,6 +120,14 @@ async function initializeModel(config: Partial<EmbeddingConfig> = {}): Promise<v
 
   initPromise = (async () => {
     try {
+      // External embedder endpoint — route to a shared service, skip the
+      // in-process model entirely.
+      if (fullConfig.endpoint) {
+        console.log(`[RealEmbeddings] Using external embedder endpoint: ${fullConfig.endpoint}`);
+        embeddingModel = createEndpointPipeline(fullConfig.endpoint);
+        return;
+      }
+
       // Dynamic import to avoid issues if transformers not available
       const transformers = await import('@huggingface/transformers');
       pipeline = transformers.pipeline;

--- a/tests/unit/learning/embedder-endpoint.test.ts
+++ b/tests/unit/learning/embedder-endpoint.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for the external embedder endpoint client (embedder-endpoint.ts).
+ *
+ * Verifies createEndpointPipeline() against mock embedder servers on both a
+ * Unix socket and HTTP, the batch path, and the unsupported-scheme error.
+ * No real model is loaded — the mock servers return deterministic vectors.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import net from 'node:net';
+import http from 'node:http';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+
+import { createEndpointPipeline } from '../../../src/learning/embedder-endpoint.js';
+
+const DIM = 384;
+
+/** Deterministic fake embedding so assertions are stable. */
+const fakeEmbedding = (seed: number): number[] =>
+  Array.from({ length: DIM }, (_, i) => (seed + i) / 1000);
+
+describe('embedder-endpoint: createEndpointPipeline', () => {
+  let tmp: string;
+  let unixServer: net.Server;
+  let httpServer: http.Server;
+  let socketPath: string;
+  let httpUrl: string;
+
+  beforeAll(async () => {
+    tmp = mkdtempSync(path.join(tmpdir(), 'aqe-embed-'));
+    socketPath = path.join(tmp, 'embedder.sock');
+
+    // Mock Unix-socket embedder: { texts } -> { embeddings }
+    unixServer = net.createServer((conn) => {
+      let buf = '';
+      conn.on('data', (d: Buffer) => {
+        buf += d.toString('utf8');
+        const nl = buf.indexOf('\n');
+        if (nl < 0) return;
+        const { texts } = JSON.parse(buf.slice(0, nl)) as { texts: string[] };
+        conn.write(JSON.stringify({ embeddings: texts.map((_t, i) => fakeEmbedding(i)) }) + '\n');
+      });
+    });
+    await new Promise<void>((resolve) => unixServer.listen(socketPath, resolve));
+
+    // Mock HTTP embedder
+    httpServer = http.createServer((req, res) => {
+      let body = '';
+      req.on('data', (c) => (body += c));
+      req.on('end', () => {
+        const { texts } = JSON.parse(body) as { texts: string[] };
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ embeddings: texts.map((_t, i) => fakeEmbedding(i)) }));
+      });
+    });
+    await new Promise<void>((resolve) => httpServer.listen(0, '127.0.0.1', resolve));
+    const addr = httpServer.address() as net.AddressInfo;
+    httpUrl = `http://127.0.0.1:${addr.port}`;
+  });
+
+  afterAll(() => {
+    unixServer?.close();
+    httpServer?.close();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('embeds a single string over a unix socket', async () => {
+    const extract = createEndpointPipeline(`unix:${socketPath}`);
+    const out = await extract('hello world');
+    expect(out.data).toBeInstanceOf(Float32Array);
+    expect(out.data.length).toBe(DIM);
+    expect(out.dims).toEqual([1, DIM]);
+    expect(out.data[0]).toBeCloseTo(0); // fakeEmbedding(0)[0]
+  });
+
+  it('embeds a batch over a unix socket — correct dims and ordering', async () => {
+    const extract = createEndpointPipeline(`unix:${socketPath}`);
+    const out = await extract(['a', 'b', 'c']);
+    expect(out.data.length).toBe(3 * DIM);
+    expect(out.dims).toEqual([3, DIM]);
+    // text #1 received seed 1 -> its embedding[0] sits at flat offset DIM
+    expect(out.data[DIM]).toBeCloseTo(1 / 1000);
+  });
+
+  it('embeds over an HTTP endpoint', async () => {
+    const extract = createEndpointPipeline(httpUrl);
+    const out = await extract('hello');
+    expect(out.data.length).toBe(DIM);
+    expect(out.dims).toEqual([1, DIM]);
+  });
+
+  it('rejects an unsupported endpoint scheme', async () => {
+    const extract = createEndpointPipeline('ftp://nope');
+    await expect(extract('x')).rejects.toThrow(/unsupported embedder endpoint/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an opt-in **`embedding.endpoint`** config (and an `AQE_EMBEDDER_ENDPOINT`
env var). When set, AQE routes `feature-extraction` to an external embedder
service instead of loading its own in-process model. When unset, nothing
changes.

A small, fully backward-compatible addition that removes a real duplicate-model
cost in the (common) deployment where AQE runs alongside ruflo / ruvector.
Thank you for considering it 🙏 — filed kindly by folks running AQE in
production next to ruvector.

## Motivation

AQE and **ruflo/ruvector are usually deployed together**, and both embed with
the *identical* stack: `@huggingface/transformers`,
`pipeline('feature-extraction', 'Xenova/all-MiniLM-L6-v2', { quantized: true })`,
mean-pooled + normalized, 384-d.

In that co-deployment today:

- the **same model is loaded warm twice** (~45–90 MB heap each, identical weights);
- worse for hooks — each `agentic-qe hooks …` invocation is a *fresh process*,
  so any hook that embeds pays a **cold model load every time** (a module
  singleton cannot help across separate processes).

With a shared resident embedder service: **one** model in memory, and embedding
becomes a warm socket/HTTP call (~8–13 ms) instead of a per-hook cold load.

Standalone AQE (no ruvector) is unaffected — `endpoint` unset → today's behavior.

## What's in this PR

- **`src/learning/embedder-endpoint.ts`** *(new)* — the endpoint client.
  `createEndpointPipeline(endpoint)` returns a function with the *same
  signature* as the `@huggingface/transformers` feature-extraction pipeline
  (`(input) => { data, dims }`), so it is a drop-in. Supports `http(s)://` and
  `unix:<path>` endpoints.
- **`src/learning/real-embeddings.ts`** — `EmbeddingConfig` gains an optional
  `endpoint` field (defaults to the `AQE_EMBEDDER_ENDPOINT` env var);
  `initializeModel()` branches to `createEndpointPipeline()` when it is set,
  skipping the in-process model load entirely.
- **`tests/unit/learning/embedder-endpoint.test.ts`** *(new)* — unix-socket
  (single + batch), HTTP, and unsupported-scheme coverage against mock servers.

### Wire protocol

One request → one response, identical JSON over HTTP (POST body) or a Unix
socket (one newline-terminated line):

```jsonc
// request
{ "texts": ["first", "second"] }
// response — mean-pooled, L2-normalized, 384-d, order-preserving
{ "embeddings": [[/* 384 floats */], [/* 384 floats */]] }
```

The endpoint owns pooling/normalization; AQE only sends raw text — which is all
`extractor(text, { pooling: 'mean', normalize: true })` needs.

## Backward compatibility

`endpoint` defaults to `undefined` → the in-process model path is byte-for-byte
unchanged. Pure opt-in; only set in deployments that run an embedder service.

## Verification

- `npm run typecheck` (`tsc --noEmit`) — clean.
- `npx vitest run tests/unit/learning/embedder-endpoint.test.ts` — 4/4 pass.

## Context — why we're filing this

We bridged this on our side meanwhile with a `NODE_OPTIONS=--require` shim that
monkey-patches `Module._load` to intercept `@huggingface/transformers`. It
works and keeps AQE vanilla on disk — but it is a hack: it depends on AQE's
internal library usage and would break on an AQE / transformers.js change. A
first-class `embedding.endpoint` option makes the shim unnecessary and gives
every AQE user a clean, supported path.

Happy to adjust naming, shape, or protocol to match your conventions — and to
add docs wherever you'd like them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
