### PR TITLE
fix(rvf): resolve project root via static import, not require() (#516 follow-up)

### DIFF
--- a/src/integrations/ruvector/shared-rvf-adapter.ts
+++ b/src/integrations/ruvector/shared-rvf-adapter.ts
@@ -12,6 +12,9 @@
  */
 
 import type { RvfNativeAdapter, RvfCompactionResult, RvfStatus } from './rvf-native-adapter.js';
+// Issue #516: lightweight, sqlite-free project-root resolver (static import so it
+// resolves under the test runner; avoids pulling unified-memory's sqlite graph).
+import { findProjectRoot } from '../../kernel/project-root.js';
 
 let sharedAdapter: RvfNativeAdapter | null = null;
 let initAttempted = false;
@@ -83,8 +86,6 @@ export function getSharedRvfAdapter(
     // A subfolder cwd (vendored builds, background workers, `aqe code index
     // docs/`) otherwise scatters stray patterns.rvf-only stores. Explicit
     // absolute dataDir args are honored as-is.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { findProjectRoot } = require('../../kernel/unified-memory.js');
     const baseDir = path.isAbsolute(dataDir)
       ? dataDir
       : path.join(process.env.AQE_PROJECT_ROOT ?? findProjectRoot(), dataDir);

--- a/src/kernel/project-root.ts
+++ b/src/kernel/project-root.ts
@@ -1,0 +1,92 @@
+/**
+ * Project Root Detection
+ *
+ * Lightweight, dependency-free resolution of the AQE project root. Kept in its
+ * own module (no SQLite / kernel imports) so hot paths — e.g. the RVF pattern
+ * store factory — can import it statically without dragging in the sqlite-heavy
+ * unified-memory graph, and so it resolves cleanly under the test runner.
+ *
+ * `unified-memory` re-exports `findProjectRoot` / `clearProjectRootCache` for
+ * backward compatibility, so existing import sites keep working.
+ *
+ * @module kernel/project-root
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** Module-level cache for findProjectRoot result. */
+let _cachedProjectRoot: string | null = null;
+
+/**
+ * Clear the cached project root. Useful for testing or when the
+ * environment changes at runtime.
+ */
+export function clearProjectRootCache(): void {
+  _cachedProjectRoot = null;
+}
+
+/**
+ * Find the project root by walking up the directory tree.
+ *
+ * Priority order:
+ * 1. AQE_PROJECT_ROOT environment variable (set by MCP config or init)
+ * 2. Walk up looking for the NEAREST .agentic-qe directory (existing AQE project)
+ * 3. Walk up looking for .git directory (git repo root)
+ * 4. Walk up looking for package.json WITHOUT node_modules sibling (monorepo root)
+ * 5. Fallback to current working directory
+ *
+ * Optimized: single upward walk checks all markers in one pass,
+ * and the result is cached at module level for subsequent calls.
+ */
+export function findProjectRoot(startDir: string = process.cwd()): string {
+  if (_cachedProjectRoot) {
+    return _cachedProjectRoot;
+  }
+
+  if (process.env.AQE_PROJECT_ROOT) {
+    _cachedProjectRoot = process.env.AQE_PROJECT_ROOT;
+    return _cachedProjectRoot;
+  }
+
+  const dir = startDir;
+  const root = path.parse(dir).root;
+
+  let checkDir = dir;
+  let nearestAqeDir: string | null = null;
+  let lowestGitDir: string | null = null;
+  let topmostPackageJson: string | null = null;
+
+  while (checkDir !== root) {
+    // Issue #516: prefer the NEAREST (lowest) .agentic-qe, mirroring the
+    // .git logic below. Keeping the topmost match let an ancestor store
+    // (e.g. ~/.agentic-qe, created by any `aqe` run from $HOME) hijack
+    // every descendant project and fragment its learning into $HOME.
+    if (fs.existsSync(path.join(checkDir, '.agentic-qe'))) {
+      if (nearestAqeDir === null) {
+        nearestAqeDir = checkDir;
+      }
+    }
+    if (fs.existsSync(path.join(checkDir, '.git'))) {
+      if (lowestGitDir === null) {
+        lowestGitDir = checkDir;
+      }
+    }
+    if (fs.existsSync(path.join(checkDir, 'package.json'))) {
+      topmostPackageJson = checkDir;
+    }
+    checkDir = path.dirname(checkDir);
+  }
+
+  if (nearestAqeDir) {
+    _cachedProjectRoot = nearestAqeDir;
+  } else if (lowestGitDir) {
+    _cachedProjectRoot = lowestGitDir;
+  } else if (topmostPackageJson) {
+    _cachedProjectRoot = topmostPackageJson;
+  } else {
+    _cachedProjectRoot = process.cwd();
+  }
+
+  return _cachedProjectRoot;
+}

--- a/src/kernel/unified-memory.ts
+++ b/src/kernel/unified-memory.ts
@@ -74,81 +74,14 @@ import {
 // Project Root Detection
 // ============================================================================
 
-/** Module-level cache for findProjectRoot result. */
-let _cachedProjectRoot: string | null = null;
-
-/**
- * Clear the cached project root. Useful for testing or when the
- * environment changes at runtime.
- */
-export function clearProjectRootCache(): void {
-  _cachedProjectRoot = null;
-}
-
-/**
- * Find the project root by walking up the directory tree.
- *
- * Priority order:
- * 1. AQE_PROJECT_ROOT environment variable (set by MCP config or init)
- * 2. Walk up looking for the NEAREST .agentic-qe directory (existing AQE project)
- * 3. Walk up looking for .git directory (git repo root)
- * 4. Walk up looking for package.json WITHOUT node_modules sibling (monorepo root)
- * 5. Fallback to current working directory
- *
- * Optimized: single upward walk checks all markers in one pass,
- * and the result is cached at module level for subsequent calls.
- */
-export function findProjectRoot(startDir: string = process.cwd()): string {
-  if (_cachedProjectRoot) {
-    return _cachedProjectRoot;
-  }
-
-  if (process.env.AQE_PROJECT_ROOT) {
-    _cachedProjectRoot = process.env.AQE_PROJECT_ROOT;
-    return _cachedProjectRoot;
-  }
-
-  const dir = startDir;
-  const root = path.parse(dir).root;
-
-  let checkDir = dir;
-  let nearestAqeDir: string | null = null;
-  let lowestGitDir: string | null = null;
-  let topmostPackageJson: string | null = null;
-
-  while (checkDir !== root) {
-    // Issue #516: prefer the NEAREST (lowest) .agentic-qe, mirroring the
-    // .git logic below. Keeping the topmost match let an ancestor store
-    // (e.g. ~/.agentic-qe, created by any `aqe` run from $HOME) hijack
-    // every descendant project and fragment its learning into $HOME.
-    if (fs.existsSync(path.join(checkDir, '.agentic-qe'))) {
-      if (nearestAqeDir === null) {
-        nearestAqeDir = checkDir;
-      }
-    }
-    if (fs.existsSync(path.join(checkDir, '.git'))) {
-      if (lowestGitDir === null) {
-        lowestGitDir = checkDir;
-      }
-    }
-    if (fs.existsSync(path.join(checkDir, 'package.json'))) {
-      topmostPackageJson = checkDir;
-    }
-    checkDir = path.dirname(checkDir);
-  }
-
-  if (nearestAqeDir) {
-    _cachedProjectRoot = nearestAqeDir;
-  } else if (lowestGitDir) {
-    _cachedProjectRoot = lowestGitDir;
-  } else if (topmostPackageJson) {
-    _cachedProjectRoot = topmostPackageJson;
-  } else {
-    _cachedProjectRoot = process.cwd();
-  }
-
-  return _cachedProjectRoot;
-}
+// Issue #516: findProjectRoot / clearProjectRootCache live in a lightweight,
+// sqlite-free module so RVF hot paths can import them statically without
+// pulling in this sqlite-heavy module. Re-exported here for backward compat —
+// existing `import { findProjectRoot } from '.../unified-memory.js'` sites keep
+// working unchanged. Imported (not bare re-exported) so internal callers below
+// have a usable local binding.
+import { findProjectRoot, clearProjectRootCache } from './project-root.js';
+export { findProjectRoot, clearProjectRootCache };
 
 /**
  * Get the default database path using project root detection.

--- a/src/learning/pattern-store.ts
+++ b/src/learning/pattern-store.ts
@@ -8,6 +8,9 @@
 
 import { v4 as uuidv4 } from 'uuid';
 import type { MemoryBackend } from '../kernel/interfaces.js';
+// Issue #516: lightweight, sqlite-free project-root resolver (static import so it
+// resolves under the test runner; avoids pulling unified-memory's sqlite graph).
+import { findProjectRoot } from '../kernel/project-root.js';
 import type { Result } from '../shared/types/index.js';
 import { ok, err } from '../shared/types/index.js';
 import { RvfPatternStore } from './rvf-pattern-store.js';
@@ -1851,7 +1854,6 @@ export function createPatternStore(
       // the project's own .agentic-qe/ rather than a cwd-relative stray store.
       const { existsSync } = require('fs');
       const { join: joinPath } = require('path');
-      const { findProjectRoot } = require('../kernel/unified-memory.js');
       const projectRoot = process.env.AQE_PROJECT_ROOT ?? findProjectRoot();
       const rvfDir = joinPath(projectRoot, '.agentic-qe');
       const rvfPath = joinPath(rvfDir, 'patterns.rvf');

--- a/tests/unit/learning/rvf-pattern-store.test.ts
+++ b/tests/unit/learning/rvf-pattern-store.test.ts
@@ -320,26 +320,39 @@ describe('createPatternStore factory routing', () => {
       return;
     }
 
+    // Issue #516: createPatternStore now anchors the RVF dir to the project root
+    // (AQE_PROJECT_ROOT ?? findProjectRoot()) instead of a cwd-relative
+    // '.agentic-qe'. Pin a hermetic project root with an existing .agentic-qe so
+    // the RVF branch is taken deterministically regardless of test order or cwd
+    // side-effects (previously this relied on another test having created
+    // ./.agentic-qe in the process cwd).
+    const { mkdtempSync, mkdirSync, rmSync } = await import('fs');
+    const { tmpdir } = await import('os');
+    const { join } = await import('path');
+    const projectRoot = mkdtempSync(join(tmpdir(), 'aqe-rvf-factory-'));
+    mkdirSync(join(projectRoot, '.agentic-qe'), { recursive: true });
+    const savedRoot = process.env.AQE_PROJECT_ROOT;
+    process.env.AQE_PROJECT_ROOT = projectRoot;
+
     setRuVectorFeatureFlags({ useRVFPatternStore: true });
 
-    const { createPatternStore } = await import('../../../src/learning/pattern-store.js');
-    const mockMemory = {
-      get: vi.fn(),
-      set: vi.fn(),
-      delete: vi.fn(),
-      list: vi.fn(() => []),
-      clear: vi.fn(),
-    };
-    const store = createPatternStore(mockMemory as any);
+    try {
+      const { createPatternStore } = await import('../../../src/learning/pattern-store.js');
+      const mockMemory = {
+        get: vi.fn(),
+        set: vi.fn(),
+        delete: vi.fn(),
+        list: vi.fn(() => []),
+        clear: vi.fn(),
+      };
+      const store = createPatternStore(mockMemory as any);
 
-    expect(store.constructor.name).toBe('RvfPatternStore');
-    await store.dispose();
-
-    // Cleanup the .rvf file created
-    const { existsSync, unlinkSync } = await import('fs');
-    for (const ext of ['', '.idmap.json']) {
-      const p = `.agentic-qe/patterns.rvf${ext}`;
-      if (existsSync(p)) unlinkSync(p);
+      expect(store.constructor.name).toBe('RvfPatternStore');
+      await store.dispose();
+    } finally {
+      if (savedRoot === undefined) delete process.env.AQE_PROJECT_ROOT;
+      else process.env.AQE_PROJECT_ROOT = savedRoot;
+      rmSync(projectRoot, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
## Summary

Hotfix for the v3.10.4 publish failure. The publish gate (`test:unit:fast` under vitest) failed `rvf-pattern-store.test.ts` — `createPatternStore` returned `PatternStore` instead of `RvfPatternStore`.

Root cause: the #516 change resolved the project root via `require('../kernel/unified-memory.js')` inside `createPatternStore`. esbuild inlines that in the shipped bundle, but under vitest it throws `Cannot find module`, so the entire RVF block fell through to the plain store — RVF pattern store was silently disabled under the test runner.

Fix: extract `findProjectRoot`/`clearProjectRootCache` into a lightweight, sqlite-free module (`src/kernel/project-root.ts`) and import it **statically** from the RVF hot paths. `unified-memory.ts` imports + re-exports them, so existing import sites are unchanged. A static import resolves cleanly under vitest and avoids dragging `unified-memory`'s eager `better-sqlite3` load into these modules.

## Verification

Native RVF is available in this environment, so the previously-failing assertion actually executes locally:

```
$ npm run typecheck
  exit 0 (0 errors)

$ npx vitest run tests/unit/learning/rvf-pattern-store.test.ts tests/unit/kernel/find-project-root.test.ts
  Test Files  2 passed (2)
  Tests  20 passed (20)
  # includes "should return RvfPatternStore when useRVFPatternStore is true and native is available"

$ npx vitest run tests/unit/integrations/ruvector
  181 passed; 32 failed — ALL 32 are "better_sqlite3.node: invalid ELF header"
  (macOS native binary on this Linux container; env-only, unrelated to this change)
```

## Failure modes

- **Re-export breaks existing `findProjectRoot` importers.** `unified-memory.ts` imports the functions (local binding for its internal callers at 4 sites) and re-exports them, so `import { findProjectRoot } from '.../unified-memory.js'` is unchanged. Exercised by `find-project-root.test.ts` (which imports from `unified-memory`) — 4/4 pass.
- **`createPatternStore` returns the wrong store type.** The exact regression this fixes. Exercised by `rvf-pattern-store.test.ts` (RvfPatternStore true-path), now hermetic via a pinned `AQE_PROJECT_ROOT`.
- **`shared-rvf-adapter` had the same latent `require()` bug.** Fixed identically; runtime-validated by the 181 passing ruvector tests.
- **Full sqlite-backed suite not run on this local platform** (macOS `better-sqlite3` binary → `invalid ELF header`). Mitigated by CI running `test:unit:fast` + `test:integration:fast` on a matched Linux runner on this PR — that run is the gate. Not a code failure mode.

---

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.** "Unlikely" is not an acceptable substitute. If you wrote "I don't think this can happen but...", that sentence is a failure mode and needs a test or an issue link.

### Optional context

- Linked issues: #516 (follow-up)
- Trust tier change (if any): none
- Affects published API or CLI surface: no (internal resolution refactor; behavior unchanged)
- Touches the init flow / `npm-publish.yml` / `tests/fixtures/init-corpus/`: no
