### PR TITLE
chore(release): v3.10.5 — Fable 5 parity: CLI fleet fix, prompt caching, adversarial QCSD reviews, qe-arena

### DIFF
--- a/.claude/skills/qcsd-development-swarm/SKILL.md
+++ b/.claude/skills/qcsd-development-swarm/SKILL.md
@@ -3,7 +3,7 @@ name: qcsd-development-swarm
 description: "Use when monitoring in-sprint code quality with TDD adherence checks, complexity analysis, coverage gap detection, or defect prediction in the QCSD Development phase."
 category: qcsd-phases
 priority: critical
-version: 1.0.0
+version: 1.1.0
 tokenEstimate: 3400
 # DDD Domain Mapping (from QCSD-AGENTIC-QE-MAPPING-FRAMEWORK.md)
 domains:
@@ -34,13 +34,14 @@ agents:
   total: 10
   sub_agents: 0
 skills: [tdd-london-chicago, mutation-testing, performance-testing, security-testing]
-# Execution Models (Task Tool is PRIMARY)
+# Execution Models (Workflow is PRIMARY where the harness supports it — ADR-102)
 execution:
-  primary: task-tool
-  alternatives: [mcp-tools, cli]
+  primary: workflow
+  workflow_name: qcsd-development-review
+  alternatives: [task-tool, mcp-tools, cli]
 swarm_pattern: true
 parallel_batches: 3
-last_updated: 2026-02-03
+last_updated: 2026-06-10
 enforcement_level: strict
 tags: [qcsd, development, tdd, complexity, coverage, security, performance, mutation, defect-prediction, swarm, parallel, ddd]
 trust_tier: 3
@@ -192,9 +193,29 @@ skip to step N. Ensure you have the required prerequisite data from prior steps.
 
 | Model | When to Use | Agent Spawn |
 |-------|-------------|-------------|
-| **Task Tool** (PRIMARY) | Claude Code sessions | `Task({ subagent_type, run_in_background: true })` |
+| **Workflow** (PRIMARY, ADR-102) | Harness with the Workflow tool | `Workflow({ name: "qcsd-development-review", args: { sourcePath, testPath } })` |
+| **Task Tool** (fallback) | Claude Code sessions without Workflow support | `Task({ subagent_type, run_in_background: true })` |
 | **MCP Tools** | MCP server available | `fleet_init({})` / `task_submit({})` |
 | **CLI** | Terminal/scripts | `swarm init` / `agent spawn` |
+
+### Workflow execution (ADR-102)
+
+`.claude/workflows/qcsd-development-review.js` runs the review as a deterministic
+pipeline: one finder per quality dimension (TDD adherence, complexity, coverage
+gaps — `args.dimensions` selects a subset) → **3 blind adversarial refuters per
+finding** (Loki-mode, ADR-074: refuters see only the bare claim + evidence,
+never the finder's confidence or each other; uncertainty defaults to refuted)
+→ deterministic synthesis into `finding-verdict@1` envelopes (ADR-103,
+`schemas/finding-verdict.schema.json`). A finding survives only if fewer than
+⌈N/2⌉ refuters kill it. The final report contains ONLY confirmed findings;
+killed findings are retained under `killed` with their refutations for audit.
+
+Args: `sourcePath` (required), `testPath`, `dimensions` (subset of
+`tdd-adherence|complexity|coverage-gaps`), `maxFindings` per dimension (default 5).
+
+When the Workflow tool is unavailable, fall back to the Task-tool protocol
+below — the report format and gates are identical, minus the adversarial
+verification stage (note this in the report header as `verification: none`).
 
 ---
 

--- a/.claude/skills/skills-manifest.json
+++ b/.claude/skills/skills-manifest.json
@@ -939,7 +939,7 @@
   },
   "metadata": {
     "generatedBy": "Agentic QE Fleet",
-    "fleetVersion": "3.10.4",
+    "fleetVersion": "3.10.5",
     "manifestVersion": "1.4.0",
     "lastUpdated": "2026-04-13T00:00:00.000Z",
     "contributors": [

--- a/.claude/workflows/qcsd-development-review.js
+++ b/.claude/workflows/qcsd-development-review.js
@@ -1,0 +1,168 @@
+export const meta = {
+  name: 'qcsd-development-review',
+  description: 'QCSD Development-phase review: parallel dimension finders → adversarial refuters (majority kill) → schema-validated verdict synthesis (ADR-102)',
+  whenToUse: 'In-sprint code-quality review with adversarially verified findings. Invoked by the qcsd-development-swarm skill (execution.primary: workflow). Args: { sourcePath, testPath?, dimensions?, maxFindings? }',
+  phases: [
+    { title: 'Find', detail: 'one finder per quality dimension' },
+    { title: 'Verify', detail: '3 blind refuters per finding, majority kill' },
+    { title: 'Synthesize', detail: 'deterministic finding-verdict@1 assembly' },
+  ],
+}
+
+// ── Parameters ──────────────────────────────────────────────────────────────
+const sourcePath = (args && args.sourcePath) || 'src/'
+const testPath = (args && args.testPath) || 'tests/'
+const maxFindings = (args && args.maxFindings) || 5
+const REFUTERS = 3 // majority kill at >= 2 refuted votes
+
+// ── Schemas (mirror schemas/finding-verdict.schema.json, ADR-103) ──────────
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  required: ['findings'],
+  additionalProperties: false,
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['id', 'title', 'file', 'severity', 'confidence', 'evidence'],
+        additionalProperties: false,
+        properties: {
+          id: { type: 'string' },
+          title: { type: 'string' },
+          file: { type: 'string' },
+          severity: { enum: ['critical', 'high', 'medium', 'low', 'info'] },
+          confidence: { type: 'number', minimum: 0, maximum: 1 },
+          evidence: { type: 'array', items: { type: 'string' } },
+        },
+      },
+    },
+  },
+}
+
+const REFUTER_SCHEMA = {
+  type: 'object',
+  required: ['refuted', 'reasoning'],
+  additionalProperties: false,
+  properties: {
+    refuted: { type: 'boolean' },
+    reasoning: { type: 'string' },
+  },
+}
+
+// ── Quality dimensions (qcsd-development-swarm core agent mapping) ──────────
+const ALL_DIMENSIONS = [
+  {
+    key: 'tdd-adherence',
+    agentType: 'qe-tdd-specialist',
+    prompt:
+      `Review the code under ${sourcePath} (tests under ${testPath}) for TDD-adherence problems: ` +
+      `production code paths with no corresponding test, tests asserting implementation details instead of behavior, ` +
+      `and test files that mock the unit under test. `,
+  },
+  {
+    key: 'complexity',
+    agentType: 'qe-code-complexity',
+    prompt:
+      `Review the code under ${sourcePath} for complexity hotspots: functions with high cyclomatic/cognitive complexity, ` +
+      `deeply nested control flow, and god-functions doing unrelated work. `,
+  },
+  {
+    key: 'coverage-gaps',
+    agentType: 'qe-coverage-specialist',
+    prompt:
+      `Review the code under ${sourcePath} against the tests under ${testPath} for risk-weighted coverage gaps: ` +
+      `error paths, boundary conditions, and concurrency-sensitive branches with no test exercising them. `,
+  },
+]
+const wanted = args && Array.isArray(args.dimensions) ? args.dimensions : null
+const DIMENSIONS = wanted ? ALL_DIMENSIONS.filter((d) => wanted.includes(d.key)) : ALL_DIMENSIONS
+if (wanted && DIMENSIONS.length < wanted.length) {
+  log(`unknown dimension keys ignored: ${wanted.filter((k) => !ALL_DIMENSIONS.some((d) => d.key === k)).join(', ')}`)
+}
+
+const FINDER_TAIL =
+  `Report up to ${maxFindings} findings. Report every issue you find including uncertain ones — a separate ` +
+  `adversarial verification step filters false positives; your job is coverage, not filtering. For each finding: ` +
+  `a stable kebab-case id, a one-line title, the file path, severity (critical|high|medium|low|info), your ` +
+  `confidence (0..1), and concrete evidence strings (file:line references, code excerpts). Findings without ` +
+  `verifiable evidence will be killed downstream, so cite precisely. Return zero findings if the code is clean.`
+
+// Loki-mode constraints (ADR-074): blind review — refuters see only the bare
+// claim and evidence, never the finder's confidence, dimension, or each
+// other's verdicts; anti-sycophancy — the refuter's job is to attack the
+// claim, and uncertainty defaults to refuted.
+const refuterPrompt = (finding, lens) =>
+  `You are an adversarial reviewer. Try to REFUTE this code-review claim using the ${lens} lens.\n` +
+  `Claim: "${finding.title}" in ${finding.file}\n` +
+  `Evidence offered: ${finding.evidence.join(' | ')}\n` +
+  `Read the actual code at the cited locations and judge ONLY what you can verify yourself. ` +
+  `Set refuted=true unless the evidence checks out AND the claim is a real, actionable problem ` +
+  `(default to refuted=true when uncertain — unverifiable claims must not survive). ` +
+  `Give one-sentence reasoning.`
+
+const LENSES = ['does-the-evidence-reproduce', 'is-it-actually-a-problem', 'is-the-cited-code-really-doing-this']
+
+// ── Find → Verify (pipeline: no barrier between dimensions) ────────────────
+const reviewed = await pipeline(
+  DIMENSIONS,
+  (d) =>
+    agent(d.prompt + FINDER_TAIL, {
+      label: `find:${d.key}`,
+      phase: 'Find',
+      schema: FINDINGS_SCHEMA,
+      agentType: d.agentType,
+    }),
+  (found, d) => {
+    const findings = (found && found.findings ? found.findings : []).slice(0, maxFindings)
+    if (findings.length === 0) {
+      log(`${d.key}: clean — no findings`)
+      return []
+    }
+    return parallel(
+      findings.map((f) => () =>
+        parallel(
+          LENSES.slice(0, REFUTERS).map((lens, i) => () =>
+            agent(refuterPrompt(f, lens), {
+              label: `refute:${f.id}:${i + 1}`,
+              phase: 'Verify',
+              schema: REFUTER_SCHEMA,
+            })
+          )
+        ).then((votes) => ({ dimension: d.key, finding: f, votes: votes.filter(Boolean) }))
+      )
+    )
+  }
+)
+
+// ── Synthesize (deterministic — plain code, no agent) ───────────────────────
+const all = reviewed.filter(Boolean).flat()
+const verdicts = all.map(({ dimension, finding, votes }) => {
+  const refutations = votes.filter((v) => v.refuted).map((v) => v.reasoning)
+  // majority kill: refuted when >= ceil(N/2) of cast votes refute (2-of-3)
+  const killed = votes.length > 0 && refutations.length >= Math.ceil(votes.length / 2)
+  return {
+    contract: 'finding-verdict@1',
+    id: `${dimension}:${finding.id}`,
+    title: finding.title,
+    file: finding.file,
+    severity: finding.severity,
+    confidence: finding.confidence,
+    evidence: finding.evidence,
+    verdict: votes.length === 0 ? 'uncertain' : killed ? 'refuted' : 'upheld',
+    refutations,
+  }
+})
+
+const confirmed = verdicts.filter((v) => v.verdict === 'upheld')
+const killed = verdicts.filter((v) => v.verdict === 'refuted')
+log(`synthesis: ${confirmed.length} confirmed, ${killed.length} killed by adversarial verification, of ${verdicts.length} raw findings`)
+
+return {
+  contractVersion: 'finding-verdict@1',
+  sourcePath,
+  dimensions: DIMENSIONS.map((d) => d.key),
+  rawFindingCount: verdicts.length,
+  confirmed,
+  killed,
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,9 +33,15 @@
       ]
     }
   },
-  "postCreateCommand": "bash .devcontainer/install-tools.sh",
+  // node_modules lives in a named volume so the container installs its own
+  // (Linux) native binaries instead of seeing the host's (e.g. macOS) ones
+  // via the workspace bind mount. The host's node_modules is untouched.
+  // The volume is root-owned on first creation, hence the chown before npm ci.
+  "postCreateCommand": "sudo chown vscode:vscode node_modules && bash .devcontainer/install-tools.sh && npm ci",
   "shutdownAction": "none",
-  "mounts": [],
+  "mounts": [
+    "source=agentic-qe-node-modules,target=${containerWorkspaceFolder}/node_modules,type=volume"
+  ],
   "capAdd": [
     "SYS_ADMIN",
     "SYS_PTRACE"

--- a/.devcontainer/install-tools.sh
+++ b/.devcontainer/install-tools.sh
@@ -327,12 +327,12 @@ if command_exists npm; then
         echo "ruflo is already installed"
     else
         echo "Installing ruflo via npm..."
-        if npm install -g ruflo@3.5.18 2>/dev/null; then
-            record_status "claude-flow" "✅ Success" "Installed via npm (ruflo@3.5.18)"
+        if npm install -g ruflo@3 2>/dev/null; then
+            record_status "claude-flow" "✅ Success" "Installed via npm (ruflo@3)"
         elif command_exists sudo; then
             echo "Retrying ruflo installation with sudo..."
-            if sudo npm install -g ruflo@3.5.18 2>/dev/null; then
-                record_status "claude-flow" "✅ Success" "Installed via npm with sudo (ruflo@3.5.18)"
+            if sudo npm install -g ruflo@3 2>/dev/null; then
+                record_status "claude-flow" "✅ Success" "Installed via npm with sudo (ruflo@3)"
             else
                 record_status "claude-flow" "❌ Failed" "npm installation failed"
             fi
@@ -554,12 +554,12 @@ if [ $FAILED_ITEMS -gt 0 ]; then
         echo "" >> "$REPORT_FILE"
         echo "**Install Claude Flow (alpha version):**" >> "$REPORT_FILE"
         echo '```bash' >> "$REPORT_FILE"
-        echo "npm install -g ruflo@3.5.18" >> "$REPORT_FILE"
+        echo "npm install -g ruflo@3" >> "$REPORT_FILE"
         echo '```' >> "$REPORT_FILE"
         echo "" >> "$REPORT_FILE"
         echo "**If you get permission errors, try:**" >> "$REPORT_FILE"
         echo '```bash' >> "$REPORT_FILE"
-        echo "sudo npm install -g ruflo@3.5.18" >> "$REPORT_FILE"
+        echo "sudo npm install -g ruflo@3" >> "$REPORT_FILE"
         echo '```' >> "$REPORT_FILE"
         echo "" >> "$REPORT_FILE"
         echo "**For more information, visit:** https://github.com/ruvnet/ruflo" >> "$REPORT_FILE"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,77 @@ All notable changes to the Agentic QE project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.10.5] - 2026-06-10
+
+The Fable 5 / harness-parity release (#520): the CLI's memory and fleet
+commands work for the first time, prompt caching actually engages, the
+self-learning pipeline stays clean under reasoning-heavy models, and two new
+capabilities land — adversarially verified QCSD reviews and competitive
+test-strategy tournaments. Seven improvements, each with its own ADR and a
+reproduction-first verification record on #520.
+
+### Added
+
+- **`aqe arena` — competitive test-strategy tournaments (ADR-104, Phase 1).**
+  Strategies compete on *real* fitness: built-in operator mutants executed via
+  `node --test`, real line coverage, and a deterministic suite-cost term.
+  `aqe arena run --target fixtures/arena-demo --seed 42` produces a ranked
+  competitive array that reproduces byte-identically under the same seed;
+  `--evolve` hill-climbs the winner; runs persist to memory.db (`aqe arena list`).
+- **Adversarially verified QCSD reviews (ADR-102).** The development-phase
+  swarm now runs as a deterministic workflow: one finder per quality dimension,
+  then 3 blind refuters per finding (majority kill, Loki-mode rules from
+  ADR-074), then code-only synthesis. Reports contain only confirmed findings;
+  killed findings are retained with their refutations. In the validation run,
+  the gate filtered a factually-wrong finding that the old prompt-driven
+  fan-out would have shipped.
+- **Structured verdict contracts (ADR-103).** Versioned, additive envelopes —
+  `RiskDecision`, `FindingVerdict`, `CoverageGap` — with dependency-free
+  validators and published JSON Schemas (`schemas/*.schema.json`). The
+  `quality_assess` MCP tool now attaches a validated `riskDecision` envelope.
+- **Tool-loop circuit breaker (ADR-100).** When the same Bash command fails
+  3× consecutively the pre-command hook warns; at 5× it emits a block
+  recommendation with a recovery hint (`AQE_STRICT_TOOL_LOOP=1` upgrades to a
+  hard deny). Success resets; an open breaker grants a probe after 2 minutes.
+- **Nested-subagent readiness (ADR-101).** Anthropic announced depth-5 nested
+  subagents on 2026-06-09; AQE is ready the day the gate lifts: post-task
+  hooks accept `--parent-agent-id`/`--depth` (validated, persisted into
+  trajectory metadata for per-hierarchy-level learning), and a committed probe
+  script (`scripts/probe-nested-spawn-depth.mjs`) detects the upstream
+  rollout — current verdict: `NO_AGENT_TOOL`, denylist still active.
+- **LLM judge benchmark harness** (`scripts/judge-benchmark.ts`) with Phase-1
+  results.
+
+### Fixed
+
+- **`aqe memory` / `agent` / `task` / `team` / `pipeline` CLI commands always
+  failed with "Fleet not initialized".** The CLI initialized a full kernel but
+  never registered it with the shared MCP handlers' fleet state. A new bridge
+  (`adoptExternalFleet`) gives both entry points one fleet state — these
+  commands now work from the terminal for the first time.
+- **Prompt caching was dead code (ADR-088 amendment).** `enableCache: true`
+  existed but never set `cache_control`; every advisor/LLM call paid full
+  input price. The Anthropic provider now marks the system prompt as an
+  ephemeral cache breakpoint, surfaces `cacheRead/cacheCreation` tokens, and
+  bills them at the real 0.1×/1.25× rates in cost tracking.
+- **Pattern embeddings were contaminated by extended-thinking blocks
+  (ADR-099).** Reasoning-heavy models (Fable 5 era) emit large scratchpads
+  inside task results; these are now scrubbed (boundary-gated) at trajectory
+  ingestion, distillation, embedding backfill, and query time — prose that
+  merely mentions a tag survives byte-identical.
+- **Fresh-install learning silently no-oped.** `persistTaskOutcome` assumed
+  middleware-created tables (`captured_experiences`, `experience_applications`);
+  on a fresh `.agentic-qe` the whole post-task learning transaction failed
+  silently. The hook path now ensures the canonical schema.
+
+### Changed
+
+- Devcontainer now mounts `node_modules` as a named volume and installs
+  in-container, so Linux containers stop tripping over host (macOS) native
+  binaries (contributors only; takes effect on container rebuild).
+- Setup docs and the devcontainer install script no longer pin the long-stale
+  `ruflo@3.5.18` (now `ruflo@3` + global `ruflo mcp start`).
+
 ## [3.10.4] - 2026-06-08
 
 Two correctness fixes that keep a project's self-learning where it belongs and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,7 +244,8 @@ npx ruflo memory retrieve --key "pattern-auth" --namespace patterns
 ## Quick Setup
 
 ```bash
-claude mcp add ruflo -- npx -y ruflo@3.5.18
+npm install -g ruflo@3            # install/refresh the global CLI (3.x)
+claude mcp add ruflo -- ruflo mcp start
 npx ruflo daemon start
 aqe health
 ```

--- a/docs/implementation/adrs/ADR-088-prompt-cache-latch-fields.md
+++ b/docs/implementation/adrs/ADR-088-prompt-cache-latch-fields.md
@@ -197,6 +197,7 @@ Session End
 |--------|------|-------|
 | Proposed | 2026-04-01 | Initial creation from Claude Code internals research |
 | Implemented | 2026-04-02 | IMP-05 complete: PromptCacheLatch wired in claude-provider.ts, 13 tests passing |
+| Amended | 2026-06-10 | Option 5 implemented (issue #520, improvement 2): `ClaudeProvider.generate()` sends `system` as a content-block array with `cache_control: {type: "ephemeral"}` when `enableCache` (previously a dead flag); `cache_creation_input_tokens`/`cache_read_input_tokens` surfaced into `TokenUsage.cacheCreationTokens`/`cacheReadTokens`; `CostTracker.calculateCost` bills cache reads at 0.1x and writes at 1.25x input rate. Anthropic-native provider only (ADR-092). Note: prefixes below the model minimum (1024–4096 tokens by model) silently don't cache. 5 new provider tests. |
 
 ---
 

--- a/docs/implementation/adrs/ADR-099-reasoning-tag-scrubbing.md
+++ b/docs/implementation/adrs/ADR-099-reasoning-tag-scrubbing.md
@@ -1,0 +1,105 @@
+# ADR-099: Reasoning-Tag Scrubbing for Pattern Embedding Sanitization
+
+| Field | Value |
+|-------|-------|
+| **Decision ID** | ADR-099 |
+| **Status** | Implemented |
+| **Date** | 2026-06-10 |
+| **Author** | AQE Core (Fable 5 improvement initiative, issue #520) |
+| **Review Cadence** | 6 months |
+
+---
+
+## WH(Y) Decision Statement
+
+**In the context of** the ReasoningBank learning pipeline (trajectory tracking, experience distillation, and HNSW pattern embeddings in `memory.db`),
+
+**facing** reasoning-capable models (Fable 5 era) that emit large extended-thinking scratchpad blocks inside task results and step actions, which — embedded verbatim — contaminate the 384-dim pattern vectors and degrade retrieval quality,
+
+**we decided for** a boundary-gated scrubber (`scrubReasoningBlocks` / `scrubReasoningDeep` in `src/shared/reasoning-scrub.ts`) applied at every learning-pipeline ingestion and embedding point,
+
+**and neglected** scrubbing at each CLI/MCP entry flag (too many entry points, easy to miss new ones) and a one-time `memory.db` rewrite of historical rows (violates data-protection rules),
+
+**to achieve** clean pattern embeddings whose signal reflects what a step actually did rather than how the model deliberated, with legacy rows cleaned as they flow forward through embedding backfill,
+
+**accepting that** already-embedded contaminated vectors decay naturally rather than being purged, and a small per-write regex cost is added to trajectory persistence.
+
+---
+
+## Context
+
+Adopted from ruflo's Hermes-Agent tier-1 audit (ruflo PR #2237, `scrubReasoningBlocks()` before DISTILL). AQE's pipeline embedded trajectory text as-is: `ExperienceReplay.storeExperience()` built embedding text from raw `task + strategy + keyActions`, `TrajectoryTracker.recordStep()` persisted raw `action`/`result` payloads, and the init-time embedding backfills re-embedded raw historical rows.
+
+Fable 5 makes this acute: extended thinking is emitted far more often and at greater length than prior models, so every fleet run dilutes the patterns the self-learning loop depends on. The scrub is boundary-gated — only well-formed `<tag>…</tag>` pairs are removed, so prose that merely *mentions* a tag (e.g. test documentation about `<thinking>` blocks — common in a QE codebase) survives intact.
+
+## Options Considered
+
+### Option 1: Scrub at learning-pipeline ingestion + embedding points (Selected)
+
+Sanitize inside `TrajectoryTracker` (task, step action, result data/error), `ExperienceReplay` (distillation, inserts, embedding backfills, query embeddings).
+
+**Pros:**
+- Single utility, applied where data crosses into persistence — new entry points (hooks, MCP, middleware) are covered automatically
+- Backfill scrubbing cleans legacy rows as they get (re-)embedded, without rewriting `memory.db`
+- Query-side scrub keeps retrieval symmetric with stored vectors
+
+**Cons:**
+- Regex cost on every step write (negligible: short-circuit on `<` absence)
+- Stored historical text rows keep their scratchpads until re-embedded
+
+### Option 2: Scrub at each CLI flag / MCP param (Rejected)
+
+**Why rejected:** dozens of entry points (hooks, middleware, MCP tools) and every future one would need to remember the scrub; one missed path re-contaminates the bank.
+
+### Option 3: One-time memory.db migration scrubbing historical rows (Rejected)
+
+**Why rejected:** rewriting 1K+ irreplaceable learning records violates the project's data-protection rules for marginal benefit; forward-flow cleaning via backfill achieves the goal safely.
+
+---
+
+## Dependencies
+
+| Relationship | ADR ID | Title | Notes |
+|--------------|--------|-------|-------|
+| Relates To | ADR-051 | Agentic-Flow Integration | ReasoningBank/trajectory pipeline being sanitized |
+| Relates To | ADR-061 | Asymmetric Learning Rates | Consumes the same pattern store |
+| Relates To | ADR-071/081/090 | HNSW implementation | Embedding index whose quality this protects |
+| Part Of | — | Fable 5 / ruflo-parity initiative | Tracking issue #520, improvement 1 |
+
+---
+
+## References
+
+| Ref ID | Title | Type | Location |
+|--------|-------|------|----------|
+| — | Scrubber implementation | Source | `src/shared/reasoning-scrub.ts` |
+| — | Ingestion application | Source | `src/integrations/agentic-flow/reasoning-bank/trajectory-tracker.ts`, `experience-replay.ts` |
+| — | Unit tests (15) | Tests | `tests/unit/shared/reasoning-scrub.test.ts` |
+| — | ruflo prior art | External | ruvnet/ruflo PR #2237 (Hermes tier-1, reasoning scrub) |
+
+---
+
+## Governance
+
+| Review Board | Date | Outcome | Next Review |
+|--------------|------|---------|-------------|
+| AQE Core | 2026-06-10 | Implemented | 2026-12-10 |
+
+---
+
+## Status History
+
+| Status | Date | Notes |
+|--------|------|-------|
+| Proposed | 2026-06-10 | From Fable 5 improvement plan (issue #520) |
+| Implemented | 2026-06-10 | Scrubber + ingestion/backfill/query application + 15 unit tests |
+
+---
+
+## Definition of Done Checklist
+
+- [x] Evidence: 15 unit tests green; tsc clean; boundary-gating verified (prose-mention tests)
+- [x] Criteria: no `<thinking>` content reaches new embeddings; clean input returned byte-identical
+- [x] Agreement: follows ruflo #2237 prior art per improvement plan
+- [x] Documentation: this ADR + plan doc (`docs/implementation/fable5-improvement-plan.md`)
+- [x] Review: verification record on issue #520

--- a/docs/implementation/adrs/ADR-100-tool-loop-circuit-breaker.md
+++ b/docs/implementation/adrs/ADR-100-tool-loop-circuit-breaker.md
@@ -1,0 +1,98 @@
+# ADR-100: Tool-Loop Circuit Breaker for Hook Reliability
+
+| Field | Value |
+|-------|-------|
+| **Decision ID** | ADR-100 |
+| **Status** | Implemented |
+| **Date** | 2026-06-10 |
+| **Author** | AQE Core (Fable 5 improvement initiative, issue #520) |
+| **Review Cadence** | 6 months |
+
+---
+
+## WH(Y) Decision Statement
+
+**In the context of** the Bash command lifecycle hooks (`aqe hooks pre-command` / `post-command`) that Claude Code invokes around every shell command,
+
+**facing** runaway retry loops — agents re-running the same failing command verbatim, which Fable 5-era models' persistence makes more expensive, not less,
+
+**we decided for** a consecutive-failure circuit breaker keyed by normalized command signature (WARN at 3, BLOCK at 5, half-open probe after 2 minutes, reset on success), persisted in a JSON sidecar (`.agentic-qe/tool-loop-state.json`), advisory by default with `AQE_STRICT_TOOL_LOOP=1` upgrading the block to a PreToolUse deny,
+
+**and neglected** in-process state (impossible — every hook call is a fresh CLI process) and kv-store persistence via memory.db (adds DB-init latency to every Bash command in pre-command, which today deliberately runs without opening the DB),
+
+**to achieve** early interruption of unproductive retry loops with a recovery hint, without slowing the hot pre-command path or ever breaking a hook (fail-open everywhere),
+
+**accepting that** a small non-DB state file lives under `.agentic-qe/` (ephemeral guardrail state, safe to delete; not a data store — the unified-persistence rule targets durable data) and that advisory mode relies on the model heeding the hint.
+
+---
+
+## Context
+
+Adopted from ruflo's Hermes-Agent tier-1 audit (ruflo PR #2237, tool-loop circuit breaker: warn at 3 / block at 5). AQE already has a circuit breaker at the *domain* level (`src/coordination/circuit-breaker/domain-circuit-breaker.ts`, ADR-064 Phase 2D) protecting QE domains inside the long-lived queen process; nothing protected the command level, where each hook invocation is a separate short-lived process.
+
+The breaker mirrors ADR-064's closed → open → half-open semantics. The signature normalizes whitespace and caps length so cosmetic command variations share one failure count. It is orthogonal to the existing dangerous-command patterns in pre-command (security) — the breaker addresses *futility*, not danger.
+
+## Options Considered
+
+### Option 1: JSON sidecar state + hook integration (Selected)
+
+Per-project `tool-loop-state.json`; `post-command` records `(signature, success)`, `pre-command` consults and emits warnings/blocks through the existing PreToolUse output (additionalContext / permissionDecision).
+
+**Pros:** sub-ms reads on the hot path; survives process boundaries; fail-open trivially; stale entries pruned on write
+**Cons:** one more file under `.agentic-qe/` (documented as ephemeral)
+
+### Option 2: Reuse DomainCircuitBreaker class in-process (Rejected)
+
+**Why rejected:** hook processes live for one command — in-process state never sees the previous invocation. The class's *semantics* were reused; its instance lifecycle cannot be.
+
+### Option 3: kv_store via UnifiedMemory (Rejected)
+
+**Why rejected:** pre-command currently runs without opening memory.db; adding a DB init to every Bash command's PreToolUse hook adds user-visible latency for a few bytes of counter state.
+
+---
+
+## Dependencies
+
+| Relationship | ADR ID | Title | Notes |
+|--------------|--------|-------|-------|
+| Relates To | ADR-064 | Agentic Teams Integration | Domain circuit breaker whose state-machine semantics this mirrors |
+| Relates To | ADR-021 | QE ReasoningBank | post-command already records outcomes for learning; the breaker piggybacks on the same hook |
+| Part Of | — | Fable 5 / ruflo-parity initiative | Tracking issue #520, improvement 3 |
+
+---
+
+## References
+
+| Ref ID | Title | Type | Location |
+|--------|-------|------|----------|
+| — | Guardrail implementation | Source | `src/cli/commands/hooks-handlers/tool-loop-guardrail.ts` |
+| — | Hook integration | Source | `src/cli/commands/hooks-handlers/command-hooks.ts` (pre-command/post-command) |
+| — | Unit tests (11) | Tests | `tests/unit/cli/hooks/tool-loop-guardrail.test.ts` |
+| — | ruflo prior art | External | ruvnet/ruflo PR #2237 (`tool-loop-guardrail.ts`) |
+
+---
+
+## Governance
+
+| Review Board | Date | Outcome | Next Review |
+|--------------|------|---------|-------------|
+| AQE Core | 2026-06-10 | Implemented | 2026-12-10 |
+
+---
+
+## Status History
+
+| Status | Date | Notes |
+|--------|------|-------|
+| Proposed | 2026-06-10 | From Fable 5 improvement plan (issue #520) |
+| Implemented | 2026-06-10 | Guardrail + hook wiring + 11 unit tests + E2E verification via real hook commands |
+
+---
+
+## Definition of Done Checklist
+
+- [x] Evidence: 11 unit tests green; E2E via real `aqe hooks pre-command`/`post-command` sequence (warn after 3, block after 5, strict deny, reset on success)
+- [x] Criteria: 3 options compared; fail-open verified (corrupt state file → allow)
+- [x] Agreement: follows ruflo #2237 prior art per improvement plan
+- [x] Documentation: this ADR; MCP parity N/A documented (AQE MCP server exposes no hooks tools — hooks are a CLI-only surface)
+- [x] Review: verification record on issue #520

--- a/docs/implementation/adrs/ADR-101-nested-subagent-readiness.md
+++ b/docs/implementation/adrs/ADR-101-nested-subagent-readiness.md
@@ -1,0 +1,110 @@
+# ADR-101: Nested Subagent Hierarchy — Depth Limits, Privilege Model, Trajectory Provenance
+
+| Field | Value |
+|-------|-------|
+| **Decision ID** | ADR-101 |
+| **Status** | Implemented (P2 stage 1) / Proposed (P1 frontmatter — pending maintainer confirmation) |
+| **Date** | 2026-06-10 |
+| **Author** | AQE Core (Fable 5 improvement initiative, issue #520) |
+| **Review Cadence** | After every `claude update` (re-run the probe) |
+
+---
+
+## WH(Y) Decision Statement
+
+**In the context of** the AQE fleet's agent hierarchy (queen → fleet-commander → domain specialists), which today flattens all delegation into depth-1 Task-tool fan-out,
+
+**facing** Anthropic's 2026-06-09 announcement of nested subagent support (depth=5), where empirical probing shows the runtime plumbing exists but the `Task` tool is stripped at parent→child spawn time by an upstream denylist,
+
+**we decided for** building the readiness infrastructure now — nesting provenance (`parentAgentId`, `depth`) through trajectory recording and the post-task hook, a committed empirical probe script as the regression test for the gate lifting, and validation bounds (identifier check, 0 ≤ depth ≤ 32),
+
+**and neglected** waiting for the upstream rollout (loses the independently-useful provenance for today's flat spawns) and immediately retrofitting `tools:` frontmatter onto all shipped `qe-*.md` agents (a restrictive allowlist that would cut agents off from inherited MCP tools — deferred pending maintainer confirmation, see P1 below),
+
+**to achieve** zero-code-change activation when Anthropic flips the gate, plus per-hierarchy-level pattern segmentation in ReasoningBank starting today,
+
+**accepting that** provenance lands in the JSON metadata blob rather than dedicated columns (stage 1 — no schema migration) and that the privilege split between coordinator and leaf agents is documented but not yet enforced in frontmatter.
+
+---
+
+## Context
+
+ruflo's ADR-147 (PR #2336) probed Claude CLI 2.1.169 and found: `parentAgentId`/`isSubagent` plumbing exists in the binary; YAML `tools:` declarations propagate to children; the runtime strips `Task` at parent→child spawn regardless of flags — a hardcoded or server-side denylist. Our own probe (committed at `docs/probes/probe-nested-spawn-2026-06-10.txt`) reproduces this against this project's runtime: `level=0 task_tool=yes`, `level=1 task_tool=no` → `NO_AGENT_TOOL`.
+
+The provenance fields are useful before the gate lifts: Claude Code's flat spawns still have a parent (the main loop or the queen), and segmenting learned patterns by hierarchy level improves routing priors (ADR-095/096 read the same outcome rows).
+
+## Phases
+
+| Phase | Content | Status |
+|---|---|---|
+| **P1** | `tools:` frontmatter with coordinator/leaf privilege split across `qe-*.md` (+ `assets/agents/v3/` mirror) | **Proposed — blocked on maintainer confirmation.** Claude Code's `tools:` frontmatter is a restrictive *allowlist*: declaring it cuts the agent off from inherited tools, **including all `mcp__agentic-qe__*` tools** unless each is enumerated (wildcard support in agent frontmatter is unverified). Retrofitting ~50 shipped agents risks breaking the fleet for users — production-safety rule requires explicit sign-off and an MCP-wildcard test first. |
+| **P2 stage 1** | `--parent-agent-id` / `--depth` on post-task; validation; persisted to `qe_trajectories.metadata_json`; forwarded into ReasoningBank feedback; `TaskExecution.parentAgentId/depth` types | **Implemented** (this ADR) |
+| **P2 stage 2** | Dedicated columns + indexes for provenance | Deferred until query patterns demand it |
+| **P3** | Depth-aware pre-task guardrail (`NESTING_DEPTH_EXCEEDED`) | Blocked on P2 stage 2 |
+| **P4** | Queen-coordinator delegation rewrite for real nesting | Blocked on the upstream gate lifting (probe flips to `TASK_TOOL_LIVE`) |
+
+## Options Considered
+
+### Option 1: Provenance-first readiness, frontmatter deferred (Selected)
+
+**Pros:** all shipped behavior unchanged; provenance independently useful today; probe tells us exactly when to do more
+**Cons:** least-privilege boundary not yet enforced
+
+### Option 2: Full ruflo-style P1 now (restrictive tools: lists on all agents) (Rejected for now)
+
+**Why rejected:** ruflo declared `tools:` on 8 *new* agents; retrofitting AQE's ~50 *shipped* agents changes their effective toolset (MCP access loss risk) without a way to test nested behavior until the denylist lifts. Revisit with maintainer sign-off + an MCP-wildcard frontmatter test.
+
+### Option 3: Wait for upstream rollout (Rejected)
+
+**Why rejected:** loses today's provenance value and the regression signal; ruflo's "independently useful" argument applies verbatim.
+
+---
+
+## Dependencies
+
+| Relationship | ADR ID | Title | Notes |
+|--------------|--------|-------|-------|
+| Relates To | ADR-095/096 | Routing exploration / Route-Q loop | Consume the same outcome rows provenance now annotates |
+| Relates To | ADR-064 | Agentic Teams | Queen hierarchy whose delegation P4 will rewrite |
+| Relates To | ADR-099 | Reasoning-tag scrub | Same trajectory pipeline |
+| Part Of | — | Fable 5 / ruflo-parity initiative | Tracking issue #520, improvement 4 |
+
+---
+
+## References
+
+| Ref ID | Title | Type | Location |
+|--------|-------|------|----------|
+| — | Provenance validation | Source | `src/cli/commands/hooks-handlers/nesting-provenance.ts` |
+| — | Hook + persistence wiring | Source | `task-hooks.ts`, `hooks-dream-learning.ts` (metadata_json) |
+| — | Type extension | Source | `src/coordination/queen-types.ts` (`TaskExecution`) |
+| — | Probe script | Source | `scripts/probe-nested-spawn-depth.mjs` |
+| — | Probe result (2026-06-10) | Evidence | `docs/probes/probe-nested-spawn-2026-06-10.txt` — `level=1 status=NO_AGENT_TOOL` |
+| — | Tests (8) | Tests | `tests/unit/cli/hooks/nesting-provenance.test.ts` |
+| — | ruflo prior art | External | ruvnet/ruflo PR #2336 (ADR-147) |
+
+---
+
+## Governance
+
+| Review Board | Date | Outcome | Next Review |
+|--------------|------|---------|-------------|
+| AQE Core | 2026-06-10 | P2 stage 1 Implemented; P1 awaiting maintainer call | Re-run probe after every `claude update` |
+
+---
+
+## Status History
+
+| Status | Date | Notes |
+|--------|------|-------|
+| Proposed | 2026-06-10 | From Fable 5 improvement plan (issue #520) |
+| Implemented (P2 stage 1) | 2026-06-10 | Provenance flags + validation + metadata_json persistence + probe + 8 tests. Drive-by fix: fresh-project `captured_experiences`/`experience_applications` DDL in persistTaskOutcome (Stream B silently no-oped on fresh installs). |
+
+---
+
+## Definition of Done Checklist
+
+- [x] Evidence: probe committed (`NO_AGENT_TOOL` — denylist active, matching ruflo); E2E persistence of `{"parentAgentId":"qe-fleet-commander","depth":2}` and `{"depth":0}` on a fresh temp project; rejection of invalid id / negative / non-integer / >32 depth
+- [x] Criteria: 3 options compared; validation bounds match ruflo's suite (0 ≤ d ≤ 32)
+- [ ] Agreement: **P1 frontmatter awaits maintainer confirmation** (MCP allowlist risk)
+- [x] Documentation: this ADR; fail-open exit semantics documented (hooks never break the tool pipeline — rejection = printed error + no persistence, exit 0)
+- [x] Review: verification record on issue #520

--- a/docs/implementation/adrs/ADR-102-deterministic-workflow-orchestration.md
+++ b/docs/implementation/adrs/ADR-102-deterministic-workflow-orchestration.md
@@ -1,0 +1,105 @@
+# ADR-102: Deterministic Workflow Orchestration with Adversarial Verification
+
+| Field | Value |
+|-------|-------|
+| **Decision ID** | ADR-102 |
+| **Status** | Implemented (QCSD Development phase; remaining phases follow-up) |
+| **Date** | 2026-06-10 |
+| **Author** | AQE Core (Fable 5 improvement initiative, issue #520) |
+| **Review Cadence** | 6 months |
+
+---
+
+## WH(Y) Decision Statement
+
+**In the context of** the QCSD swarm skills, which orchestrate multi-agent reviews by *prompting* the model to fan out Task-tool spawns and hoping the topology holds,
+
+**facing** non-deterministic orchestration (fan-out shape varies per run), unverified findings (whatever a finder asserts lands in the report), and prose handoffs no consumer can validate,
+
+**we decided for** deterministic workflow scripts in `.claude/workflows/` as the primary execution model — starting with `qcsd-development-review`: one finder per quality dimension → **3 blind adversarial refuters per finding with majority kill** (Loki-mode constraints, ADR-074) → deterministic synthesis into `finding-verdict@1` envelopes (ADR-103) — with the Task-tool protocol retained as documented fallback,
+
+**and neglected** keeping prompt-driven fan-out as primary (irreproducible, no verification stage) and building an in-repo orchestration engine (the harness's Workflow tool already provides deterministic control flow, schema-enforced agent outputs with auto-retry, and progress reporting),
+
+**to achieve** reproducible review topology, schema-validated agent outputs at every stage, and reports that contain only adversarially confirmed findings (killed findings retained with refutations for audit),
+
+**accepting that** the workflow path requires a Workflow-capable harness (fallback documented in the skill, reports marked `verification: none`), and that finder/refuter schemas are inlined in the script (workflow scripts have no filesystem access) and must mirror `schemas/finding-verdict.schema.json`.
+
+---
+
+## Context
+
+The "harness generates intelligence" thread of the Fable 5 plan. The skill previously declared `execution.primary: task-tool`: the model reads a protocol and improvises spawns. The workflow script replaces improvisation with code: `pipeline()` runs dimensions without barriers (a dimension's findings go to verification while another dimension still searches), every `agent()` call carries a JSON schema (malformed output auto-retries at the tool-call layer), and synthesis is plain deterministic JavaScript — no agent gets to editorialize the final report.
+
+Adversarial verification encodes ADR-074's Loki rules as prompt constraints: **blind review** (refuters receive only the bare claim + evidence — never the finder's confidence, dimension, or each other's verdicts), **anti-sycophancy** (the refuter's instruction is to attack; "default to refuted when uncertain"), and three distinct lenses (evidence-reproduces, actually-a-problem, code-really-does-this) rather than three identical votes.
+
+## Options Considered
+
+### Option 1: Harness Workflow scripts, skill-integrated (Selected)
+
+**Pros:** deterministic topology; per-stage schemas with auto-retry; pipeline wall-clock efficiency; progress tree visible to the user; scripts are reviewable artifacts in the repo
+**Cons:** harness-dependent (fallback retained); inline schema duplication with ADR-103 files
+
+### Option 2: Keep prompt-driven Task-tool fan-out as primary (Rejected)
+
+**Why rejected:** the fan-out shape, finding format, and verification rigor vary run to run; no structural place to put the refuter stage.
+
+### Option 3: In-repo orchestration engine (WorkflowOrchestrator-based) (Rejected for this layer)
+
+**Why rejected:** the kernel's WorkflowOrchestrator coordinates domain actions, not LLM subagent topologies; duplicating the harness's agent orchestration would be parallel infrastructure (violates the extend-don't-duplicate principle of ADR-074).
+
+---
+
+## Rollout
+
+| Phase skill | Status |
+|---|---|
+| qcsd-development-swarm → `qcsd-development-review` | **Done** (this ADR) |
+| qcsd-ideation / refinement / cicd / production | Follow-up after the development phase proves out (plan step 5) |
+
+---
+
+## Dependencies
+
+| Relationship | ADR ID | Title | Notes |
+|--------------|--------|-------|-------|
+| Depends On | ADR-103 | Structured Verdict Handoffs | Output envelopes are `finding-verdict@1` |
+| Relates To | ADR-074 | Loki-Mode Adversarial Quality Gates | Refuter prompt constraints encode its blind-review/anti-sycophancy rules |
+| Relates To | ADR-064 | Agentic Teams | Task-tool fallback path |
+| Part Of | — | Fable 5 / ruflo-parity initiative | Tracking issue #520, improvement 5 |
+
+---
+
+## References
+
+| Ref ID | Title | Type | Location |
+|--------|-------|------|----------|
+| — | Workflow script | Source | `.claude/workflows/qcsd-development-review.js` |
+| — | Skill integration | Source | `.claude/skills/qcsd-development-swarm/SKILL.md` (v1.1.0, `execution.primary: workflow`) |
+| — | Validation run | Evidence | See Status History — bounded run on `src/cli/commands/hooks-handlers/` |
+
+---
+
+## Governance
+
+| Review Board | Date | Outcome | Next Review |
+|--------------|------|---------|-------------|
+| AQE Core | 2026-06-10 | Implemented (development phase) | 2026-12-10 |
+
+---
+
+## Status History
+
+| Status | Date | Notes |
+|--------|------|-------|
+| Proposed | 2026-06-10 | From Fable 5 improvement plan (issue #520) |
+| Implemented | 2026-06-10 | Script + skill integration; validation run results recorded on issue #520 |
+
+---
+
+## Definition of Done Checklist
+
+- [x] Evidence: validation run 2026-06-10 (`wf_254f1271-022`): 3 dimensions over `src/`, 48 agents, 15 raw findings → 14 confirmed / **1 killed by 3-of-3 adversarial refutation** (a factually-wrong "private method" claim — the methods are public interface members); 2 confirmed findings retain minority refutations for audit; all stages schema-enforced. Caller note: pass `args` as a JSON **object** — a stringified object reaches the script as a string and defaults apply.
+- [x] Criteria: 3 options compared; Loki constraints traceable to ADR-074 features
+- [x] Agreement: plan-mandated; fallback preserves non-Workflow users
+- [x] Documentation: this ADR + SKILL.md workflow section
+- [x] Review: verification record on issue #520

--- a/docs/implementation/adrs/ADR-103-structured-verdict-handoffs.md
+++ b/docs/implementation/adrs/ADR-103-structured-verdict-handoffs.md
@@ -1,0 +1,96 @@
+# ADR-103: Structured JSON-Schema Verdict Handoffs
+
+| Field | Value |
+|-------|-------|
+| **Decision ID** | ADR-103 |
+| **Status** | Implemented |
+| **Date** | 2026-06-10 |
+| **Author** | AQE Core (Fable 5 improvement initiative, issue #520) |
+| **Review Cadence** | 6 months |
+
+---
+
+## WH(Y) Decision Statement
+
+**In the context of** handoffs between QE agents and at MCP tool boundaries, which today exchange prose and ad-hoc JSON,
+
+**facing** unverifiable agent outputs — a quality gate's "decision" is whatever shape the producing code happened to emit, so consumers (workflows, dashboards, downstream agents) cannot validate, retry, or rank what they receive,
+
+**we decided for** versioned, additive-only verdict envelopes (`RiskDecision`, `FindingVerdict`, `CoverageGap`) with dependency-free TypeScript validators as the source of truth (`src/contracts/verdicts.ts`), mirrored as published draft-07 JSON Schemas (`schemas/*.schema.json`), validated at the MCP boundary before emission,
+
+**and neglected** adding zod/ajv as runtime dependencies (the package deliberately keeps installs light; the envelope subset is simple enough for hand-rolled validators) and restructuring existing MCP payloads (breaking consumers — the envelope is attached additively),
+
+**to achieve** machine-verifiable handoffs that workflow `agent({schema})` calls can enforce with auto-retry (improvement 5) and external tooling can validate with stock ajv,
+
+**accepting that** validators and schemas are maintained in one module and kept in lockstep by contract tests, and that only the quality-gate boundary emits an envelope so far (finding/coverage envelopes ship with their producers in improvements 5/7).
+
+---
+
+## Context
+
+Part of the Fable 5 plan's "SynthLang" thread: replace prose handoffs with explicit constraint-bearing structures. ruflo's neural-trader pipeline (RegimeVerdict → SignalProposal → RiskDecision as typed gates) is the prior art. The first wired boundary is `quality_assess`: `mapToResult` derives a `RiskDecision` from the gate outcome (passed → approve, failed → block, indeterminate → escalate), validates it, and attaches it additively — both the direct and wrapped MCP handlers flow through the same config, so MCP parity is inherent.
+
+## Options Considered
+
+### Option 1: Dependency-free validators + published JSON Schemas (Selected)
+
+**Pros:** zero new runtime deps; validators boundary-grade and unit-tested; schemas consumable by ajv and workflow structured-output enforcement; additive envelopes can't break existing consumers
+**Cons:** two artifacts to keep in sync (enforced by contract tests + the generator script)
+
+### Option 2: zod + zod-to-json-schema (Rejected)
+
+**Why rejected:** adds runtime dependencies to a package with a deliberate light-install posture (and a history of supply-chain audits); the schema subset needed here is trivial.
+
+### Option 3: Extend ADR-075's framework type system (Rejected)
+
+**Why rejected:** ADR-075 types describe test frameworks, not verdict envelopes; grafting envelopes there couples unrelated lifecycles. Relates-to, not part-of.
+
+---
+
+## Dependencies
+
+| Relationship | ADR ID | Title | Notes |
+|--------------|--------|-------|-------|
+| Relates To | ADR-075 | Unified Test Framework Type System | Adjacent type system, deliberately not extended |
+| Relates To | ADR-054 | A2A Protocol | Verdicts ride inside A2A envelopes unchanged |
+| Relates To | ADR-074 | Loki-Mode Adversarial Gates | `FindingVerdict.refutations` carries refuter votes (improvement 5) |
+| Part Of | — | Fable 5 / ruflo-parity initiative | Tracking issue #520, improvement 6 |
+
+---
+
+## References
+
+| Ref ID | Title | Type | Location |
+|--------|-------|------|----------|
+| — | Contracts + validators + schemas | Source | `src/contracts/verdicts.ts` |
+| — | Boundary wiring | Source | `src/mcp/handlers/domain-handler-configs.ts` (qualityAssess `mapToResult`) |
+| — | Published schemas | Artifact | `schemas/{risk-decision,finding-verdict,coverage-gap}.schema.json` |
+| — | Generator | Script | `scripts/generate-verdict-schemas.mjs` |
+| — | Contract tests (17) | Tests | `tests/unit/contracts/verdicts.test.ts` |
+
+---
+
+## Governance
+
+| Review Board | Date | Outcome | Next Review |
+|--------------|------|---------|-------------|
+| AQE Core | 2026-06-10 | Implemented | 2026-12-10 |
+
+---
+
+## Status History
+
+| Status | Date | Notes |
+|--------|------|-------|
+| Proposed | 2026-06-10 | From Fable 5 improvement plan (issue #520) |
+| Implemented | 2026-06-10 | Contracts + quality-gate boundary + published schemas + 17 contract tests; ajv round-trip verified (golden valid, mutated invalid) |
+
+---
+
+## Definition of Done Checklist
+
+- [x] Evidence: 17 contract tests green; emitted envelope from the compiled boundary builder validates with stock ajv against the published schema; mutated sample rejected
+- [x] Criteria: 3 options compared; additive-only rule encoded (`additionalProperties: true`, envelope `contract` discriminator)
+- [x] Agreement: follows the improvement plan; ruflo typed-gate prior art
+- [x] Documentation: this ADR; generator workflow documented in the script header
+- [x] Review: verification record on issue #520

--- a/docs/implementation/adrs/ADR-104-qe-arena-competitive-tournaments.md
+++ b/docs/implementation/adrs/ADR-104-qe-arena-competitive-tournaments.md
@@ -1,0 +1,89 @@
+# ADR-104: qe-arena — Competitive Test-Strategy Tournaments (Phase 1)
+
+| Field | Value |
+|-------|-------|
+| **Decision ID** | ADR-104 |
+| **Status** | Implemented (Phase 1) |
+| **Date** | 2026-06-10 |
+| **Author** | AQE Core (Fable 5 improvement initiative, issue #520) |
+| **Review Cadence** | 6 months |
+
+---
+
+## WH(Y) Decision Statement
+
+**In the context of** test-strategy selection, where QE has objective fitness functions (mutation kill rate, coverage, runtime) but no mechanism that lets candidate strategies *compete* on them,
+
+**facing** the absence of any empirical, reproducible way to compare test suites — and inspired by ruflo-arena's Wolfram-style competitive ruliology (strategies as programs, tournaments as competitive arrays),
+
+**we decided for** a self-contained arena engine (`src/arena/`) where Phase-1 strategies are deterministic test-group selections over a committed fixture, fitness comes from REAL runs — a built-in first-order operator mutator with `node --test` executions per mutant (0.6·killRate + 0.3·coverage − 0.1·suiteCost) — tournaments emit pairwise competitive arrays, hill-climb evolves the winner by seeded group flips, and everything reproduces byte-identically under `--seed`,
+
+**and neglected** LLM-generated strategies in Phase 1 (not seedably reproducible — Phase 2, distilling winners into qe-test-architect priors), Stryker as the mutation engine (heavyweight dependency for a fixture-scale arena; the built-in mutator runs real mutants in milliseconds), and measured-wall-clock runtime penalties (empirically jitter-dominated at fixture scale — see Reproducibility note),
+
+**to achieve** an `aqe arena run` that produces a reproducible competitive array with real kill rates, plus fail-soft persistence of runs into memory.db (`kv_store`, namespace `arena`),
+
+**accepting that** Phase 1 fitness is fixture-scoped (suite selection, not generation), the runtime term is a suite-size proxy rather than measured milliseconds, and MCP `arena_run` registration is a follow-up (the CLI and any future MCP handler call the identical `runArena()` — parity by construction).
+
+---
+
+## Reproducibility note (empirical)
+
+The first implementation penalized runtime by *measured-duration rank*. Verification caught it: at fixture scale every baseline runs in 50–300 ms where node-boot jitter dominates, so ranks shuffled across identical-seed runs and flipped rankings. The deterministic replacement is `suiteCostRatio = selectedGroups / totalGroups` — a runtime proxy that preserves the economic trade-off; real per-strategy milliseconds remain in the envelope under `informational` (explicitly excluded from the reproducibility contract).
+
+## Options Considered
+
+### Option 1: Deterministic suite-selection arena with built-in mutator (Selected)
+**Pros:** every number from real executions; byte-reproducible; zero new dependencies; fast enough for CI
+### Option 2: Stryker-based mutation scoring (Rejected for Phase 1)
+**Why rejected:** heavyweight dependency + per-run instrumentation for a fixture-scale tournament; revisit if Phase 2 targets real projects.
+### Option 3: LLM-generated strategies now (Rejected for Phase 1)
+**Why rejected:** generation isn't seed-reproducible; reproducibility is the Phase-1 acceptance criterion. Phase 2: generate, then freeze candidates as artifacts and tournament them.
+
+---
+
+## Dependencies
+
+| Relationship | ADR ID | Title | Notes |
+|--------------|--------|-------|-------|
+| Relates To | ADR-094 | Kernel-Side Dream Cycles | Candidate offline-evolution host (Phase 2) |
+| Relates To | ADR-103 | Structured Verdict Handoffs | `arena-result@1` follows the same versioned-envelope convention |
+| Part Of | — | Fable 5 / ruflo-parity initiative | Tracking issue #520, improvement 7 |
+
+---
+
+## References
+
+| Ref ID | Title | Type | Location |
+|--------|-------|------|----------|
+| — | Engine | Source | `src/arena/{arena,mutator,runner,rng}.ts` |
+| — | CLI | Source | `src/cli/commands/arena.ts` (`aqe arena run|list`) |
+| — | Fixture | Source | `fixtures/arena-demo/` (pricing module + 4 test groups of varying kill power) |
+| — | Tests (10) | Tests | `tests/unit/arena/arena.test.ts` (incl. real-engine reproducibility) |
+| — | ruflo prior art | External | ruvnet/ruflo PR #2315 (ruflo-arena) |
+
+---
+
+## Governance
+
+| Review Board | Date | Outcome | Next Review |
+|--------------|------|---------|-------------|
+| AQE Core | 2026-06-10 | Implemented (Phase 1) | 2026-12-10 |
+
+---
+
+## Status History
+
+| Status | Date | Notes |
+|--------|------|-------|
+| Proposed | 2026-06-10 | From Fable 5 improvement plan (issue #520) |
+| Implemented | 2026-06-10 | Engine + fixture + CLI + 10 tests; E2E reproducibility verified after replacing the jitter-prone runtime-rank penalty |
+
+---
+
+## Definition of Done Checklist
+
+- [x] Evidence: plan's exact command run twice → byte-identical deterministic envelope; different seed → different tournament; hill-climb steps with real re-evaluation; persistence + `arena list` verified against memory.db
+- [x] Criteria: 3 options compared; reproducibility contract explicit (informational.runtimesMs excluded)
+- [x] Agreement: ruflo-arena prior art; no core changes (self-contained per plan)
+- [x] Documentation: this ADR; MCP follow-up + Phase 2 scope recorded
+- [x] Review: verification record on issue #520

--- a/docs/implementation/fable5-improvement-plan.md
+++ b/docs/implementation/fable5-improvement-plan.md
@@ -1,0 +1,265 @@
+# Fable 5 / ruflo-Parity Improvement Plan (GOAP)
+
+**Date:** 2026-06-10
+**Method:** Goal-Oriented Action Planning (`/goal-plan`)
+**Source analysis:** ruflo v3.10.27–v3.10.40 release review (ADR-147 nested subagents, Hermes tier-1 adoptions PR #2237, ruflo-arena PR #2315) + AQE codebase gap audit
+**Tracking:** GitHub issue (see footer)
+
+---
+
+## Goal
+
+AQE platform exploits Fable 5 era capabilities at parity with ruflo where applicable:
+clean learning embeddings, prompt-cache savings, runaway-loop protection, nested-subagent
+readiness, deterministic adversarial orchestration, typed agent handoffs, and competitive
+test-strategy evolution.
+
+**Success criteria (goal state):**
+
+1. No `<thinking>`-contaminated embeddings written to `memory.db` after the scrub ships
+2. Second consecutive advisor/LLM call shows `cache_read_tokens > 0`
+3. A command failing 5× consecutively is blocked by hooks with a recovery hint
+4. All `qe-*.md` agents declare `tools:` with a coordinator/leaf split; trajectories persist `parent_agent_id` + `depth`; probe script committed
+5. At least one QCSD phase runs as a deterministic workflow with adversarial find→refute verification
+6. QE quality-gate outputs validate against published JSON schemas (`RiskDecision`, `CoverageGap`, `FindingVerdict`)
+7. `aqe arena run` produces a reproducible competitive array for test strategies (Phase 1)
+
+## Current State
+
+| Capability | Status today | Evidence |
+|---|---|---|
+| Reasoning scrub | Absent | `src/integrations/agentic-flow/reasoning-bank/experience-replay.ts` embeds trajectories as-is (`computeRealEmbedding()`, ~L287) |
+| Prompt caching | Flag dead | `src/shared/llm/providers/claude.ts` defines `enableCache: true` (~L41) but never sets `cache_control` |
+| Tool-loop breaker | Domain-level only | `src/coordination/circuit-breaker/domain-circuit-breaker.ts` (ADR-064 Phase 2D); nothing at command level |
+| Nested subagent plumbing | Absent | No `tools:` frontmatter in `.claude/agents/v3/qe-*.md`; no `parentAgentId`/`depth` in `src/coordination/queen-types.ts` or post-task hooks |
+| Deterministic workflows | Absent | QCSD skills use flat Task-tool fan-out; no `.claude/workflows/` |
+| Typed verdict handoffs | Absent | Prose handoffs; ADR-075 covers framework types only |
+| Competitive tournaments | Absent | No ADR/code coverage |
+
+## ADR Actions
+
+| Improvement | ADR action | Status |
+|---|---|---|
+| 1. Reasoning-tag scrub | **NEW ADR-099** — Reasoning-Tag Scrubbing for Pattern Embedding Sanitization | Proposed |
+| 2. Prompt caching | **UPDATE ADR-088** (Prompt Cache Latch Fields, Implemented 2026-04-02) — add ephemeral breakpoint injection section | Amend |
+| 3. Tool-loop breaker | **NEW ADR-100** — Tool-Loop Circuit Breaker for Hook Reliability | Proposed |
+| 4. Nested subagents | **NEW ADR-101** — Nested Subagent Hierarchy: Depth Limits, Privilege Model, Trajectory Provenance | Proposed |
+| 5. QCSD workflows | **NEW ADR-102** — Deterministic Workflow Orchestration with Adversarial Verification (relates to ADR-074 Loki Mode, Accepted) | Proposed |
+| 6. Typed verdicts | **NEW ADR-103** — Structured JSON-Schema Verdict Handoffs (relates to ADR-075, ADR-054) | Proposed |
+| 7. qe-arena | **NEW ADR-104** — Competitive Test-Strategy Tournaments (qe-arena Phase 1) | Proposed |
+
+Highest existing ADR: 098. New ADRs follow `docs/implementation/adrs/templates/ADR-TEMPLATE.md` (WH(Y) statement, Options Considered, Dependencies, Governance, ECADR Definition of Done).
+
+## Plan (GOAP)
+
+```
+Goal: Fable 5 capability parity (7 criteria above)
+Plan Cost: ~13–18 dev-days across 4 tiers
+Execution order: [1 ∥ 2 ∥ 3] → 4 → 6 → 5 → 7
+  (6 before 5: workflow scripts consume the verdict schemas)
+```
+
+---
+
+### Improvement 1 — Reasoning-Tag Scrub Before Distillation (ADR-099) · Tier 1 · Cost S
+
+**Why now:** Fable 5 emits far more extended thinking than prior models; every fleet run
+dilutes `memory.db` pattern embeddings with reasoning-scratchpad text.
+
+**Steps**
+1. Add `scrubReasoningBlocks(text)` utility — strips `<think>`, `<thinking>`, `<reasoning>`, `<REASONING_SCRATCHPAD>` blocks; boundary-gated (prose *mentioning* the tags is left intact). *Precondition: none. Effect: reusable sanitizer with unit tests.*
+2. Apply in `experience-replay.ts` to trajectory `action`/`result` fields **before** distillation and `computeRealEmbedding()`. *Precondition: step 1. Effect: new embeddings clean.*
+3. Apply in `src/workers/workers/learning-consolidation.ts` consolidation path. *Effect: consolidated patterns clean.*
+4. Unit tests: tagged trajectory → stored pattern contains no tag content; prose mention survives.
+
+**Integration points:** ReasoningBank trajectory pipeline, post-task hook → `recordFeedback` path, `memory.db` `qe_patterns` writes. No schema migration. Existing rows untouched (data-protection rules apply — no rewrite of `memory.db`).
+
+**User verification (reproduction-first):**
+```bash
+# CLI path: record a trajectory whose result embeds a thinking block
+aqe hooks post-task --task-id scrub-test \
+  --result "$(printf '<thinking>secret scratchpad</thinking>real outcome')"
+sqlite3 .agentic-qe/memory.db \
+  "SELECT content FROM qe_patterns ORDER BY rowid DESC LIMIT 1;"
+# EXPECT: row contains "real outcome", does NOT contain "secret scratchpad"
+```
+MCP parity: same check via `mcp__agentic-qe__memory_query` on the latest pattern.
+
+---
+
+### Improvement 2 — Wire Prompt Caching (ADR-088 update) · Tier 1 · Cost S
+
+**Steps**
+1. In `claude.ts` request builder: when `enableCache`, send `system` as a content-block array with `cache_control: { type: "ephemeral" }` on the final system block (system + trailing-message strategy, per ruflo #2237). *Effect: ~90% discount on cached input tokens, 5-min TTL.*
+2. Surface `cache_creation_input_tokens` / `cache_read_input_tokens` from the API response into the existing ADR-088 latch/usage metrics and ADR-042 token tracking.
+3. Gate by provider — ephemeral breakpoints only on the Anthropic-native path; no-op for non-Anthropic providers (ADR-043/ADR-092 vendor independence).
+4. Tests: assert `cache_control` present in serialized request body when enabled, absent when disabled.
+
+**Integration points:** `src/shared/llm/providers/claude.ts`, token tracking (ADR-042), `routing_economics` / `routing_metrics` MCP tools, `aqe costs`.
+
+**User verification:**
+```bash
+# Two consecutive advisor calls within 5 minutes
+aqe advisor consult --question "test strategy for checkout flow"
+aqe advisor consult --question "test strategy for payment flow"
+aqe costs   # or: routing_metrics via MCP
+# EXPECT: second call reports cache_read_tokens > 0 and lower input cost
+```
+MCP parity: `mcp__agentic-qe__advisor_consult` ×2 → `mcp__agentic-qe__routing_metrics` shows cache reads.
+
+---
+
+### Improvement 3 — Tool-Loop Circuit Breaker (ADR-100) · Tier 1 · Cost M
+
+**Why now:** Fable 5 is more persistent than prior models — runaway retry loops are more
+expensive, not less.
+
+**Steps**
+1. New `tool-loop-guardrail` module reusing the closed→open→half-open state machine from `domain-circuit-breaker.ts`, keyed by normalized command signature instead of domain.
+2. `post-command` hook records `(command, success)`; `pre-command` hook consults the breaker: **warn at 3, block at 5** consecutive failures of the same command, emitting a recovery hint ("same command failed 5×; change approach or inspect the error").
+3. Advisory by default; `AQE_STRICT_TOOL_LOOP=1` upgrades warn→block. Orthogonal to security guardrails.
+4. Tests: 7 cases (below threshold, warn boundary, block boundary, reset on success, distinct commands independent, half-open recovery, env-var enforcement).
+
+**Integration points:** hooks `pre-command`/`post-command` handlers, existing circuit-breaker module (reuse, don't fork), in-process state (no DB write per command).
+
+**User verification:**
+```bash
+for i in 1 2 3 4 5; do
+  aqe hooks pre-command --command "npm run definitely-broken"
+  aqe hooks post-command --command "npm run definitely-broken" --success false
+done
+# EXPECT: iteration 3 prints a WARN with failure count; iteration 5 prints BLOCK + recovery hint
+aqe hooks post-command --command "npm run definitely-broken" --success true
+aqe hooks pre-command --command "npm run definitely-broken"
+# EXPECT: breaker reset, command allowed
+```
+MCP parity: same sequence through the MCP hooks tool returns the same warn/block envelope.
+
+---
+
+### Improvement 4 — Nested Subagent Readiness, depth=5 (ADR-101) · Tier 2 · Cost M–L
+
+**Why now:** Anthropic announced nested subagent support (depth=5) on 2026-06-09. ruflo's
+probe shows runtime plumbing exists but `Task` is stripped parent→child (upstream denylist).
+Building now means AQE activates with **zero code changes** the day the gate lifts.
+
+**Steps**
+1. Add `tools:` frontmatter to all `.claude/agents/v3/qe-*.md`: coordinators (`qe-queen-coordinator`, `qe-fleet-commander`, `qe-parallel-executor`, `qe-learning-coordinator`) declare `Task`; leaf specialists explicitly do not (least-privilege boundary). Mirror **only `qe-*.md`** changes into `assets/agents/v3/` (npm distribution rule — no non-QE agents there).
+2. Extend trajectory recording: `parentAgentId?: string`, `depth?: number` on `TaskExecution` (`src/coordination/queen-types.ts`) and post-task hook flags `--parent-agent-id` / `--depth` (validated: identifier check, integer 0 ≤ d ≤ 32). Lands in the JSON metadata blob — no schema migration for stage 1.
+3. Forward both fields through `recordFeedback` into ReasoningBank so learning can segment patterns per hierarchy level.
+4. Commit `scripts/probe-nested-spawn-depth.mjs` (port of ruflo's probe): spawns a coordinator that recursively chains L1→L2→… until refusal; commit probe output under `docs/probes/`. This is the regression test that announces when the upstream denylist lifts — re-run after every `claude update`.
+5. Tests: propagation, omission, depth=0 boundary, invalid id rejection, negative/non-integer/>32 depth rejection (7 cases, mirroring ruflo's suite).
+
+**Integration points:** `.claude/agents/v3/`, `assets/agents/v3/`, hooks post-task (CLI + MCP schema), ReasoningBank feedback, queen coordinator types.
+
+**User verification:**
+```bash
+# Agents parse cleanly with new frontmatter
+aqe health                       # no agent-load errors
+node scripts/probe-nested-spawn-depth.mjs
+# EXPECT today: "level=1 status=NO_AGENT_TOOL" (denylist active — documented, expected)
+# EXPECT post-rollout: level≥2 — signal to activate follow-up phases
+
+aqe hooks post-task --task-id nest-test --parent-agent-id qe-fleet-commander --depth 2
+sqlite3 .agentic-qe/memory.db "SELECT ... ORDER BY rowid DESC LIMIT 1;"
+# EXPECT: persisted entry contains parentAgentId=qe-fleet-commander, depth=2
+```
+MCP parity: `hooks_post-task` MCP input schema accepts both fields; same persistence check.
+
+---
+
+### Improvement 5 — Deterministic Workflow Orchestration for QCSD (ADR-102) · Tier 3 · Cost L
+
+**Depends on:** Improvement 6 (consumes verdict schemas).
+
+**Steps**
+1. Create `.claude/workflows/` with the first script: `qcsd-development-review` — dimensions → parallel finders → **adversarial refuters per finding** (N=3 skeptics prompted to refute; kill on majority refute) → synthesis. Findings/verdicts use ADR-103 schemas via the `agent(…, {schema})` option.
+2. Update `qcsd-development-swarm` SKILL.md: `execution.primary: workflow` where the harness supports it, keeping `task-tool` as documented fallback (not all users run a Workflow-capable harness).
+3. Wire ADR-074 Loki-mode escalation rules (blind review, sycophancy detection) as refuter prompt constraints.
+4. Baseline measurement: run old fan-out vs new workflow on the same fixture; record finding count, confirmed-finding count, false positives.
+5. Roll out to remaining QCSD phases (ideation/refinement/cicd/production) as follow-up once the development phase proves out.
+
+**Integration points:** `.claude/skills/qcsd-*`, qe agents as `agentType`, ADR-074, ADR-103 schemas.
+
+**User verification:**
+```bash
+# In Claude Code, on a fixture repo:
+/qcsd-development-swarm
+# EXPECT: workflow progress tree (Find → Verify → Synthesize phases visible);
+# final report lists ONLY confirmed findings, each carrying refuter verdicts (e.g. 3/3 upheld);
+# comparison note vs baseline shows reduced false positives
+```
+
+---
+
+### Improvement 6 — Structured Verdict Handoffs (ADR-103) · Tier 3 · Cost M
+
+**Steps**
+1. New `src/contracts/verdicts.ts` (typed + Zod/JSON Schema, versioned envelope): `FindingVerdict {id, title, file, severity, confidence, evidence[], verdict, refutations[]}`, `CoverageGap {file, range, riskScore, suggestedTests[]}`, `RiskDecision {decision: approve|block|escalate, riskFactors[], confidence, rationale}`.
+2. Validate at MCP boundaries: `quality_assess`, `coverage_analyze_sublinear`, quality-gate handlers emit schema-conformant payloads (validation at the boundary per project rules).
+3. Export schemas for workflow `agent(…, {schema})` use (improvement 5) — malformed agent output is auto-retried at the tool-call layer.
+4. Contract tests: golden samples validate; mutated samples (missing severity, confidence > 1) rejected.
+
+**Integration points:** ADR-075 type system (extend, don't fork), MCP handlers, QCSD workflows, A2A envelopes (ADR-054) unchanged — verdicts ride inside them.
+
+**User verification:**
+```bash
+aqe analyze --quality-gate --json > verdict.json
+npx ajv validate -s schemas/risk-decision.schema.json -d verdict.json
+# EXPECT: "verdict.json valid"
+```
+MCP parity: `mcp__agentic-qe__quality_assess` response body validates against the same schema.
+
+---
+
+### Improvement 7 — qe-arena: Competitive Test-Strategy Tournaments (ADR-104) · Tier 4 · Cost L
+
+**Why:** QE has objective fitness functions (mutation kill rate, coverage delta, runtime) —
+a better fit for ruflo-arena's tournament model than almost any other domain.
+
+**Steps (Phase 1, self-contained — no core changes)**
+1. Strategy = declarative test-generation config (framework, technique mix, edge-case emphasis, model tier). Seeded RNG; **no `Date.now()`/randomness in scoring paths** — reproducible under `--seed`.
+2. Arena engine: run N candidate strategies against a fixture project; fitness = `w1·mutationKillRate + w2·coverageDelta − w3·runtimePenalty` (Stryker for mutation scoring via the existing mutation-testing skill).
+3. Tournament → competitive array (pairwise fitness matrix); hill-climb evolution over strategy parameters.
+4. Persistence to `memory.db` via existing memory layer (unified persistence ADR — **no new SQLite file**); winners feed qe-test-architect as learned priors.
+5. Surface: `aqe arena run|tournament|list` CLI + `arena_run`/`tournament_run` MCP tools (registered through the standard handler registry — avoid ruflo's unregistered-plugin-tools gap).
+
+**Integration points:** mutation-testing skill, `qe-test-architect`, memory layer, optionally dream cycles (ADR-094) for offline evolution.
+
+**User verification:**
+```bash
+aqe arena run --strategies 4 --target fixtures/demo-project --seed 42
+# EXPECT: competitive array table (4×4 fitness matrix), ranked strategies,
+# winner with mutation kill-rate and coverage numbers
+aqe arena run --strategies 4 --target fixtures/demo-project --seed 42
+# EXPECT: identical output (reproducibility)
+```
+MCP parity: `arena_run` with the same seed returns the same ranked result envelope.
+
+---
+
+## Risk Factors (replan triggers)
+
+| Risk | Affected | Mitigation |
+|---|---|---|
+| Anthropic never lifts the `Task` denylist for nested spawns | 4 | All work is forward-compatible and independently useful (provenance fields help flat spawns today); probe script tells us when to proceed |
+| Workflow harness not available in every user environment | 5 | Keep `task-tool` execution path as documented fallback in QCSD skills |
+| `cache_control` rejected by non-Anthropic gateways/proxies | 2 | Provider-gated; no-op elsewhere (ADR-092) |
+| Mutation runs too slow for tournaments | 7 | Fixture-scoped Phase 1; sampled mutants; runtime penalty in fitness |
+| Scrub regex too aggressive (eats legitimate prose) | 1 | Boundary-gated matching + prose-mention tests before merge |
+| Schema changes break existing MCP consumers | 6 | Versioned envelope; additive fields only in v1 |
+
+**Fallback:** if Tier 3 (5+6) proves too large in one pass, ship ADR-103 schemas alone — they are independently useful for MCP output validation — and defer workflow conversion.
+
+---
+
+## Verification Gates (per project policy)
+
+- Reproduction-first: each improvement closes only after its **user-perspective command sequence above** runs green on a real fixture project
+- MCP–CLI parity: every CLI verification has an MCP twin, verified through the protocol server
+- No batch-close: 7 improvements = 7 separate verification records on the tracking issue
+- `npm run build` + `npm test` green before any merge; smoke test before release
+
+---
+
+*Tracking issue: see "Fable 5 / ruflo-parity improvement initiative" on proffesor-for-testing/agentic-qe.*

--- a/docs/probes/probe-nested-spawn-2026-06-10.txt
+++ b/docs/probes/probe-nested-spawn-2026-06-10.txt
@@ -1,0 +1,7 @@
+=== nested-spawn probe 2026-06-10T10:00:11.887Z ===
+verdict: level=1 status=NO_AGENT_TOOL (upstream denylist active — expected until Anthropic flips the gate)
+--- stdout ---
+level=0 task_tool=yes
+level=1 task_tool=no
+--- stderr ---
+Warning: no stdin data received in 3s, proceeding without it. If piping from a slow command, redirect stdin explicitly: < /dev/null to skip, or wait longer.

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -4,6 +4,7 @@ All Agentic QE release notes organized by version.
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| [v3.10.5](v3.10.5.md) | 2026-06-10 | Fable 5 parity (#520): CLI fleet/memory commands fixed, prompt caching wired, reasoning-scrub for clean learning, adversarial QCSD reviews, `aqe arena` tournaments. ADR-099–104. |
 | [v3.10.4](v3.10.4.md) | 2026-06-08 | Keep project learning in its own `.agentic-qe/` (#516: nearest-root + RVF resolution); stop orphaned `aqe-mcp` busy-loop / SIGTERM-ignore (#513); opt-in local Nagual hub + LLM judge. |
 | [v3.10.3](v3.10.3.md) | 2026-06-03 | TS/JS code intelligence with no `typescript` dependency via bundled tree-sitter WASM grammars (#511); fixes MCP domain tools hanging on fresh install, `code deps`/`search` returning empty, CLI↔MCP graph namespace; repaired stale WASM grammars; lint cleanup. |
 | [v3.10.2](v3.10.2.md) | 2026-06-02 | Self-learning hardening: fixes #508 (post-task hook recorded every trajectory `success=0`/`agent=unknown`) + #509 (stale dream readout); EWC++ forgetting protection, contradiction detection, MCP/learning verification harnesses, ADR-098. |

--- a/docs/releases/v3.10.5.md
+++ b/docs/releases/v3.10.5.md
@@ -1,0 +1,53 @@
+# v3.10.5 Release Notes
+
+**Release Date:** 2026-06-10
+
+## Highlights
+
+The Fable 5 / harness-parity release (#520): CLI memory and fleet commands work
+for the first time, prompt caching actually engages, the learning pipeline stays
+clean under reasoning-heavy models, and two new capabilities land — adversarially
+verified QCSD reviews and `aqe arena` competitive test-strategy tournaments.
+Seven improvements, each with an ADR (099–104 + the ADR-088 amendment) and a
+reproduction-first verification record on issue #520.
+
+## Added
+
+- **`aqe arena` (ADR-104, Phase 1)** — test strategies compete on real fitness:
+  built-in operator mutants run via `node --test`, real coverage, deterministic
+  suite-cost. Reproducible byte-for-byte under `--seed`; `--evolve` hill-climbs
+  the winner; `aqe arena list` reads persisted runs.
+- **Adversarially verified QCSD reviews (ADR-102)** — the development swarm runs
+  as a deterministic workflow: dimension finders → 3 blind refuters per finding
+  (majority kill, ADR-074 Loki rules) → code-only synthesis. Only confirmed
+  findings ship; killed findings keep their refutations for audit.
+- **Structured verdict contracts (ADR-103)** — `RiskDecision`, `FindingVerdict`,
+  `CoverageGap` envelopes with published JSON Schemas (`schemas/`); the
+  `quality_assess` MCP tool now returns a validated `riskDecision`.
+- **Tool-loop circuit breaker (ADR-100)** — warn at 3, block-recommend at 5
+  consecutive failures of the same Bash command (recovery hint included);
+  `AQE_STRICT_TOOL_LOOP=1` upgrades to a hard deny; success resets.
+- **Nested-subagent readiness (ADR-101)** — post-task `--parent-agent-id`/`--depth`
+  provenance for per-hierarchy-level learning, plus a committed probe script that
+  announces when Anthropic's depth-5 nested-subagent gate lifts.
+- **LLM judge benchmark harness** (`scripts/judge-benchmark.ts`).
+
+## Fixed
+
+- **CLI fleet/memory commands never worked** — `aqe memory|agent|task|team|pipeline`
+  always failed with "Fleet not initialized"; the CLI's auto-init now registers
+  its kernel with the shared handler fleet state.
+- **Prompt caching was a dead flag** — the Anthropic provider now sets an
+  ephemeral `cache_control` breakpoint, reports cache tokens, and prices them
+  correctly (0.1× reads / 1.25× writes).
+- **Extended-thinking contamination of pattern embeddings** — `<thinking>`-style
+  blocks are scrubbed (boundary-gated) before trajectories are persisted,
+  distilled, or embedded.
+- **Fresh-install learning no-op** — post-task persistence no longer depends on
+  middleware-created tables existing.
+
+## Changed
+
+- Devcontainer mounts `node_modules` as a named volume (contributor-only;
+  applies on rebuild) — no more macOS-host native binaries inside Linux containers.
+- Docs/install script: stale `ruflo@3.5.18` pins replaced with `ruflo@3`.

--- a/fixtures/arena-demo/src/pricing.mjs
+++ b/fixtures/arena-demo/src/pricing.mjs
@@ -1,0 +1,70 @@
+/**
+ * Arena demo fixture (ADR-104) — a small pricing module with deliberate
+ * branch density so operator mutations produce meaningful mutants.
+ * Pure ESM, no dependencies; tests run under `node --test`.
+ */
+
+export function applyDiscount(price, tier, coupon) {
+  if (typeof price !== 'number' || Number.isNaN(price)) {
+    throw new TypeError('price must be a number');
+  }
+  if (price < 0) {
+    throw new RangeError('price must be >= 0');
+  }
+
+  let rate = 0;
+  if (tier === 'gold') {
+    rate = 0.2;
+  } else if (tier === 'silver') {
+    rate = 0.1;
+  }
+
+  if (coupon === 'SAVE5' && price >= 50) {
+    rate = rate + 0.05;
+  }
+
+  if (rate > 0.25) {
+    rate = 0.25;
+  }
+
+  return Math.round(price * (1 - rate) * 100) / 100;
+}
+
+export function computeTotal(items, taxRate) {
+  if (!Array.isArray(items)) {
+    throw new TypeError('items must be an array');
+  }
+  if (typeof taxRate !== 'number' || taxRate < 0 || taxRate > 1) {
+    throw new RangeError('taxRate must be in [0, 1]');
+  }
+
+  let subtotal = 0;
+  for (const item of items) {
+    if (!item || typeof item.price !== 'number' || typeof item.qty !== 'number') {
+      throw new TypeError('item must have numeric price and qty');
+    }
+    if (item.qty <= 0) {
+      continue;
+    }
+    subtotal = subtotal + item.price * item.qty;
+  }
+
+  const total = subtotal * (1 + taxRate);
+  return Math.round(total * 100) / 100;
+}
+
+export function shippingBand(weightKg) {
+  if (typeof weightKg !== 'number' || weightKg < 0) {
+    throw new RangeError('weight must be >= 0');
+  }
+  if (weightKg === 0) {
+    return 'none';
+  }
+  if (weightKg <= 1) {
+    return 'small';
+  }
+  if (weightKg <= 10) {
+    return 'medium';
+  }
+  return 'freight';
+}

--- a/fixtures/arena-demo/tests/boundary.test.mjs
+++ b/fixtures/arena-demo/tests/boundary.test.mjs
@@ -1,0 +1,41 @@
+// Arena demo — "boundary" group: edge values at every branch threshold
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { applyDiscount, computeTotal, shippingBand } from '../src/pricing.mjs';
+
+test('coupon applies exactly at the 50 threshold', () => {
+  assert.equal(applyDiscount(50, 'none', 'SAVE5'), 47.5);
+});
+
+test('coupon does not apply just below the threshold', () => {
+  assert.equal(applyDiscount(49.99, 'none', 'SAVE5'), 49.99);
+});
+
+test('discount rate is capped at 25%', () => {
+  // gold (0.20) + SAVE5 (0.05) = 0.25 exactly — cap must not reduce it
+  assert.equal(applyDiscount(100, 'gold', 'SAVE5'), 75);
+});
+
+test('zero price is allowed', () => {
+  assert.equal(applyDiscount(0, 'gold'), 0);
+});
+
+test('zero-qty items are skipped, not summed', () => {
+  assert.equal(computeTotal([{ price: 10, qty: 0 }, { price: 5, qty: 1 }], 0), 5);
+});
+
+test('zero weight ships nothing', () => {
+  assert.equal(shippingBand(0), 'none');
+});
+
+test('exactly 1kg is still small', () => {
+  assert.equal(shippingBand(1), 'small');
+});
+
+test('exactly 10kg is still medium', () => {
+  assert.equal(shippingBand(10), 'medium');
+});
+
+test('just over 10kg is freight', () => {
+  assert.equal(shippingBand(10.01), 'freight');
+});

--- a/fixtures/arena-demo/tests/errors.test.mjs
+++ b/fixtures/arena-demo/tests/errors.test.mjs
@@ -1,0 +1,36 @@
+// Arena demo — "errors" group: rejection paths and invalid input
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { applyDiscount, computeTotal, shippingBand } from '../src/pricing.mjs';
+
+test('non-numeric price throws TypeError', () => {
+  assert.throws(() => applyDiscount('100', 'gold'), TypeError);
+});
+
+test('NaN price throws TypeError', () => {
+  assert.throws(() => applyDiscount(Number.NaN, 'gold'), TypeError);
+});
+
+test('negative price throws RangeError', () => {
+  assert.throws(() => applyDiscount(-1, 'gold'), RangeError);
+});
+
+test('non-array items throws TypeError', () => {
+  assert.throws(() => computeTotal('items', 0.1), TypeError);
+});
+
+test('taxRate above 1 throws RangeError', () => {
+  assert.throws(() => computeTotal([], 1.01), RangeError);
+});
+
+test('negative taxRate throws RangeError', () => {
+  assert.throws(() => computeTotal([], -0.01), RangeError);
+});
+
+test('item without numeric qty throws TypeError', () => {
+  assert.throws(() => computeTotal([{ price: 10 }], 0), TypeError);
+});
+
+test('negative weight throws RangeError', () => {
+  assert.throws(() => shippingBand(-0.5), RangeError);
+});

--- a/fixtures/arena-demo/tests/exhaustive.test.mjs
+++ b/fixtures/arena-demo/tests/exhaustive.test.mjs
@@ -1,0 +1,39 @@
+// Arena demo — "exhaustive" group: dense input sweeps (strongest killer,
+// genuinely slowest — the runtime penalty exists for suites like this)
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { applyDiscount, computeTotal, shippingBand } from '../src/pricing.mjs';
+
+test('discount sweep across tiers, coupons and prices', () => {
+  const expectRate = (tier, coupon, price) => {
+    let rate = tier === 'gold' ? 0.2 : tier === 'silver' ? 0.1 : 0;
+    if (coupon === 'SAVE5' && price >= 50) rate += 0.05;
+    return Math.min(rate, 0.25);
+  };
+  for (const tier of ['gold', 'silver', 'none']) {
+    for (const coupon of ['SAVE5', undefined]) {
+      for (let price = 0; price <= 120; price += 0.5) {
+        const expected = Math.round(price * (1 - expectRate(tier, coupon, price)) * 100) / 100;
+        assert.equal(applyDiscount(price, tier, coupon), expected, `tier=${tier} coupon=${coupon} price=${price}`);
+      }
+    }
+  }
+});
+
+test('total sweep across carts and tax rates', () => {
+  for (let qty = 1; qty <= 25; qty++) {
+    for (let tax = 0; tax <= 1; tax += 0.05) {
+      const t = Math.round(tax * 100) / 100;
+      const expected = Math.round(7.3 * qty * (1 + t) * 100) / 100;
+      assert.equal(computeTotal([{ price: 7.3, qty }], t), expected, `qty=${qty} tax=${t}`);
+    }
+  }
+});
+
+test('shipping band sweep at fine granularity', () => {
+  for (let w = 0; w <= 15; w += 0.01) {
+    const kg = Math.round(w * 100) / 100;
+    const expected = kg === 0 ? 'none' : kg <= 1 ? 'small' : kg <= 10 ? 'medium' : 'freight';
+    assert.equal(shippingBand(kg), expected, `w=${kg}`);
+  }
+});

--- a/fixtures/arena-demo/tests/happy.test.mjs
+++ b/fixtures/arena-demo/tests/happy.test.mjs
@@ -1,0 +1,20 @@
+// Arena demo — "happy" group: nominal paths only (weak mutant killer by design)
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { applyDiscount, computeTotal, shippingBand } from '../src/pricing.mjs';
+
+test('gold tier gets 20% off', () => {
+  assert.equal(applyDiscount(100, 'gold'), 80);
+});
+
+test('no tier pays full price', () => {
+  assert.equal(applyDiscount(40, 'none'), 40);
+});
+
+test('total sums items with tax', () => {
+  assert.equal(computeTotal([{ price: 10, qty: 2 }], 0.1), 22);
+});
+
+test('medium parcel band', () => {
+  assert.equal(shippingBand(5), 'medium');
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentic-qe",
-  "version": "3.10.4",
+  "version": "3.10.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentic-qe",
-      "version": "3.10.4",
+      "version": "3.10.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-qe",
-  "version": "3.10.4",
+  "version": "3.10.5",
   "description": "Agentic Quality Engineering V3 - Domain-Driven Design Architecture with 13 Bounded Contexts, O(log n) coverage analysis, ReasoningBank learning, 60 specialized QE agents, mathematical Coherence verification, deep Claude Flow integration",
   "type": "module",
   "main": "./dist/index.js",

--- a/schemas/coverage-gap.schema.json
+++ b/schemas/coverage-gap.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://agentic-qe.dev/schemas/coverage-gap.schema.json",
+  "title": "CoverageGap",
+  "type": "object",
+  "required": [
+    "contract",
+    "file",
+    "riskScore",
+    "suggestedTests"
+  ],
+  "additionalProperties": true,
+  "properties": {
+    "contract": {
+      "const": "coverage-gap@1"
+    },
+    "file": {
+      "type": "string",
+      "minLength": 1
+    },
+    "rangeStart": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "rangeEnd": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "riskScore": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "suggestedTests": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/schemas/finding-verdict.schema.json
+++ b/schemas/finding-verdict.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://agentic-qe.dev/schemas/finding-verdict.schema.json",
+  "title": "FindingVerdict",
+  "type": "object",
+  "required": [
+    "contract",
+    "id",
+    "title",
+    "severity",
+    "confidence",
+    "evidence",
+    "verdict",
+    "refutations"
+  ],
+  "additionalProperties": true,
+  "properties": {
+    "contract": {
+      "const": "finding-verdict@1"
+    },
+    "id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "file": {
+      "type": "string"
+    },
+    "severity": {
+      "enum": [
+        "critical",
+        "high",
+        "medium",
+        "low",
+        "info"
+      ]
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "evidence": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "verdict": {
+      "enum": [
+        "upheld",
+        "refuted",
+        "uncertain"
+      ]
+    },
+    "refutations": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/schemas/risk-decision.schema.json
+++ b/schemas/risk-decision.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://agentic-qe.dev/schemas/risk-decision.schema.json",
+  "title": "RiskDecision",
+  "type": "object",
+  "required": [
+    "contract",
+    "decision",
+    "riskFactors",
+    "confidence",
+    "rationale"
+  ],
+  "additionalProperties": true,
+  "properties": {
+    "contract": {
+      "const": "risk-decision@1"
+    },
+    "decision": {
+      "enum": [
+        "approve",
+        "block",
+        "escalate"
+      ]
+    },
+    "riskFactors": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "rationale": {
+      "type": "string",
+      "minLength": 1
+    }
+  }
+}

--- a/scripts/generate-verdict-schemas.mjs
+++ b/scripts/generate-verdict-schemas.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+/**
+ * ADR-103 — Publish the verdict JSON Schemas from the compiled contracts
+ * module to schemas/*.schema.json. The TypeScript validators in
+ * src/contracts/verdicts.ts are the source of truth; run this after
+ * changing them (requires a prior `npx tsc` emit).
+ *
+ * Usage: node scripts/generate-verdict-schemas.mjs
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const { VERDICT_SCHEMAS } = await import(join(root, 'dist', 'contracts', 'verdicts.js'));
+
+const outDir = join(root, 'schemas');
+mkdirSync(outDir, { recursive: true });
+
+for (const [name, schema] of Object.entries(VERDICT_SCHEMAS)) {
+  const file = join(outDir, `${name}.schema.json`);
+  writeFileSync(file, JSON.stringify(schema, null, 2) + '\n');
+  console.log(`wrote ${file}`);
+}

--- a/scripts/probe-nested-spawn-depth.mjs
+++ b/scripts/probe-nested-spawn-depth.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * ADR-101 — Empirical probe: can spawned subagents spawn subagents?
+ *
+ * Anthropic announced nested subagent support (depth=5) on 2026-06-09, but
+ * the runtime currently strips the Task tool at parent→child spawn time
+ * (upstream denylist — see ruflo ADR-147 for the original investigation).
+ * This script is the regression test that tells us when the gate lifts:
+ * re-run it after every `claude update`.
+ *
+ * Usage:   node scripts/probe-nested-spawn-depth.mjs
+ * Output:  verdict on stdout; full transcript appended under docs/probes/
+ *
+ * Verdicts:
+ *   level=1 status=NO_AGENT_TOOL   — denylist active (expected today)
+ *   level=N status=TASK_TOOL_LIVE  — nested spawning works to level N:
+ *                                    activate ADR-101 follow-up phases
+ *   status=PROBE_INCONCLUSIVE      — output didn't match; inspect transcript
+ */
+
+import { execFile } from 'node:child_process';
+import { mkdirSync, appendFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const probesDir = join(root, 'docs', 'probes');
+
+const PROMPT = `PROBE for nested subagent support. Follow these steps exactly, no extra prose:
+1. Use your Task/Agent tool (subagent_type: general-purpose) to spawn ONE subagent with exactly this instruction:
+   "Output the single line 'level=1 task_tool=yes' if you have a Task or Agent tool available to spawn subagents, or 'level=1 task_tool=no' if you do not. If yes, additionally spawn one general-purpose subagent instructing it to output 'level=2 task_tool=yes' or 'level=2 task_tool=no' by the same rule, and append its output line to yours. Return only these lines."
+2. Output 'level=0 task_tool=yes' followed by the subagent's returned lines, verbatim, one per line. Nothing else.`;
+
+function runProbe() {
+  return new Promise((resolve) => {
+    const child = execFile(
+      'claude',
+      ['-p', PROMPT, '--max-turns', '10', '--output-format', 'text'],
+      { timeout: 600_000, maxBuffer: 10 * 1024 * 1024 },
+      (error, stdout, stderr) => resolve({ error, stdout: stdout ?? '', stderr: stderr ?? '' })
+    );
+    child.on('error', (error) => resolve({ error, stdout: '', stderr: String(error) }));
+  });
+}
+
+const { error, stdout, stderr } = await runProbe();
+
+const lines = stdout.split('\n').map((l) => l.trim());
+const levels = new Map();
+for (const line of lines) {
+  const m = line.match(/^level=(\d+)\s+task_tool=(yes|no)$/);
+  if (m) levels.set(Number(m[1]), m[2] === 'yes');
+}
+
+let verdict;
+if (error && !stdout) {
+  verdict = `status=PROBE_FAILED error=${error.code ?? error.message}`;
+} else if (levels.size === 0) {
+  verdict = 'status=PROBE_INCONCLUSIVE (no level lines in output — inspect transcript)';
+} else {
+  const deepestYes = Math.max(...[...levels.entries()].filter(([, yes]) => yes).map(([l]) => l));
+  const firstNo = [...levels.entries()].find(([, yes]) => !yes)?.[0];
+  verdict =
+    firstNo !== undefined && firstNo <= 1
+      ? `level=${firstNo} status=NO_AGENT_TOOL (upstream denylist active — expected until Anthropic flips the gate)`
+      : `level=${deepestYes} status=TASK_TOOL_LIVE (nested spawning works — activate ADR-101 follow-up phases)`;
+}
+
+const stamp = new Date().toISOString();
+const record = [
+  `=== nested-spawn probe ${stamp} ===`,
+  `verdict: ${verdict}`,
+  `--- stdout ---`,
+  stdout.trim(),
+  stderr.trim() ? `--- stderr ---\n${stderr.trim()}` : '',
+  '',
+].join('\n');
+
+mkdirSync(probesDir, { recursive: true });
+const outFile = join(probesDir, `probe-nested-spawn-${stamp.slice(0, 10)}.txt`);
+appendFileSync(outFile, record);
+
+console.log(verdict);
+console.log(`transcript: ${outFile}`);

--- a/src/arena/arena.ts
+++ b/src/arena/arena.ts
@@ -1,0 +1,235 @@
+/**
+ * Agentic QE v3 - Competitive Test-Strategy Arena (ADR-104, Phase 1)
+ *
+ * Strategies are deterministic selections of fixture test groups; fitness
+ * comes from REAL runs: mutation kill rate (built-in operator mutants,
+ * `node --test` per mutant) + line coverage − a runtime penalty. The
+ * tournament produces Wolfram-style pairwise competitive arrays; optional
+ * hill-climb evolves the winner by seeded group flips with re-evaluation.
+ *
+ * Reproducibility contract: with the same seed and fixture, every field
+ * of the result envelope is identical across runs EXCEPT
+ * `informational.runtimesMs` (real wall-clock, reported but excluded —
+ * the fitness runtime term uses ordinal rank, which is stable because
+ * group runtimes differ by design).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { mulberry32, nextInt, type Rng } from './rng.js';
+import { enumerateMutants, applyMutant, type Mutant } from './mutator.js';
+import {
+  discoverFixture,
+  prepareWorkspace,
+  runNodeTest,
+  makeTmpRoot,
+  cleanupTmpRoot,
+  type FixtureLayout,
+} from './runner.js';
+
+export interface ArenaStrategy {
+  id: string;
+  name: string;
+  groups: string[];
+}
+
+export interface EvaluatedStrategy extends ArenaStrategy {
+  baselinePassed: boolean;
+  mutantsKilled: number;
+  mutantsTotal: number;
+  killRate: number;
+  coveragePct: number | null;
+  /** Deterministic runtime proxy: selected groups / total groups (0..1) */
+  suiteCostRatio: number;
+  fitness: number;
+}
+
+export interface ArenaResult {
+  contract: 'arena-result@1';
+  seed: number;
+  target: string;
+  weights: { kill: number; coverage: number; runtimePenalty: number };
+  mutantsTotal: number;
+  strategies: EvaluatedStrategy[];
+  /** strategy ids best→worst */
+  ranking: string[];
+  /** competitiveArray[i][j]: 1 if strategies[i] beats [j], -1 if loses, 0 tie (by fitness) */
+  competitiveArray: number[][];
+  evolution: Array<{ step: number; groups: string[]; fitness: number; accepted: boolean }>;
+  informational: { runtimesMs: Record<string, number> };
+}
+
+export interface ArenaOptions {
+  target: string;
+  strategies?: number;
+  seed?: number;
+  maxMutants?: number;
+  evolveSteps?: number;
+  log?: (line: string) => void;
+}
+
+const WEIGHTS = { kill: 0.6, coverage: 0.3, runtimePenalty: 0.1 } as const;
+
+/** First strategy is always the full suite; the rest are seeded distinct subsets. */
+export function buildStrategies(groups: string[], n: number, rng: Rng): ArenaStrategy[] {
+  const sorted = [...groups].sort();
+  const seen = new Set<string>([sorted.join('+')]);
+  const strategies: ArenaStrategy[] = [
+    { id: 's1', name: `all(${sorted.join('+')})`, groups: sorted },
+  ];
+  let guard = 0;
+  while (strategies.length < n && guard++ < 200) {
+    const subset = sorted.filter(() => rng() < 0.5);
+    if (subset.length === 0) continue;
+    const key = subset.join('+');
+    if (seen.has(key)) continue;
+    seen.add(key);
+    strategies.push({ id: `s${strategies.length + 1}`, name: key, groups: subset });
+  }
+  return strategies;
+}
+
+/**
+ * Fitness with a DETERMINISTIC runtime term: at fixture scale, measured
+ * wall-clock is jitter-dominated (node boot ≈ the suite runtime), so the
+ * penalty uses suite-size ratio as the runtime proxy. Real per-strategy
+ * milliseconds are still reported under `informational`.
+ */
+function fitnessOf(killRate: number, coveragePct: number | null, suiteCostRatio: number): number {
+  const coverageTerm = coveragePct === null ? 0 : coveragePct / 100;
+  const f = WEIGHTS.kill * killRate + WEIGHTS.coverage * coverageTerm - WEIGHTS.runtimePenalty * suiteCostRatio;
+  return Math.round(f * 10000) / 10000;
+}
+
+function evaluateStrategy(
+  layout: FixtureLayout,
+  strategy: ArenaStrategy,
+  mutantsByFile: Array<{ relPath: string; source: string; mutants: Mutant[] }>,
+  tmpRoot: string
+): { baselinePassed: boolean; killed: number; total: number; coveragePct: number | null; runtimeMs: number } {
+  const baselineDir = prepareWorkspace({ layout, groups: strategy.groups }, tmpRoot);
+  const baseline = runNodeTest(baselineDir, { coverage: true });
+  if (!baseline.ok) {
+    return { baselinePassed: false, killed: 0, total: 0, coveragePct: baseline.coveragePct, runtimeMs: baseline.durationMs };
+  }
+
+  let killed = 0;
+  let total = 0;
+  for (const file of mutantsByFile) {
+    for (const mutant of file.mutants) {
+      total++;
+      const dir = prepareWorkspace(
+        { layout, groups: strategy.groups, mutatedFile: { relPath: file.relPath, content: applyMutant(file.source, mutant) } },
+        tmpRoot
+      );
+      const run = runNodeTest(dir);
+      if (!run.ok) killed++;
+    }
+  }
+  return { baselinePassed: true, killed, total, coveragePct: baseline.coveragePct, runtimeMs: baseline.durationMs };
+}
+
+export function runArena(options: ArenaOptions): ArenaResult {
+  const seed = options.seed ?? 42;
+  const log = options.log ?? (() => {});
+  const rng = mulberry32(seed);
+  const layout = discoverFixture(options.target);
+  const tmpRoot = makeTmpRoot();
+
+  try {
+    // Enumerate + deterministically sample mutants
+    const maxMutants = options.maxMutants ?? 24;
+    const mutantsByFile = layout.sourceFiles.map((relPath) => {
+      const source = fs.readFileSync(path.join(layout.root, relPath), 'utf8');
+      return { relPath, source, mutants: enumerateMutants(source, relPath) };
+    });
+    let allMutants = mutantsByFile.flatMap((f) => f.mutants.map((m) => ({ file: f.relPath, m })));
+    if (allMutants.length > maxMutants) {
+      const picked = new Set<string>();
+      while (picked.size < maxMutants) {
+        picked.add(allMutants[nextInt(rng, allMutants.length)].m.id);
+      }
+      for (const f of mutantsByFile) {
+        f.mutants = f.mutants.filter((m) => picked.has(m.id));
+      }
+      allMutants = mutantsByFile.flatMap((f) => f.mutants.map((m) => ({ file: f.relPath, m })));
+    }
+    log(`mutants: ${allMutants.length} (of ${mutantsByFile.reduce((n, f) => n + enumerateMutants(f.source, f.relPath).length, 0)} enumerated)`);
+
+    // Build + evaluate strategies (real runs)
+    const strategies = buildStrategies(Object.keys(layout.testGroups), options.strategies ?? 4, rng);
+    const runtimesMs: Record<string, number> = {};
+    const raw = strategies.map((s) => {
+      log(`evaluating ${s.id} [${s.name}] ...`);
+      const e = evaluateStrategy(layout, s, mutantsByFile, tmpRoot);
+      runtimesMs[s.id] = e.runtimeMs;
+      return { s, e };
+    });
+
+    const totalGroups = Object.keys(layout.testGroups).length;
+    const evaluated: EvaluatedStrategy[] = raw.map(({ s, e }) => {
+      const killRate = e.total > 0 ? Math.round((e.killed / e.total) * 10000) / 10000 : 0;
+      const suiteCostRatio = Math.round((s.groups.length / totalGroups) * 10000) / 10000;
+      return {
+        ...s,
+        baselinePassed: e.baselinePassed,
+        mutantsKilled: e.killed,
+        mutantsTotal: e.total,
+        killRate,
+        coveragePct: e.coveragePct,
+        suiteCostRatio,
+        fitness: e.baselinePassed ? fitnessOf(killRate, e.coveragePct, suiteCostRatio) : 0,
+      };
+    });
+
+    const ranking = [...evaluated]
+      .sort((a, b) => b.fitness - a.fitness || a.id.localeCompare(b.id))
+      .map((s) => s.id);
+    const competitiveArray = evaluated.map((a) =>
+      evaluated.map((b) => (a.fitness > b.fitness ? 1 : a.fitness < b.fitness ? -1 : 0))
+    );
+
+    // Optional hill-climb from the winner: seeded single-group flips,
+    // accept only on real fitness improvement
+    const evolution: ArenaResult['evolution'] = [];
+    if (options.evolveSteps && options.evolveSteps > 0) {
+      const allGroups = Object.keys(layout.testGroups).sort();
+      let bestGroups = evaluated.find((s) => s.id === ranking[0])!.groups;
+      let bestFitness = evaluated.find((s) => s.id === ranking[0])!.fitness;
+      for (let step = 1; step <= options.evolveSteps; step++) {
+        const flip = allGroups[nextInt(rng, allGroups.length)];
+        const candidate = bestGroups.includes(flip)
+          ? bestGroups.filter((g) => g !== flip)
+          : [...bestGroups, flip].sort();
+        if (candidate.length === 0) {
+          evolution.push({ step, groups: candidate, fitness: 0, accepted: false });
+          continue;
+        }
+        const e = evaluateStrategy(layout, { id: `evo${step}`, name: candidate.join('+'), groups: candidate }, mutantsByFile, tmpRoot);
+        const killRate = e.total > 0 ? e.killed / e.total : 0;
+        const f = e.baselinePassed ? fitnessOf(killRate, e.coveragePct, candidate.length / allGroups.length) : 0;
+        const accepted = f > bestFitness;
+        evolution.push({ step, groups: candidate, fitness: f, accepted });
+        if (accepted) {
+          bestGroups = candidate;
+          bestFitness = f;
+        }
+      }
+    }
+
+    return {
+      contract: 'arena-result@1',
+      seed,
+      target: path.relative(process.cwd(), layout.root) || '.',
+      weights: { ...WEIGHTS },
+      mutantsTotal: allMutants.length,
+      strategies: evaluated,
+      ranking,
+      competitiveArray,
+      evolution,
+      informational: { runtimesMs },
+    };
+  } finally {
+    cleanupTmpRoot(tmpRoot);
+  }
+}

--- a/src/arena/mutator.ts
+++ b/src/arena/mutator.ts
@@ -1,0 +1,114 @@
+/**
+ * Agentic QE v3 - Operator Mutator for qe-arena (ADR-104)
+ *
+ * Generates first-order operator mutants from JavaScript source text:
+ * comparison flips, boundary shifts, arithmetic swaps, logical swaps.
+ * String literals, template literals, comments, and arrow tokens are
+ * excluded so mutants change behavior, not error messages. Enumeration
+ * order is deterministic (position-sorted), so seeded sampling over the
+ * mutant list is reproducible.
+ */
+
+export interface Mutant {
+  id: string;
+  /** Byte offset in the source file */
+  index: number;
+  from: string;
+  to: string;
+  line: number;
+}
+
+/** Longest-first so '<=' is claimed before '<', '===' before '==' etc. */
+const OPERATOR_SUBSTITUTIONS: Array<[from: string, to: string]> = [
+  ['===', '!=='],
+  ['!==', '==='],
+  ['<=', '<'],
+  ['>=', '>'],
+  ['&&', '||'],
+  ['||', '&&'],
+  ['<', '<='],
+  ['>', '>='],
+  ['+', '-'],
+  ['*', '+'],
+];
+
+/**
+ * Mark every index that sits inside a string literal, template literal,
+ * or comment — operators there must not be mutated.
+ */
+function excludedRanges(source: string): boolean[] {
+  const excluded = new Array<boolean>(source.length).fill(false);
+  let i = 0;
+  let mode: 'code' | 'single' | 'double' | 'template' | 'line-comment' | 'block-comment' = 'code';
+  while (i < source.length) {
+    const c = source[i];
+    const next = source[i + 1];
+    if (mode === 'code') {
+      if (c === "'") mode = 'single';
+      else if (c === '"') mode = 'double';
+      else if (c === '`') mode = 'template';
+      else if (c === '/' && next === '/') mode = 'line-comment';
+      else if (c === '/' && next === '*') mode = 'block-comment';
+      if (mode !== 'code') excluded[i] = true;
+    } else {
+      excluded[i] = true;
+      if (mode === 'single' && c === "'" && source[i - 1] !== '\\') mode = 'code';
+      else if (mode === 'double' && c === '"' && source[i - 1] !== '\\') mode = 'code';
+      else if (mode === 'template' && c === '`' && source[i - 1] !== '\\') mode = 'code';
+      else if (mode === 'line-comment' && c === '\n') mode = 'code';
+      else if (mode === 'block-comment' && c === '*' && next === '/') {
+        excluded[i + 1] = true;
+        i++;
+        mode = 'code';
+      }
+    }
+    i++;
+  }
+  return excluded;
+}
+
+function lineOf(source: string, index: number): number {
+  let line = 1;
+  for (let i = 0; i < index; i++) {
+    if (source[i] === '\n') line++;
+  }
+  return line;
+}
+
+/** Enumerate all first-order mutants of a source text, position-sorted. */
+export function enumerateMutants(source: string, fileLabel: string): Mutant[] {
+  const excluded = excludedRanges(source);
+  const claimed = new Array<boolean>(source.length).fill(false);
+  const mutants: Mutant[] = [];
+
+  for (const [from, to] of OPERATOR_SUBSTITUTIONS) {
+    let pos = source.indexOf(from);
+    while (pos !== -1) {
+      const end = pos + from.length;
+      const overlapsClaim = claimed.slice(pos, end).some(Boolean);
+      const overlapsExcluded = excluded.slice(pos, end).some(Boolean);
+      // '=>' protection: never mutate the '>' of an arrow; '>=' handled by ordering
+      const isArrow = from === '>' && source[pos - 1] === '=';
+      // avoid '<=' / '>=' double-claim from the 1-char pass
+      const widerLeft = (from === '<' || from === '>') && (source[end] === '=' || source[pos - 1] === '<' || source[pos - 1] === '>');
+      if (!overlapsClaim && !overlapsExcluded && !isArrow && !widerLeft) {
+        for (let i = pos; i < end; i++) claimed[i] = true;
+        mutants.push({
+          id: `${fileLabel}:${lineOf(source, pos)}:${pos}:${from}->${to}`,
+          index: pos,
+          from,
+          to,
+          line: lineOf(source, pos),
+        });
+      }
+      pos = source.indexOf(from, pos + 1);
+    }
+  }
+
+  return mutants.sort((a, b) => a.index - b.index);
+}
+
+/** Apply one mutant to the source text. */
+export function applyMutant(source: string, mutant: Mutant): string {
+  return source.slice(0, mutant.index) + mutant.to + source.slice(mutant.index + mutant.from.length);
+}

--- a/src/arena/rng.ts
+++ b/src/arena/rng.ts
@@ -1,0 +1,38 @@
+/**
+ * Agentic QE v3 - Seeded RNG for qe-arena (ADR-104)
+ *
+ * mulberry32 — tiny deterministic PRNG. Everything the arena randomizes
+ * (strategy subset sampling, mutant sampling, hill-climb flips) draws from
+ * one seeded stream so identical seeds reproduce identical tournaments.
+ * No Math.random()/Date.now() anywhere in scoring paths.
+ */
+
+export type Rng = () => number;
+
+export function mulberry32(seed: number): Rng {
+  let a = seed >>> 0;
+  return function () {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Deterministic integer in [0, maxExclusive) */
+export function nextInt(rng: Rng, maxExclusive: number): number {
+  return Math.floor(rng() * maxExclusive);
+}
+
+/** Deterministic sample of k distinct items (order-stable Fisher-Yates prefix) */
+export function sample<T>(rng: Rng, items: readonly T[], k: number): T[] {
+  const pool = [...items];
+  const out: T[] = [];
+  const n = Math.min(k, pool.length);
+  for (let i = 0; i < n; i++) {
+    const idx = nextInt(rng, pool.length);
+    out.push(pool.splice(idx, 1)[0]);
+  }
+  return out;
+}

--- a/src/arena/runner.ts
+++ b/src/arena/runner.ts
@@ -1,0 +1,111 @@
+/**
+ * Agentic QE v3 - Fixture Runner for qe-arena (ADR-104)
+ *
+ * Materializes a strategy's workspace (fixture sources — optionally with
+ * one mutant applied — plus only the test groups the strategy selects)
+ * in a temp directory and runs it with `node --test`. Real test runs,
+ * real exit codes; nothing simulated.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { spawnSync } from 'child_process';
+
+export interface FixtureLayout {
+  /** Absolute path of the fixture project */
+  root: string;
+  /** Source files, relative to root (mutation targets) */
+  sourceFiles: string[];
+  /** Test group name → test file relative path */
+  testGroups: Record<string, string>;
+}
+
+export interface RunResult {
+  ok: boolean;
+  durationMs: number;
+  /** Line-coverage percent parsed from --experimental-test-coverage, when requested */
+  coveragePct: number | null;
+}
+
+/** Discover the conventional fixture layout: src/*.mjs + tests/<group>.test.mjs */
+export function discoverFixture(root: string): FixtureLayout {
+  const abs = path.resolve(root);
+  const srcDir = path.join(abs, 'src');
+  const testsDir = path.join(abs, 'tests');
+  if (!fs.existsSync(srcDir) || !fs.existsSync(testsDir)) {
+    throw new Error(`not an arena fixture (expected src/ and tests/): ${abs}`);
+  }
+  const sourceFiles = fs.readdirSync(srcDir).filter((f) => f.endsWith('.mjs')).sort()
+    .map((f) => path.join('src', f));
+  const testGroups: Record<string, string> = {};
+  for (const f of fs.readdirSync(testsDir).filter((f) => f.endsWith('.test.mjs')).sort()) {
+    testGroups[f.replace('.test.mjs', '')] = path.join('tests', f);
+  }
+  if (sourceFiles.length === 0 || Object.keys(testGroups).length === 0) {
+    throw new Error(`fixture has no src/*.mjs or tests/*.test.mjs: ${abs}`);
+  }
+  return { root: abs, sourceFiles, testGroups };
+}
+
+export interface WorkspaceSpec {
+  layout: FixtureLayout;
+  groups: string[];
+  /** When set, this source file's content replaces the original */
+  mutatedFile?: { relPath: string; content: string };
+}
+
+/** Build a throwaway workspace for one (strategy, mutant?) evaluation. */
+export function prepareWorkspace(spec: WorkspaceSpec, tmpRoot: string): string {
+  const dir = fs.mkdtempSync(path.join(tmpRoot, 'arena-ws-'));
+  fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+  fs.mkdirSync(path.join(dir, 'tests'), { recursive: true });
+
+  for (const rel of spec.layout.sourceFiles) {
+    const content =
+      spec.mutatedFile && spec.mutatedFile.relPath === rel
+        ? spec.mutatedFile.content
+        : fs.readFileSync(path.join(spec.layout.root, rel), 'utf8');
+    fs.writeFileSync(path.join(dir, rel), content);
+  }
+  for (const group of spec.groups) {
+    const rel = spec.layout.testGroups[group];
+    fs.copyFileSync(path.join(spec.layout.root, rel), path.join(dir, rel));
+  }
+  return dir;
+}
+
+/** Run `node --test` on the workspace's test files (explicit paths — a bare
+ * directory argument is not portably supported by the node test runner). */
+export function runNodeTest(dir: string, options: { coverage?: boolean; timeoutMs?: number } = {}): RunResult {
+  const args = ['--test'];
+  if (options.coverage) args.push('--experimental-test-coverage');
+  const testFiles = fs.readdirSync(path.join(dir, 'tests')).filter((f) => f.endsWith('.test.mjs')).sort()
+    .map((f) => path.join('tests', f));
+  args.push(...testFiles);
+
+  const startedAt = process.hrtime.bigint();
+  const proc = spawnSync(process.execPath, args, {
+    cwd: dir,
+    timeout: options.timeoutMs ?? 120_000,
+    encoding: 'utf8',
+  });
+  const durationMs = Number(process.hrtime.bigint() - startedAt) / 1e6;
+
+  let coveragePct: number | null = null;
+  if (options.coverage) {
+    // node's coverage table summary row: "# all files | 91.43 | 84.21 | ..."
+    const m = /all files\s*\|\s*([\d.]+)/.exec(proc.stdout ?? '');
+    coveragePct = m ? Number(m[1]) : null;
+  }
+
+  return { ok: proc.status === 0, durationMs: Math.round(durationMs), coveragePct };
+}
+
+export function makeTmpRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'qe-arena-'));
+}
+
+export function cleanupTmpRoot(tmpRoot: string): void {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+}

--- a/src/cli/commands/arena.ts
+++ b/src/cli/commands/arena.ts
@@ -1,0 +1,137 @@
+/**
+ * Agentic QE v3 - qe-arena CLI (ADR-104, Phase 1)
+ *
+ * Competitive test-strategy tournaments over an arena fixture:
+ * real mutation kill rates, real coverage, seeded reproducibility.
+ */
+
+import { Command } from 'commander';
+import chalk from 'chalk';
+import type { CLIContext } from '../handlers/interfaces.js';
+import { toErrorMessage } from '../../shared/error-utils.js';
+
+export function createArenaCommand(
+  _context: CLIContext,
+  cleanupAndExit: (code: number) => Promise<never>,
+  ensureInitialized: () => Promise<boolean>
+): Command {
+  const arena = new Command('arena')
+    .description('Competitive test-strategy tournaments (ADR-104)')
+    .addHelpText('after', `
+Examples:
+  # Run a 4-strategy tournament against the demo fixture (reproducible under --seed)
+  aqe arena run --strategies 4 --target fixtures/arena-demo --seed 42
+
+  # Evolve the winner with 3 hill-climb steps
+  aqe arena run --target fixtures/arena-demo --seed 42 --evolve 3
+
+  # List persisted runs
+  aqe arena list
+`);
+
+  arena
+    .command('run')
+    .description('Run a seeded strategy tournament against an arena fixture')
+    .requiredOption('--target <dir>', 'Arena fixture directory (src/*.mjs + tests/*.test.mjs)')
+    .option('--strategies <n>', 'Number of strategies', '4')
+    .option('--seed <n>', 'RNG seed (same seed = same tournament)', '42')
+    .option('--max-mutants <n>', 'Mutant sample cap', '24')
+    .option('--evolve <steps>', 'Hill-climb steps from the winner', '0')
+    .option('--json', 'Output the full arena-result@1 envelope as JSON')
+    .action(async (options) => {
+      try {
+        const { runArena } = await import('../../arena/arena.js');
+        const result = runArena({
+          target: options.target,
+          strategies: parseInt(options.strategies, 10),
+          seed: parseInt(options.seed, 10),
+          maxMutants: parseInt(options.maxMutants, 10),
+          evolveSteps: parseInt(options.evolve, 10),
+          log: options.json ? () => {} : (line) => console.error(chalk.dim(`  ${line}`)),
+        });
+
+        // Persist fail-soft (memory.db may be unavailable; the run itself
+        // is standalone by design)
+        try {
+          const { getUnifiedMemory } = await import('../../kernel/unified-memory.js');
+          const um = getUnifiedMemory();
+          if (!um.isInitialized()) await um.initialize();
+          um.getDatabase()
+            .prepare(`INSERT OR REPLACE INTO kv_store (namespace, key, value) VALUES ('arena', ?, ?)`)
+            .run(`run:${result.seed}:${result.target}`, JSON.stringify(result));
+        } catch (persistError) {
+          console.error(chalk.dim(`  note: run not persisted (${toErrorMessage(persistError)})`));
+        }
+
+        if (options.json) {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+
+        const byId = new Map(result.strategies.map((s) => [s.id, s]));
+        console.log(chalk.blue(`\n  Arena: ${result.target} · seed ${result.seed} · ${result.mutantsTotal} mutants\n`));
+        console.log('  rank  id   kill-rate  coverage  cost  fitness  groups');
+        result.ranking.forEach((id, i) => {
+          const s = byId.get(id)!;
+          const cov = s.coveragePct === null ? '   n/a' : `${s.coveragePct.toFixed(2)}%`.padStart(7);
+          console.log(
+            `  ${String(i + 1).padEnd(5)}${s.id.padEnd(5)}` +
+            `${(s.killRate * 100).toFixed(1).padStart(6)}%   ${cov}   ${s.suiteCostRatio.toFixed(2).padEnd(6)}` +
+            `${s.fitness.toFixed(4).padEnd(9)}${s.name}` +
+            (s.baselinePassed ? '' : chalk.red('  [baseline FAILED]'))
+          );
+        });
+        console.log(`\n  competitive array (row beats column = 1):`);
+        const ids = result.strategies.map((s) => s.id);
+        console.log(`        ${ids.map((i) => i.padEnd(4)).join('')}`);
+        result.competitiveArray.forEach((row, i) => {
+          console.log(`    ${ids[i].padEnd(4)}${row.map((v) => String(v).padStart(2).padEnd(4)).join('')}`);
+        });
+        if (result.evolution.length > 0) {
+          console.log(`\n  evolution:`);
+          for (const e of result.evolution) {
+            console.log(`    step ${e.step}: [${e.groups.join('+')}] fitness ${e.fitness.toFixed(4)} ${e.accepted ? chalk.green('accepted') : 'rejected'}`);
+          }
+        }
+        const winner = byId.get(result.ranking[0])!;
+        console.log(chalk.green(`\n  winner: ${winner.id} [${winner.name}] — kill ${(winner.killRate * 100).toFixed(1)}%, fitness ${winner.fitness.toFixed(4)}\n`));
+      } catch (error) {
+        console.error(chalk.red(`  ✗ ${toErrorMessage(error)}`));
+        await cleanupAndExit(1);
+      }
+    });
+
+  arena
+    .command('list')
+    .description('List persisted arena runs')
+    .option('--json', 'Output as JSON')
+    .action(async (options) => {
+      if (!await ensureInitialized()) return;
+      try {
+        const { getUnifiedMemory } = await import('../../kernel/unified-memory.js');
+        const um = getUnifiedMemory();
+        if (!um.isInitialized()) await um.initialize();
+        const rows = um.getDatabase()
+          .prepare(`SELECT key, value FROM kv_store WHERE namespace = 'arena' ORDER BY key`)
+          .all() as Array<{ key: string; value: string }>;
+        if (options.json) {
+          console.log(JSON.stringify(rows.map((r) => ({ key: r.key, result: JSON.parse(r.value) })), null, 2));
+          return;
+        }
+        if (rows.length === 0) {
+          console.log(chalk.yellow('  no persisted arena runs'));
+          return;
+        }
+        for (const row of rows) {
+          const r = JSON.parse(row.value) as { ranking: string[]; mutantsTotal: number; strategies: Array<{ id: string; name: string; fitness: number }> };
+          const winner = r.strategies.find((s) => s.id === r.ranking[0]);
+          console.log(`  ${chalk.green(row.key)} — winner ${winner?.id} [${winner?.name}] fitness ${winner?.fitness}`);
+        }
+      } catch (error) {
+        console.error(chalk.red(`  ✗ ${toErrorMessage(error)}`));
+        await cleanupAndExit(1);
+      }
+    });
+
+  return arena;
+}

--- a/src/cli/commands/hooks-handlers/command-hooks.ts
+++ b/src/cli/commands/hooks-handlers/command-hooks.ts
@@ -22,6 +22,11 @@ import {
   printSuccess,
   printError,
 } from './hooks-shared.js';
+import {
+  ToolLoopGuardrail,
+  createProjectToolLoopGuardrail,
+  type ToolLoopCheck,
+} from './tool-loop-guardrail.js';
 
 /**
  * Detect test framework from a Bash command. Returns null when no recognized
@@ -244,6 +249,34 @@ export function registerCommandHooks(hooks: Command): void {
           .filter(p => p.pattern.test(command))
           .map(p => p.reason);
 
+        // ADR-100: tool-loop circuit breaker — flag commands that keep
+        // failing consecutively (state recorded by post-command). Fail-open.
+        let loopCheck: ToolLoopCheck | null = null;
+        try {
+          loopCheck = createProjectToolLoopGuardrail(findProjectRoot()).check(command);
+        } catch { /* guardrail must never break the hook */ }
+
+        if (loopCheck && loopCheck.verdict === 'block' && ToolLoopGuardrail.isStrict()) {
+          // Strict mode: deny like a dangerous command
+          if (options.json) {
+            printJson({
+              hookSpecificOutput: {
+                hookEventName: 'PreToolUse',
+                permissionDecision: 'deny',
+                permissionDecisionReason: `Tool-loop breaker (AQE_STRICT_TOOL_LOOP): ${loopCheck.hint}`,
+              },
+            });
+          } else {
+            printError(`Blocked by tool-loop breaker: ${loopCheck.hint}`);
+          }
+          return;
+        }
+        if (loopCheck && loopCheck.verdict === 'block') {
+          warnings.push(`🛑 TOOL-LOOP BREAKER: ${loopCheck.hint}`);
+        } else if (loopCheck && loopCheck.verdict === 'warn') {
+          warnings.push(`Tool-loop breaker: ${loopCheck.hint}`);
+        }
+
         if (dangerMatch) {
           // BLOCK the command
           if (options.json) {
@@ -307,6 +340,12 @@ export function registerCommandHooks(hooks: Command): void {
         const success = options.success === 'true' || options.success === true;
         const exitCode = options.exitCode ? parseInt(options.exitCode, 10) : (success ? 0 : 1);
         const command = (options.command || '').substring(0, 200);
+
+        // ADR-100: feed the tool-loop breaker — success resets, failure
+        // increments. Synchronous sidecar write; fail-open.
+        try {
+          createProjectToolLoopGuardrail(findProjectRoot()).record(command, success);
+        } catch { /* guardrail must never break the hook */ }
 
         // Determine if this is a test/build/lint command for richer learning
         const isTestCmd = /\b(test|vitest|jest|pytest|mocha)\b/i.test(command);

--- a/src/cli/commands/hooks-handlers/command-hooks.ts
+++ b/src/cli/commands/hooks-handlers/command-hooks.ts
@@ -195,7 +195,7 @@ export function registerCommandHooks(hooks: Command): void {
         }
 
         return;
-      } catch (error) {
+      } catch {
         // On error, allow (fail-open for non-critical guard)
         if (options.json) {
           printJson({
@@ -311,7 +311,7 @@ export function registerCommandHooks(hooks: Command): void {
         }
 
         return;
-      } catch (error) {
+      } catch {
         // Fail-open on error
         if (options.json) {
           printJson({

--- a/src/cli/commands/hooks-handlers/hooks-dream-learning.ts
+++ b/src/cli/commands/hooks-handlers/hooks-dream-learning.ts
@@ -340,6 +340,10 @@ export async function persistTaskOutcome(opts: {
   domain?: string;
   success: boolean;
   durationMs?: number;
+  /** ADR-101: agent that spawned this task (nesting provenance) */
+  parentAgentId?: string;
+  /** ADR-101: nesting depth, 0 = top-level */
+  depth?: number;
 }): Promise<TaskOutcomeResult> {
   const { getUnifiedMemory } = await import('../../../kernel/unified-memory.js');
   const um = getUnifiedMemory();
@@ -348,6 +352,47 @@ export async function persistTaskOutcome(opts: {
   }
   const db = um.getDatabase();
   try { db.pragma('busy_timeout = 60000'); } catch { /* hook-side patient timeout (ADR-001 / patch 260) */ }
+
+  // Fresh-project fix (found by ADR-101 E2E): captured_experiences is created
+  // by the experience-capture middleware, not the unified schema — on a fresh
+  // .agentic-qe the whole Stream B transaction silently failed against the
+  // missing table. Same canonical DDL as experience-replay.ts ensureSchema.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS captured_experiences (
+      id TEXT PRIMARY KEY,
+      task TEXT NOT NULL,
+      agent TEXT NOT NULL,
+      domain TEXT NOT NULL DEFAULT '',
+      success INTEGER NOT NULL DEFAULT 0,
+      quality REAL NOT NULL DEFAULT 0.5,
+      duration_ms INTEGER NOT NULL DEFAULT 0,
+      model_tier INTEGER,
+      routing_json TEXT,
+      steps_json TEXT,
+      result_json TEXT,
+      error TEXT,
+      started_at TEXT NOT NULL DEFAULT (datetime('now')),
+      completed_at TEXT NOT NULL DEFAULT (datetime('now')),
+      source TEXT DEFAULT 'middleware',
+      application_count INTEGER DEFAULT 0,
+      avg_token_savings REAL DEFAULT 0,
+      embedding BLOB,
+      embedding_dimension INTEGER,
+      tags TEXT,
+      last_applied_at TEXT
+    );
+    CREATE TABLE IF NOT EXISTS experience_applications (
+      id TEXT PRIMARY KEY,
+      experience_id TEXT NOT NULL,
+      task TEXT NOT NULL,
+      success INTEGER NOT NULL,
+      tokens_saved INTEGER DEFAULT 0,
+      feedback TEXT,
+      applied_at TEXT DEFAULT (datetime('now')),
+      FOREIGN KEY (experience_id) REFERENCES captured_experiences(id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_exp_apps_experience ON experience_applications(experience_id);
+  `);
 
   const experienceId = `exp-${Date.now()}-${randomUUID().slice(0, 8)}`;
   const taskField = `${opts.agent}:${opts.taskId}`;
@@ -509,10 +554,19 @@ export async function persistTaskOutcome(opts: {
     }
 
     // 5. Single-step qe_trajectories row
+    // ADR-101: nesting provenance lands in the metadata_json blob (stage 1 —
+    // no dedicated columns / schema migration)
     const trajId = `traj-${Date.now()}-${randomUUID().slice(0, 8)}`;
+    const provenanceJson =
+      opts.parentAgentId !== undefined || opts.depth !== undefined
+        ? JSON.stringify({
+            ...(opts.parentAgentId !== undefined ? { parentAgentId: opts.parentAgentId } : {}),
+            ...(opts.depth !== undefined ? { depth: opts.depth } : {}),
+          })
+        : null;
     db.prepare(`
-      INSERT INTO qe_trajectories (id, task, agent, domain, started_at, ended_at, success, steps_json)
-      VALUES (?, ?, ?, ?, datetime('now'), datetime('now'), ?, ?)
+      INSERT INTO qe_trajectories (id, task, agent, domain, started_at, ended_at, success, steps_json, metadata_json)
+      VALUES (?, ?, ?, ?, datetime('now'), datetime('now'), ?, ?, ?)
     `).run(
       trajId,
       taskField,
@@ -520,6 +574,7 @@ export async function persistTaskOutcome(opts: {
       opts.domain ?? 'general',
       opts.success ? 1 : 0,
       JSON.stringify([{ step: 1, task: opts.taskId, success: opts.success }]),
+      provenanceJson,
     );
 
     // 6. Multi-step stitch — siblings sharing the same suffix taskId in the

--- a/src/cli/commands/hooks-handlers/nesting-provenance.ts
+++ b/src/cli/commands/hooks-handlers/nesting-provenance.ts
@@ -1,0 +1,65 @@
+/**
+ * Agentic QE v3 - Nested-Subagent Provenance Validation (ADR-101)
+ *
+ * Parses and validates the `--parent-agent-id` / `--depth` flags on
+ * `aqe hooks post-task`. Anthropic announced nested subagent support
+ * (depth=5) on 2026-06-09; recording which agent spawned a task and at
+ * what depth lets ReasoningBank segment patterns per hierarchy level —
+ * useful today for flat depth-1 spawns, and ready for deep chains the
+ * day the upstream `Task` denylist lifts.
+ */
+
+/** Agent identifiers: alphanum start, then alphanum / _ . : - , max 128 chars */
+const AGENT_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$/;
+
+/** Defensive bound — well above Anthropic's announced depth=5 cap */
+export const MAX_NESTING_DEPTH = 32;
+
+export interface NestingProvenance {
+  parentAgentId?: string;
+  depth?: number;
+}
+
+export interface NestingProvenanceResult extends NestingProvenance {
+  /** Set when validation failed; the caller should reject the invocation */
+  error?: string;
+}
+
+/**
+ * Validate raw flag values. Both flags are optional and independent;
+ * depth=0 is a valid value (top-level) and must survive as 0, not be
+ * coerced to undefined.
+ */
+export function parseNestingProvenance(
+  parentAgentIdRaw?: string,
+  depthRaw?: string | number
+): NestingProvenanceResult {
+  const result: NestingProvenanceResult = {};
+
+  if (parentAgentIdRaw !== undefined) {
+    if (!AGENT_ID_RE.test(parentAgentIdRaw)) {
+      return {
+        error:
+          `Invalid --parent-agent-id "${parentAgentIdRaw}": must start with a letter or digit ` +
+          `and contain only letters, digits, "_", ".", ":", "-" (max 128 chars)`,
+      };
+    }
+    result.parentAgentId = parentAgentIdRaw;
+  }
+
+  if (depthRaw !== undefined) {
+    const depth = typeof depthRaw === 'number' ? depthRaw : Number(depthRaw);
+    if (!Number.isInteger(depth)) {
+      return { error: `Invalid --depth "${depthRaw}": must be an integer` };
+    }
+    if (depth < 0) {
+      return { error: `Invalid --depth ${depth}: must be >= 0` };
+    }
+    if (depth > MAX_NESTING_DEPTH) {
+      return { error: `Invalid --depth ${depth}: must be <= ${MAX_NESTING_DEPTH}` };
+    }
+    result.depth = depth;
+  }
+
+  return result;
+}

--- a/src/cli/commands/hooks-handlers/task-hooks.ts
+++ b/src/cli/commands/hooks-handlers/task-hooks.ts
@@ -26,6 +26,7 @@ import {
 import { ensureRoutingOutcomesAdr095Columns } from '../../../routing/routing-outcomes-migration.js';
 import { deriveTaskType } from '../../../learning/agent-routing.js';
 import { detectQEDomains } from '../../../learning/qe-patterns.js';
+import { parseNestingProvenance } from './nesting-provenance.js';
 
 // ============================================================================
 // Constants — task-bridge / routing-quality / q-learning
@@ -359,10 +360,24 @@ export function registerTaskHooks(hooks: Command): void {
     .option('--agent <name>', 'Agent that executed the task')
     .option('--duration <ms>', 'Task duration in milliseconds')
     .option('-d, --description <desc>', 'Task description — fallback Q-state source when pre-task bridge is absent (issue #499)')
+    .option('--parent-agent-id <id>', 'Agent that spawned this task (ADR-101 nesting provenance)')
+    .option('--depth <n>', 'Nesting depth of this task, 0 = top-level (ADR-101)')
     .option('--json', 'Output as JSON')
     .action(async (options) => {
       try {
         const success = options.success === 'true' || options.success === true;
+
+        // ADR-101: validate nesting provenance before any persistence
+        const provenance = parseNestingProvenance(options.parentAgentId, options.depth);
+        if (provenance.error) {
+          if (options.json) {
+            console.log(JSON.stringify({ success: false, error: provenance.error }));
+          } else {
+            console.error(chalk.red(`  ✗ ${provenance.error}`));
+          }
+          process.exitCode = 1;
+          return;
+        }
 
         // Initialize hooks system and record learning outcome
         // BUG FIX: Must call getHooksSystem() FIRST to initialize, not check state.initialized
@@ -397,11 +412,16 @@ export function registerTaskHooks(hooks: Command): void {
             const agent = options.agent || 'unknown';
             const durationMs = options.duration ? parseInt(options.duration, 10) : 0;
 
+            // ADR-101: provenance rides in the feedback string so the
+            // learning loop can segment patterns per hierarchy level
+            const provenanceSuffix =
+              (provenance.parentAgentId ? `, Parent: ${provenance.parentAgentId}` : '') +
+              (provenance.depth !== undefined ? `, Depth: ${provenance.depth}` : '');
             await reasoningBank.recordOutcome({
               patternId: `task:${agent}:${effectiveTaskId}`,
               success,
               metrics: { executionTimeMs: durationMs },
-              feedback: `Agent: ${agent}, Task: ${effectiveTaskId}`,
+              feedback: `Agent: ${agent}, Task: ${effectiveTaskId}${provenanceSuffix}`,
             });
 
             // Stream B: full experience pipeline (captured_experiences,
@@ -413,6 +433,8 @@ export function registerTaskHooks(hooks: Command): void {
               agent,
               durationMs,
               success,
+              parentAgentId: provenance.parentAgentId,
+              depth: provenance.depth,
             });
 
             // Issue #460: when --agent arrives empty (Claude Code does not

--- a/src/cli/commands/hooks-handlers/tool-loop-guardrail.ts
+++ b/src/cli/commands/hooks-handlers/tool-loop-guardrail.ts
@@ -1,0 +1,188 @@
+/**
+ * Agentic QE v3 - Tool-Loop Circuit Breaker (ADR-100)
+ *
+ * Detects consecutive failures of the same Bash command across hook
+ * invocations and breaks runaway retry loops: WARN at 3, BLOCK at 5.
+ * Advisory by default (the block is a strongly-worded recommendation in
+ * the hook output); `AQE_STRICT_TOOL_LOOP=1` upgrades the block to a
+ * PreToolUse deny.
+ *
+ * Mirrors the closed → open → half-open semantics of
+ * `src/coordination/circuit-breaker/domain-circuit-breaker.ts` (ADR-064),
+ * but persists state in a small JSON sidecar instead of process memory:
+ * every hook call is a fresh CLI process, so in-process state cannot see
+ * the previous invocation, and opening memory.db from pre-command would
+ * add DB-init latency to every Bash command. The sidecar is ephemeral
+ * guardrail state — safe to delete at any time, not a data store.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+export type ToolLoopVerdict = 'allow' | 'warn' | 'block';
+
+export interface ToolLoopCheck {
+  verdict: ToolLoopVerdict;
+  consecutiveFailures: number;
+  /** True when an open breaker is being given a probe attempt (half-open) */
+  halfOpen: boolean;
+  /** Human-readable guidance for warn/block verdicts */
+  hint?: string;
+}
+
+interface BreakerEntry {
+  consecutiveFailures: number;
+  lastFailureAt: number;
+}
+
+type ToolLoopState = Record<string, BreakerEntry>;
+
+export interface ToolLoopGuardrailOptions {
+  /** Path of the JSON state sidecar */
+  statePath: string;
+  /** Consecutive failures before warning (default 3) */
+  warnThreshold?: number;
+  /** Consecutive failures before blocking (default 5) */
+  blockThreshold?: number;
+  /** An open breaker allows one probe attempt after this long (default 2 min) */
+  halfOpenAfterMs?: number;
+  /** Entries idle longer than this are pruned (default 30 min) */
+  staleAfterMs?: number;
+}
+
+export class ToolLoopGuardrail {
+  private readonly statePath: string;
+  private readonly warnThreshold: number;
+  private readonly blockThreshold: number;
+  private readonly halfOpenAfterMs: number;
+  private readonly staleAfterMs: number;
+
+  constructor(options: ToolLoopGuardrailOptions) {
+    this.statePath = options.statePath;
+    this.warnThreshold = options.warnThreshold ?? 3;
+    this.blockThreshold = options.blockThreshold ?? 5;
+    this.halfOpenAfterMs = options.halfOpenAfterMs ?? 120_000;
+    this.staleAfterMs = options.staleAfterMs ?? 30 * 60_000;
+  }
+
+  /**
+   * Normalize a command into a breaker key: whitespace-collapsed and
+   * length-capped so cosmetic differences don't split the failure count.
+   */
+  static signature(command: string): string {
+    return command.trim().replace(/\s+/g, ' ').slice(0, 200);
+  }
+
+  /**
+   * Consult the breaker before a command runs (pre-command hook).
+   * Fail-open: any state-read problem yields 'allow'.
+   */
+  check(command: string, now: number = Date.now()): ToolLoopCheck {
+    const sig = ToolLoopGuardrail.signature(command);
+    if (!sig) {
+      return { verdict: 'allow', consecutiveFailures: 0, halfOpen: false };
+    }
+
+    const entry = this.readState()[sig];
+    if (!entry || entry.consecutiveFailures < this.warnThreshold) {
+      return { verdict: 'allow', consecutiveFailures: entry?.consecutiveFailures ?? 0, halfOpen: false };
+    }
+
+    const failures = entry.consecutiveFailures;
+
+    if (failures >= this.blockThreshold) {
+      // Open breaker: allow a single probe once the half-open window elapses
+      if (now - entry.lastFailureAt >= this.halfOpenAfterMs) {
+        return {
+          verdict: 'warn',
+          consecutiveFailures: failures,
+          halfOpen: true,
+          hint:
+            `This command has failed ${failures}x consecutively; allowing one probe attempt. ` +
+            `If it fails again it will be flagged immediately.`,
+        };
+      }
+      return {
+        verdict: 'block',
+        consecutiveFailures: failures,
+        halfOpen: false,
+        hint:
+          `The same command failed ${failures}x consecutively. Re-running it unchanged is ` +
+          `unlikely to succeed — inspect the error output, change the approach, or fix the ` +
+          `underlying problem first. (A successful run resets this breaker.)`,
+      };
+    }
+
+    return {
+      verdict: 'warn',
+      consecutiveFailures: failures,
+      halfOpen: false,
+      hint: `This command has failed ${failures}x consecutively — consider changing approach before retrying.`,
+    };
+  }
+
+  /**
+   * Record a command outcome (post-command hook). Success resets the
+   * breaker for that command; failure increments it. Fail-open on errors.
+   */
+  record(command: string, success: boolean, now: number = Date.now()): void {
+    const sig = ToolLoopGuardrail.signature(command);
+    if (!sig) return;
+
+    try {
+      const state = this.readState();
+
+      if (success) {
+        if (state[sig]) {
+          delete state[sig];
+          this.writeState(state, now);
+        }
+        return;
+      }
+
+      const entry = state[sig] ?? { consecutiveFailures: 0, lastFailureAt: now };
+      entry.consecutiveFailures += 1;
+      entry.lastFailureAt = now;
+      state[sig] = entry;
+      this.writeState(state, now);
+    } catch {
+      /* fail-open: guardrail must never break the hook */
+    }
+  }
+
+  /** Whether strict mode upgrades the advisory block to a hook deny. */
+  static isStrict(env: NodeJS.ProcessEnv = process.env): boolean {
+    return env.AQE_STRICT_TOOL_LOOP === '1' || env.AQE_STRICT_TOOL_LOOP === 'true';
+  }
+
+  private readState(): ToolLoopState {
+    try {
+      const raw = fs.readFileSync(this.statePath, 'utf8');
+      const parsed = JSON.parse(raw) as ToolLoopState;
+      return typeof parsed === 'object' && parsed !== null ? parsed : {};
+    } catch {
+      return {}; // missing or corrupt sidecar → clean slate
+    }
+  }
+
+  private writeState(state: ToolLoopState, now: number): void {
+    // Prune stale entries so the sidecar stays small
+    for (const [key, entry] of Object.entries(state)) {
+      if (now - entry.lastFailureAt > this.staleAfterMs) {
+        delete state[key];
+      }
+    }
+    fs.mkdirSync(path.dirname(this.statePath), { recursive: true });
+    fs.writeFileSync(this.statePath, JSON.stringify(state));
+  }
+}
+
+/**
+ * Guardrail bound to the project's `.agentic-qe/` directory — the shared
+ * instance used by the pre-command/post-command hooks.
+ */
+export function createProjectToolLoopGuardrail(projectRoot: string): ToolLoopGuardrail {
+  return new ToolLoopGuardrail({
+    statePath: path.join(projectRoot, '.agentic-qe', 'tool-loop-state.json'),
+  });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -343,6 +343,11 @@ registerLazyCommand(program, {
   factory: () => import('./commands/security.js').then(m => m.createSecurityCommand(context, cleanupAndExit, ensureInitialized)),
 });
 registerLazyCommand(program, {
+  name: 'arena',
+  description: 'Competitive test-strategy tournaments (ADR-104)',
+  factory: () => import('./commands/arena.js').then(m => m.createArenaCommand(context, cleanupAndExit, ensureInitialized)),
+});
+registerLazyCommand(program, {
   name: 'code',
   description: 'Code intelligence analysis',
   factory: () => import('./commands/code.js').then(m => m.createCodeCommand(context, cleanupAndExit, ensureInitialized)),

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -169,6 +169,19 @@ async function autoInitialize(): Promise<void> {
   );
   await context.queen.initialize();
 
+  // Bridge the CLI-initialized components into the MCP handlers' fleet state.
+  // The memory/agent/task/team/pipeline handlers are shared between the MCP
+  // server and the CLI and are guarded by isFleetInitialized(); without this
+  // bridge every CLI invocation failed with "Fleet not initialized" even
+  // after a successful auto-init (MCP-CLI parity).
+  const { adoptExternalFleet } = await import('../mcp/handlers/core-handlers.js');
+  adoptExternalFleet({
+    kernel: context.kernel,
+    queen: context.queen,
+    router: context.router,
+    workflowOrchestrator: context.workflowOrchestrator,
+  });
+
   context.initialized = true;
 }
 

--- a/src/contracts/verdicts.ts
+++ b/src/contracts/verdicts.ts
@@ -1,0 +1,235 @@
+/**
+ * Agentic QE v3 - Structured Verdict Contracts (ADR-103)
+ *
+ * Typed, versioned verdict envelopes for agent-to-agent and MCP-boundary
+ * handoffs: RiskDecision (quality gates), FindingVerdict (review findings
+ * with adversarial refutations), CoverageGap (risk-weighted gap reports).
+ *
+ * Validators are dependency-free and are the source of truth; the exported
+ * JSON Schemas (published to schemas/*.schema.json by
+ * scripts/generate-verdict-schemas.mjs) mirror them for external tooling
+ * (ajv, workflow agent() schema option). Envelopes are versioned and
+ * additive-only within a major version: consumers must tolerate unknown
+ * fields, so schemas keep `additionalProperties: true`.
+ */
+
+export const VERDICT_CONTRACT_VERSION = '1.0' as const;
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type RiskDecisionOutcome = 'approve' | 'block' | 'escalate';
+
+export interface RiskDecision {
+  /** Envelope discriminator + version */
+  contract: 'risk-decision@1';
+  decision: RiskDecisionOutcome;
+  riskFactors: string[];
+  /** 0..1 */
+  confidence: number;
+  rationale: string;
+}
+
+export type FindingSeverity = 'critical' | 'high' | 'medium' | 'low' | 'info';
+export type FindingOutcome = 'upheld' | 'refuted' | 'uncertain';
+
+export interface FindingVerdict {
+  contract: 'finding-verdict@1';
+  id: string;
+  title: string;
+  file?: string;
+  severity: FindingSeverity;
+  /** 0..1 */
+  confidence: number;
+  evidence: string[];
+  verdict: FindingOutcome;
+  /** One entry per refuter that voted to refute (empty when none) */
+  refutations: string[];
+}
+
+export interface CoverageGap {
+  contract: 'coverage-gap@1';
+  file: string;
+  /** 1-based inclusive line range; omit for whole-file gaps */
+  rangeStart?: number;
+  rangeEnd?: number;
+  /** 0..1 risk weighting */
+  riskScore: number;
+  suggestedTests: string[];
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+// ============================================================================
+// Validators (dependency-free, boundary-grade)
+// ============================================================================
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function isStringArray(v: unknown): v is string[] {
+  return Array.isArray(v) && v.every((x) => typeof x === 'string');
+}
+
+function inUnitRange(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v) && v >= 0 && v <= 1;
+}
+
+export function validateRiskDecision(value: unknown): ValidationResult {
+  const errors: string[] = [];
+  if (!isRecord(value)) return { valid: false, errors: ['not an object'] };
+  if (value.contract !== 'risk-decision@1') errors.push(`contract must be "risk-decision@1"`);
+  if (!['approve', 'block', 'escalate'].includes(value.decision as string)) {
+    errors.push('decision must be approve|block|escalate');
+  }
+  if (!isStringArray(value.riskFactors)) errors.push('riskFactors must be string[]');
+  if (!inUnitRange(value.confidence)) errors.push('confidence must be a number in [0,1]');
+  if (typeof value.rationale !== 'string' || value.rationale.length === 0) {
+    errors.push('rationale must be a non-empty string');
+  }
+  return { valid: errors.length === 0, errors };
+}
+
+export function validateFindingVerdict(value: unknown): ValidationResult {
+  const errors: string[] = [];
+  if (!isRecord(value)) return { valid: false, errors: ['not an object'] };
+  if (value.contract !== 'finding-verdict@1') errors.push(`contract must be "finding-verdict@1"`);
+  if (typeof value.id !== 'string' || value.id.length === 0) errors.push('id must be a non-empty string');
+  if (typeof value.title !== 'string' || value.title.length === 0) errors.push('title must be a non-empty string');
+  if (value.file !== undefined && typeof value.file !== 'string') errors.push('file must be a string when present');
+  if (!['critical', 'high', 'medium', 'low', 'info'].includes(value.severity as string)) {
+    errors.push('severity must be critical|high|medium|low|info');
+  }
+  if (!inUnitRange(value.confidence)) errors.push('confidence must be a number in [0,1]');
+  if (!isStringArray(value.evidence)) errors.push('evidence must be string[]');
+  if (!['upheld', 'refuted', 'uncertain'].includes(value.verdict as string)) {
+    errors.push('verdict must be upheld|refuted|uncertain');
+  }
+  if (!isStringArray(value.refutations)) errors.push('refutations must be string[]');
+  return { valid: errors.length === 0, errors };
+}
+
+export function validateCoverageGap(value: unknown): ValidationResult {
+  const errors: string[] = [];
+  if (!isRecord(value)) return { valid: false, errors: ['not an object'] };
+  if (value.contract !== 'coverage-gap@1') errors.push(`contract must be "coverage-gap@1"`);
+  if (typeof value.file !== 'string' || value.file.length === 0) errors.push('file must be a non-empty string');
+  for (const k of ['rangeStart', 'rangeEnd'] as const) {
+    const v = value[k];
+    if (v !== undefined && (!Number.isInteger(v) || (v as number) < 1)) {
+      errors.push(`${k} must be a positive integer when present`);
+    }
+  }
+  if (
+    Number.isInteger(value.rangeStart) &&
+    Number.isInteger(value.rangeEnd) &&
+    (value.rangeEnd as number) < (value.rangeStart as number)
+  ) {
+    errors.push('rangeEnd must be >= rangeStart');
+  }
+  if (!inUnitRange(value.riskScore)) errors.push('riskScore must be a number in [0,1]');
+  if (!isStringArray(value.suggestedTests)) errors.push('suggestedTests must be string[]');
+  return { valid: errors.length === 0, errors };
+}
+
+// ============================================================================
+// Builders — derive contract envelopes at MCP boundaries
+// ============================================================================
+
+/**
+ * Derive a RiskDecision from a quality-gate outcome (quality_assess boundary).
+ * Indeterminate gates (passed undefined) escalate rather than guess.
+ */
+export function buildRiskDecisionFromQualityGate(input: {
+  passed?: boolean;
+  qualityScore?: number;
+  recommendations?: string[];
+}): RiskDecision {
+  const { passed, qualityScore, recommendations = [] } = input;
+  const decision: RiskDecisionOutcome =
+    passed === true ? 'approve' : passed === false ? 'block' : 'escalate';
+  return {
+    contract: 'risk-decision@1',
+    decision,
+    riskFactors: recommendations.slice(0, 10),
+    confidence: decision === 'escalate' ? 0.5 : 0.9,
+    rationale:
+      decision === 'escalate'
+        ? 'Quality gate outcome indeterminate — manual review required'
+        : `Quality gate ${passed ? 'passed' : 'failed'}${
+            typeof qualityScore === 'number' ? ` with score ${qualityScore}` : ''
+          }`,
+  };
+}
+
+// ============================================================================
+// JSON Schemas (draft-07) — mirrors of the validators above, published to
+// schemas/*.schema.json for ajv / workflow agent({schema}) consumers
+// ============================================================================
+
+const unit = { type: 'number', minimum: 0, maximum: 1 } as const;
+const stringArray = { type: 'array', items: { type: 'string' } } as const;
+
+export const RISK_DECISION_SCHEMA = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  $id: 'https://agentic-qe.dev/schemas/risk-decision.schema.json',
+  title: 'RiskDecision',
+  type: 'object',
+  required: ['contract', 'decision', 'riskFactors', 'confidence', 'rationale'],
+  additionalProperties: true,
+  properties: {
+    contract: { const: 'risk-decision@1' },
+    decision: { enum: ['approve', 'block', 'escalate'] },
+    riskFactors: stringArray,
+    confidence: unit,
+    rationale: { type: 'string', minLength: 1 },
+  },
+} as const;
+
+export const FINDING_VERDICT_SCHEMA = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  $id: 'https://agentic-qe.dev/schemas/finding-verdict.schema.json',
+  title: 'FindingVerdict',
+  type: 'object',
+  required: ['contract', 'id', 'title', 'severity', 'confidence', 'evidence', 'verdict', 'refutations'],
+  additionalProperties: true,
+  properties: {
+    contract: { const: 'finding-verdict@1' },
+    id: { type: 'string', minLength: 1 },
+    title: { type: 'string', minLength: 1 },
+    file: { type: 'string' },
+    severity: { enum: ['critical', 'high', 'medium', 'low', 'info'] },
+    confidence: unit,
+    evidence: stringArray,
+    verdict: { enum: ['upheld', 'refuted', 'uncertain'] },
+    refutations: stringArray,
+  },
+} as const;
+
+export const COVERAGE_GAP_SCHEMA = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  $id: 'https://agentic-qe.dev/schemas/coverage-gap.schema.json',
+  title: 'CoverageGap',
+  type: 'object',
+  required: ['contract', 'file', 'riskScore', 'suggestedTests'],
+  additionalProperties: true,
+  properties: {
+    contract: { const: 'coverage-gap@1' },
+    file: { type: 'string', minLength: 1 },
+    rangeStart: { type: 'integer', minimum: 1 },
+    rangeEnd: { type: 'integer', minimum: 1 },
+    riskScore: unit,
+    suggestedTests: stringArray,
+  },
+} as const;
+
+export const VERDICT_SCHEMAS = {
+  'risk-decision': RISK_DECISION_SCHEMA,
+  'finding-verdict': FINDING_VERDICT_SCHEMA,
+  'coverage-gap': COVERAGE_GAP_SCHEMA,
+} as const;

--- a/src/coordination/queen-types.ts
+++ b/src/coordination/queen-types.ts
@@ -75,6 +75,10 @@ export interface TaskExecution {
   readonly result?: unknown;
   readonly error?: string;
   readonly retryCount: number;
+  /** ADR-101: agent that spawned this task (nested-subagent provenance) */
+  readonly parentAgentId?: string;
+  /** ADR-101: nesting depth, 0 = top-level (Anthropic cap is 5; bound is 32) */
+  readonly depth?: number;
 }
 
 /**

--- a/src/integrations/agentic-flow/reasoning-bank/experience-replay.ts
+++ b/src/integrations/agentic-flow/reasoning-bank/experience-replay.ts
@@ -26,6 +26,7 @@ import { CircularBuffer } from '../../../shared/utils/circular-buffer.js';
 import { HNSWEmbeddingIndex } from '../../embeddings/index/HNSWIndex.js';
 import type { IEmbedding } from '../../embeddings/base/types.js';
 import { safeJsonParse } from '../../../shared/safe-json.js';
+import { scrubReasoningBlocks } from '../../../shared/reasoning-scrub.js';
 import { ExperienceConsolidator } from '../../../learning/experience-consolidation.js';
 import { getRuVectorFeatureFlags } from '../../ruvector/feature-flags.js';
 import { ReservoirReplayBuffer } from '../../ruvector/reservoir-replay.js';
@@ -283,7 +284,8 @@ export class ExperienceReplay {
         `);
         let written = 0;
         for (const row of ghosts) {
-          const text = `${row.domain ?? ''}: ${row.task}`.slice(0, 512);
+          // ADR-099: legacy rows may predate ingestion-time scrubbing
+          const text = scrubReasoningBlocks(`${row.domain ?? ''}: ${row.task}`).slice(0, 512);
           const embedding = await computeRealEmbedding(text);
           const buf = Buffer.from(new Float32Array(embedding).buffer);
           updateStmt.run(buf, embedding.length, row.id);
@@ -328,7 +330,8 @@ export class ExperienceReplay {
         const updateStmt = this.db.prepare(`UPDATE qe_trajectories SET embedding = ? WHERE id = ?`);
         let written = 0;
         for (const row of rows) {
-          const text = `${row.domain ?? ''}: ${row.task}`.slice(0, 512);
+          // ADR-099: legacy rows may predate ingestion-time scrubbing
+          const text = scrubReasoningBlocks(`${row.domain ?? ''}: ${row.task}`).slice(0, 512);
           const embedding = await computeRealEmbedding(text);
           updateStmt.run(Buffer.from(new Float32Array(embedding).buffer), row.id);
           written++;
@@ -558,12 +561,16 @@ export class ExperienceReplay {
     }
 
     // Extract key actions
+    // ADR-099: scrub reasoning scratchpad blocks so neither the stored
+    // experience nor its embedding carries extended-thinking text
+    const task = scrubReasoningBlocks(trajectory.task);
+    strategy = scrubReasoningBlocks(strategy);
     const keyActions = trajectory.steps
       .filter(s => s.result.outcome === 'success')
-      .map(s => s.action);
+      .map(s => scrubReasoningBlocks(s.action));
 
     // Generate embedding for similarity search
-    const embeddingText = `${trajectory.task} ${strategy} ${keyActions.join(' ')}`;
+    const embeddingText = `${task} ${strategy} ${keyActions.join(' ')}`;
     const embedding = await computeRealEmbedding(embeddingText, this.config.embedding);
 
     const id = uuidv4();
@@ -572,7 +579,7 @@ export class ExperienceReplay {
     const experience: Experience = {
       id,
       trajectoryId: trajectory.id,
-      task: trajectory.task,
+      task,
       domain,
       strategy,
       keyActions,
@@ -592,7 +599,7 @@ export class ExperienceReplay {
       const embeddingBuffer = embedding ? this.floatArrayToBuffer(embedding) : null;
       insertStmt.run(
         id,
-        trajectory.task,
+        task,
         strategy, // agent column stores strategy
         domain,
         trajectory.metrics.efficiencyScore,
@@ -761,6 +768,8 @@ export class ExperienceReplay {
     }
 
     // Generate embedding for the task
+    // ADR-099: scrub so query embeddings match the scrubbed stored embeddings
+    task = scrubReasoningBlocks(task);
     const taskEmbedding = await computeRealEmbedding(task, this.config.embedding);
 
     // Create query embedding for HNSW search

--- a/src/integrations/agentic-flow/reasoning-bank/trajectory-tracker.ts
+++ b/src/integrations/agentic-flow/reasoning-bank/trajectory-tracker.ts
@@ -14,6 +14,7 @@ import { getUnifiedMemory, type UnifiedMemoryManager } from '../../../kernel/uni
 import type { QEDomain } from '../../../learning/qe-patterns.js';
 import { CircularBuffer } from '../../../shared/utils/circular-buffer.js';
 import { safeJsonParse } from '../../../shared/safe-json.js';
+import { scrubReasoningBlocks, scrubReasoningDeep } from '../../../shared/reasoning-scrub.js';
 
 // ============================================================================
 // Types
@@ -446,6 +447,10 @@ export class TrajectoryTracker {
   async startTrajectory(task: string, options: TrajectoryOptions = {}): Promise<string> {
     this.ensureInitialized();
 
+    // ADR-099: strip reasoning scratchpad blocks before the task text enters
+    // persistence and (later) embedding generation
+    task = scrubReasoningBlocks(task);
+
     const id = uuidv4();
     const startedAt = new Date();
 
@@ -520,6 +525,15 @@ export class TrajectoryTracker {
 
     const stepId = uuidv4();
     const quality = options.quality ?? this.calculateStepQuality(result);
+
+    // ADR-099: scrub reasoning blocks from step content before it is held
+    // in memory (distilled into experiences at endTrajectory) and persisted
+    action = scrubReasoningBlocks(action);
+    result = {
+      ...result,
+      data: result.data ? scrubReasoningDeep(result.data) : result.data,
+      error: result.error ? scrubReasoningBlocks(result.error) : result.error,
+    };
 
     const step: TrajectoryStep = {
       id: stepId,

--- a/src/mcp/handlers/core-handlers.ts
+++ b/src/mcp/handlers/core-handlers.ts
@@ -94,6 +94,43 @@ export function isFleetInitialized(): boolean {
 }
 
 /**
+ * Adopt already-initialized components into the fleet state.
+ *
+ * The CLI's autoInitialize() builds the same kernel/queen/router stack as
+ * handleFleetInit but kept it in its own CLIContext, so every handler guarded
+ * by isFleetInitialized() (memory, agent, task, team, pipeline) rejected CLI
+ * invocations with "Fleet not initialized" even after a successful auto-init.
+ * Bridging the components here gives the MCP server and the CLI one shared
+ * fleet state (MCP-CLI parity).
+ *
+ * Idempotent: if a fleet is already initialized, returns the existing fleetId
+ * without touching state.
+ */
+export function adoptExternalFleet(components: {
+  kernel: QEKernel;
+  queen: QueenCoordinator;
+  router?: CrossDomainEventRouter | null;
+  workflowOrchestrator?: WorkflowOrchestrator | null;
+  topology?: TopologyType;
+}): string {
+  if (isFleetInitialized()) {
+    return state.fleetId!;
+  }
+
+  state.fleetId = `fleet-${uuidv4().slice(0, 8)}`;
+  state.kernel = components.kernel;
+  state.queen = components.queen;
+  state.router = components.router ?? null;
+  state.workflowOrchestrator = components.workflowOrchestrator ?? null;
+  state.initialized = true;
+  state.initTime = new Date();
+  state.topology = components.topology ?? 'hierarchical';
+  state.agentLevels.clear();
+
+  return state.fleetId;
+}
+
+/**
  * Get the current fleet topology
  */
 export function getFleetTopology(): TopologyType {

--- a/src/mcp/handlers/domain-handler-configs.ts
+++ b/src/mcp/handlers/domain-handler-configs.ts
@@ -35,6 +35,11 @@ import {
   type SupportedLanguage,
   type TestFramework,
 } from '../../shared/types/test-frameworks.js';
+import {
+  buildRiskDecisionFromQualityGate,
+  validateRiskDecision,
+  type RiskDecision,
+} from '../../contracts/verdicts.js';
 
 const SUPPORTED_LANGUAGES = Object.keys(DEFAULT_FRAMEWORKS) as SupportedLanguage[];
 
@@ -92,6 +97,8 @@ export interface QualityAssessResult {
   recommendations: string[];
   duration: number;
   savedFiles?: string[];
+  /** ADR-103: versioned, schema-validated gate verdict (additive) */
+  riskDecision?: RiskDecision;
 }
 
 export interface SecurityScanResult {
@@ -551,16 +558,27 @@ export const qualityAssessConfig: DomainHandlerConfig<QualityAssessParams, Quali
     compiledContext: routingResult?.compiledContext,
   }),
 
-  mapToResult: (taskId, data, duration, savedFiles) => ({
-    taskId,
-    status: 'completed',
-    qualityScore: (data.qualityScore as number) || 0,
-    passed: (data.passed as boolean) || false,
-    metrics: (data.metrics as Record<string, number>) || {},
-    recommendations: (data.recommendations as string[]) || [],
-    duration,
-    savedFiles,
-  }),
+  mapToResult: (taskId, data, duration, savedFiles) => {
+    // ADR-103: attach a schema-validated RiskDecision envelope at the MCP
+    // boundary (additive — existing fields unchanged). Omit rather than
+    // emit an invalid envelope.
+    const riskDecision = buildRiskDecisionFromQualityGate({
+      passed: typeof data.passed === 'boolean' ? data.passed : undefined,
+      qualityScore: data.qualityScore as number | undefined,
+      recommendations: (data.recommendations as string[]) || [],
+    });
+    return {
+      taskId,
+      status: 'completed',
+      qualityScore: (data.qualityScore as number) || 0,
+      passed: (data.passed as boolean) || false,
+      metrics: (data.metrics as Record<string, number>) || {},
+      recommendations: (data.recommendations as string[]) || [],
+      duration,
+      savedFiles,
+      ...(validateRiskDecision(riskDecision).valid ? { riskDecision } : {}),
+    };
+  },
 };
 
 // ============================================================================

--- a/src/shared/llm/cost-tracker.ts
+++ b/src/shared/llm/cost-tracker.ts
@@ -153,8 +153,13 @@ export class CostTracker {
       };
     }
 
-    // Convert from per-million to actual cost
-    const inputCost = (usage.promptTokens / 1_000_000) * pricing.input;
+    // Convert from per-million to actual cost.
+    // ADR-088: cache reads bill at ~0.1x input rate, cache writes at ~1.25x
+    // (5-minute TTL); promptTokens already excludes both.
+    const inputCost =
+      (usage.promptTokens / 1_000_000) * pricing.input +
+      ((usage.cacheReadTokens ?? 0) / 1_000_000) * pricing.input * 0.1 +
+      ((usage.cacheCreationTokens ?? 0) / 1_000_000) * pricing.input * 1.25;
     const outputCost = (usage.completionTokens / 1_000_000) * pricing.output;
 
     return {

--- a/src/shared/llm/interfaces.ts
+++ b/src/shared/llm/interfaces.ts
@@ -38,6 +38,10 @@ export interface TokenUsage {
   promptTokens: number;
   completionTokens: number;
   totalTokens: number;
+  /** ADR-088: tokens written to the prompt cache this request (billed ~1.25x input rate) */
+  cacheCreationTokens?: number;
+  /** ADR-088: tokens served from the prompt cache this request (billed ~0.1x input rate) */
+  cacheReadTokens?: number;
 }
 
 /**

--- a/src/shared/llm/providers/claude.ts
+++ b/src/shared/llm/providers/claude.ts
@@ -56,6 +56,10 @@ interface ClaudeMessageResponse {
   usage: {
     input_tokens: number;
     output_tokens: number;
+    /** Present when a cache_control breakpoint wrote to the prompt cache */
+    cache_creation_input_tokens?: number;
+    /** Present when a prefix was served from the prompt cache */
+    cache_read_input_tokens?: number;
   };
 }
 
@@ -190,7 +194,15 @@ export class ClaudeProvider implements LLMProvider {
     };
 
     if (options?.systemPrompt) {
-      body.system = options.systemPrompt;
+      // ADR-088: when caching is enabled, send the system prompt as a
+      // content-block array with an ephemeral cache breakpoint — repeated
+      // calls within the TTL read the cached prefix at ~0.1x input price.
+      // Anthropic-native provider only (ADR-092: other providers untouched).
+      // Note: prefixes below the model's minimum (1024-4096 tokens) silently
+      // don't cache; the breakpoint is harmless in that case.
+      body.system = this.config.enableCache !== false
+        ? [{ type: 'text', text: options.systemPrompt, cache_control: { type: 'ephemeral' } }]
+        : options.systemPrompt;
     }
 
     if (options?.stopSequences && options.stopSequences.length > 0) {
@@ -243,10 +255,17 @@ export class ClaudeProvider implements LLMProvider {
 
       const data = await response.json() as ClaudeMessageResponse;
 
+      // ADR-088: input_tokens is the uncached remainder only — cache
+      // read/creation tokens are reported separately by the API.
+      const cacheCreationTokens = data.usage.cache_creation_input_tokens ?? 0;
+      const cacheReadTokens = data.usage.cache_read_input_tokens ?? 0;
       const usage: TokenUsage = {
         promptTokens: data.usage.input_tokens,
         completionTokens: data.usage.output_tokens,
-        totalTokens: data.usage.input_tokens + data.usage.output_tokens,
+        totalTokens:
+          data.usage.input_tokens + cacheCreationTokens + cacheReadTokens + data.usage.output_tokens,
+        cacheCreationTokens,
+        cacheReadTokens,
       };
 
       const cost = CostTracker.calculateCost(model, usage);

--- a/src/shared/reasoning-scrub.ts
+++ b/src/shared/reasoning-scrub.ts
@@ -1,0 +1,83 @@
+/**
+ * Agentic QE v3 - Reasoning-Tag Scrubber (ADR-099)
+ *
+ * Strips extended-thinking blocks (<think>, <thinking>, <reasoning>,
+ * <REASONING_SCRATCHPAD>) from text before it enters the learning pipeline —
+ * pattern distillation, trajectory persistence, and embedding generation.
+ *
+ * Why: reasoning-capable models (Fable 5 era) emit large scratchpad blocks
+ * inside task results and step actions. Embedding them verbatim contaminates
+ * the 384-dim pattern vectors in memory.db, degrading HNSW retrieval quality
+ * (the scratchpad dominates the signal of what the step actually did).
+ *
+ * Boundary-gated: only well-formed `<tag ...> ... </tag>` pairs are removed.
+ * Prose that merely *mentions* a tag name (e.g. documentation about
+ * "<thinking> blocks") without a closing tag is left intact.
+ */
+
+/**
+ * Tag names treated as reasoning scratchpads. Matched case-insensitively
+ * as whole tag names (open tag may carry attributes).
+ */
+const REASONING_TAG_NAMES = ['think', 'thinking', 'reasoning', 'reasoning_scratchpad'] as const;
+
+/**
+ * One alternation per tag, each backreference-paired so an open tag is only
+ * consumed when its own matching close tag exists. Non-greedy body keeps
+ * adjacent blocks separate. The `\s*` before `>` tolerates `</thinking >`.
+ */
+const REASONING_BLOCK_RE = new RegExp(
+  `<(${REASONING_TAG_NAMES.join('|')})(?:\\s[^>]*)?>[\\s\\S]*?</\\1\\s*>`,
+  'gi'
+);
+
+/**
+ * Remove reasoning scratchpad blocks from text destined for the learning
+ * pipeline. Collapses the whitespace gap a removed block leaves behind so
+ * surrounding prose re-joins cleanly. Non-string / empty input returns as-is.
+ */
+export function scrubReasoningBlocks(text: string): string {
+  if (!text || typeof text !== 'string' || !text.includes('<')) {
+    return text;
+  }
+
+  let out = text;
+  // Repeat until stable: removing an inner block can expose an outer pair
+  // (e.g. <thinking><thinking>…</thinking></thinking>).
+  for (let i = 0; i < 5; i++) {
+    const next = out.replace(REASONING_BLOCK_RE, ' ');
+    if (next === out) break;
+    out = next;
+  }
+
+  // If nothing was removed, return the original text untouched (don't
+  // re-format whitespace of clean input).
+  if (out === text) {
+    return text;
+  }
+
+  // Collapse the space runs left where blocks were removed; preserve newlines.
+  return out.replace(/[ \t]{2,}/g, ' ').trim();
+}
+
+/**
+ * Scrub a value that may be a string or a JSON-serializable structure whose
+ * string leaves may contain reasoning blocks. Non-objects pass through.
+ * Used for trajectory step `result.data` payloads serialized into memory.db.
+ */
+export function scrubReasoningDeep<T>(value: T): T {
+  if (typeof value === 'string') {
+    return scrubReasoningBlocks(value) as unknown as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((v) => scrubReasoningDeep(v)) as unknown as T;
+  }
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = scrubReasoningDeep(v);
+    }
+    return out as unknown as T;
+  }
+  return value;
+}

--- a/tests/unit/arena/arena.test.ts
+++ b/tests/unit/arena/arena.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit + integration tests for qe-arena Phase 1 (ADR-104)
+ *
+ * Pure pieces (rng, mutator, strategy building) are tested directly;
+ * the integration test runs the REAL engine against the committed demo
+ * fixture with `node --test` — no native modules involved, no simulation.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { mulberry32, sample } from '../../../src/arena/rng';
+import { enumerateMutants, applyMutant } from '../../../src/arena/mutator';
+import { buildStrategies, runArena, type ArenaResult } from '../../../src/arena/arena';
+
+const FIXTURE = path.resolve(__dirname, '../../../fixtures/arena-demo');
+
+describe('mulberry32', () => {
+  it('should produce the same sequence for the same seed', () => {
+    const a = mulberry32(42);
+    const b = mulberry32(42);
+
+    expect([a(), a(), a()]).toEqual([b(), b(), b()]);
+  });
+
+  it('should produce different sequences for different seeds', () => {
+    expect(mulberry32(42)()).not.toBe(mulberry32(43)());
+  });
+
+  it('should sample deterministically', () => {
+    const items = ['a', 'b', 'c', 'd', 'e'];
+
+    expect(sample(mulberry32(7), items, 3)).toEqual(sample(mulberry32(7), items, 3));
+  });
+});
+
+describe('enumerateMutants', () => {
+  const source = fs.readFileSync(path.join(FIXTURE, 'src/pricing.mjs'), 'utf8');
+
+  it('should enumerate a stable, position-sorted mutant list', () => {
+    const a = enumerateMutants(source, 'pricing');
+    const b = enumerateMutants(source, 'pricing');
+
+    expect(a.length).toBeGreaterThan(10);
+    expect(a).toEqual(b);
+    expect([...a].sort((x, y) => x.index - y.index)).toEqual(a);
+  });
+
+  it('should not mutate inside string literals', () => {
+    const mutants = enumerateMutants(source, 'pricing');
+    const msgIndex = source.indexOf('price must be >= 0');
+
+    const inString = mutants.filter(
+      (m) => m.index >= msgIndex && m.index < msgIndex + 'price must be >= 0'.length
+    );
+    expect(inString).toEqual([]);
+  });
+
+  it('should not mutate the > of an arrow function', () => {
+    const arrowSource = 'const f = (x) => x > 1;';
+
+    const mutants = enumerateMutants(arrowSource, 't');
+
+    expect(mutants.some((m) => m.index === arrowSource.indexOf('=>') + 1)).toBe(false);
+    expect(mutants.some((m) => m.from === '>' && m.index === arrowSource.indexOf('x > 1') + 2)).toBe(true);
+  });
+
+  it('should apply a mutant as an exact splice', () => {
+    const src = 'if (a === b) { c = a + b; }';
+    const mutants = enumerateMutants(src, 't');
+    const eq = mutants.find((m) => m.from === '===')!;
+
+    expect(applyMutant(src, eq)).toBe('if (a !== b) { c = a + b; }');
+  });
+});
+
+describe('buildStrategies', () => {
+  it('should always lead with the full suite and be seed-deterministic', () => {
+    const groups = ['boundary', 'errors', 'exhaustive', 'happy'];
+
+    const a = buildStrategies(groups, 4, mulberry32(42));
+    const b = buildStrategies(groups, 4, mulberry32(42));
+
+    expect(a[0].groups).toEqual(['boundary', 'errors', 'exhaustive', 'happy']);
+    expect(a).toEqual(b);
+    expect(new Set(a.map((s) => s.name)).size).toBe(a.length);
+  });
+});
+
+describe('runArena (real engine, demo fixture)', { timeout: 180_000 }, () => {
+  const stripNondeterministic = (r: ArenaResult) => {
+    const { informational: _informational, ...deterministic } = r;
+    return deterministic;
+  };
+
+  it('should be byte-reproducible under the same seed (excluding wall-clock)', () => {
+    const opts = { target: FIXTURE, strategies: 3, seed: 42, maxMutants: 6 };
+
+    const first = runArena(opts);
+    const second = runArena(opts);
+
+    expect(stripNondeterministic(second)).toEqual(stripNondeterministic(first));
+  });
+
+  it('should rank the full suite at or above the weakest subset on kill rate', () => {
+    const result = runArena({ target: FIXTURE, strategies: 3, seed: 42, maxMutants: 6 });
+
+    const full = result.strategies.find((s) => s.id === 's1')!;
+    expect(full.baselinePassed).toBe(true);
+    expect(full.mutantsTotal).toBe(6);
+    for (const s of result.strategies) {
+      expect(full.killRate).toBeGreaterThanOrEqual(s.killRate * 0.999);
+    }
+    // competitive array is antisymmetric with a zero diagonal
+    result.competitiveArray.forEach((row, i) => {
+      expect(row[i]).toBe(0);
+      row.forEach((v, j) => expect(v + result.competitiveArray[j][i]).toBe(0));
+    });
+  });
+});

--- a/tests/unit/cli/hooks/nesting-provenance.test.ts
+++ b/tests/unit/cli/hooks/nesting-provenance.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Unit tests for nested-subagent provenance validation (ADR-101)
+ *
+ * Mirrors ruflo's ADR-147 P2 validation suite: propagation, omission,
+ * depth=0 boundary, invalid id, negative / non-integer / >32 depth.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  parseNestingProvenance,
+  MAX_NESTING_DEPTH,
+} from '../../../../src/cli/commands/hooks-handlers/nesting-provenance';
+
+describe('parseNestingProvenance', () => {
+  it('should propagate parentAgentId and depth when both are supplied', () => {
+    const result = parseNestingProvenance('qe-fleet-commander', '2');
+
+    expect(result.error).toBeUndefined();
+    expect(result.parentAgentId).toBe('qe-fleet-commander');
+    expect(result.depth).toBe(2);
+  });
+
+  it('should omit both fields when neither is supplied (top-level lead)', () => {
+    const result = parseNestingProvenance(undefined, undefined);
+
+    expect(result.error).toBeUndefined();
+    expect(result.parentAgentId).toBeUndefined();
+    expect(result.depth).toBeUndefined();
+  });
+
+  it('should propagate depth=0 as 0, not coerce it to undefined', () => {
+    const result = parseNestingProvenance(undefined, '0');
+
+    expect(result.error).toBeUndefined();
+    expect(result.depth).toBe(0);
+  });
+
+  it('should reject an invalid parentAgentId', () => {
+    expect(parseNestingProvenance('bad id with spaces').error).toContain('parent-agent-id');
+    expect(parseNestingProvenance('-starts-with-dash').error).toContain('parent-agent-id');
+    expect(parseNestingProvenance('a'.repeat(129)).error).toContain('parent-agent-id');
+    expect(parseNestingProvenance('semi;colon').error).toContain('parent-agent-id');
+  });
+
+  it('should reject negative depth', () => {
+    const result = parseNestingProvenance(undefined, '-1');
+
+    expect(result.error).toContain('>= 0');
+  });
+
+  it('should reject non-integer depth', () => {
+    expect(parseNestingProvenance(undefined, '2.5').error).toContain('integer');
+    expect(parseNestingProvenance(undefined, 'two').error).toContain('integer');
+  });
+
+  it('should reject depth above the defensive bound and accept the bound itself', () => {
+    expect(parseNestingProvenance(undefined, '33').error).toContain('<= 32');
+    expect(parseNestingProvenance(undefined, String(MAX_NESTING_DEPTH)).depth).toBe(32);
+  });
+
+  it('should accept identifiers with dots, colons, dashes and underscores', () => {
+    const result = parseNestingProvenance('qe.fleet:commander_v3-1');
+
+    expect(result.error).toBeUndefined();
+    expect(result.parentAgentId).toBe('qe.fleet:commander_v3-1');
+  });
+});

--- a/tests/unit/cli/hooks/tool-loop-guardrail.test.ts
+++ b/tests/unit/cli/hooks/tool-loop-guardrail.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for the tool-loop circuit breaker (ADR-100)
+ *
+ * Consecutive failures of the same command: warn at 3, block at 5,
+ * reset on success, half-open probe after the window, strict-mode env flag.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ToolLoopGuardrail } from '../../../../src/cli/commands/hooks-handlers/tool-loop-guardrail';
+
+describe('ToolLoopGuardrail', () => {
+  let dir: string;
+  let guardrail: ToolLoopGuardrail;
+  const CMD = 'npm run definitely-broken';
+
+  const failTimes = (n: number, at: number = 1_000_000) => {
+    for (let i = 0; i < n; i++) {
+      guardrail.record(CMD, false, at + i);
+    }
+  };
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tool-loop-'));
+    guardrail = new ToolLoopGuardrail({
+      statePath: path.join(dir, 'tool-loop-state.json'),
+    });
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('should allow a command below the warn threshold', () => {
+    failTimes(2);
+
+    const check = guardrail.check(CMD, 1_000_010);
+
+    expect(check.verdict).toBe('allow');
+    expect(check.consecutiveFailures).toBe(2);
+  });
+
+  it('should warn at 3 consecutive failures', () => {
+    failTimes(3);
+
+    const check = guardrail.check(CMD, 1_000_010);
+
+    expect(check.verdict).toBe('warn');
+    expect(check.consecutiveFailures).toBe(3);
+    expect(check.hint).toContain('3x');
+  });
+
+  it('should block at 5 consecutive failures with a recovery hint', () => {
+    failTimes(5);
+
+    const check = guardrail.check(CMD, 1_000_010);
+
+    expect(check.verdict).toBe('block');
+    expect(check.consecutiveFailures).toBe(5);
+    expect(check.hint).toContain('change the approach');
+  });
+
+  it('should reset the breaker when the command succeeds', () => {
+    failTimes(5);
+    guardrail.record(CMD, true, 1_000_010);
+
+    const check = guardrail.check(CMD, 1_000_020);
+
+    expect(check.verdict).toBe('allow');
+    expect(check.consecutiveFailures).toBe(0);
+  });
+
+  it('should track distinct commands independently', () => {
+    failTimes(5);
+    guardrail.record('npm run other-task', false, 1_000_010);
+
+    expect(guardrail.check('npm run other-task', 1_000_020).verdict).toBe('allow');
+    expect(guardrail.check(CMD, 1_000_020).verdict).toBe('block');
+  });
+
+  it('should allow a half-open probe after the half-open window elapses', () => {
+    failTimes(5, 1_000_000);
+
+    const check = guardrail.check(CMD, 1_000_004 + 120_000);
+
+    expect(check.verdict).toBe('warn');
+    expect(check.halfOpen).toBe(true);
+    expect(check.hint).toContain('probe');
+  });
+
+  it('should treat whitespace-variant commands as the same signature', () => {
+    failTimes(5);
+
+    const check = guardrail.check('  npm   run definitely-broken ', 1_000_010);
+
+    expect(check.verdict).toBe('block');
+  });
+
+  it('should persist state across instances (fresh process per hook call)', () => {
+    failTimes(5);
+    const secondProcess = new ToolLoopGuardrail({
+      statePath: path.join(dir, 'tool-loop-state.json'),
+    });
+
+    expect(secondProcess.check(CMD, 1_000_010).verdict).toBe('block');
+  });
+
+  it('should fail open on a corrupt state file', () => {
+    fs.writeFileSync(path.join(dir, 'tool-loop-state.json'), '{not json');
+
+    const check = guardrail.check(CMD, 1_000_000);
+
+    expect(check.verdict).toBe('allow');
+  });
+
+  it('should report strict mode only when AQE_STRICT_TOOL_LOOP is set', () => {
+    expect(ToolLoopGuardrail.isStrict({} as NodeJS.ProcessEnv)).toBe(false);
+    expect(ToolLoopGuardrail.isStrict({ AQE_STRICT_TOOL_LOOP: '0' } as unknown as NodeJS.ProcessEnv)).toBe(false);
+    expect(ToolLoopGuardrail.isStrict({ AQE_STRICT_TOOL_LOOP: '1' } as unknown as NodeJS.ProcessEnv)).toBe(true);
+    expect(ToolLoopGuardrail.isStrict({ AQE_STRICT_TOOL_LOOP: 'true' } as unknown as NodeJS.ProcessEnv)).toBe(true);
+  });
+
+  it('should prune stale entries on write', () => {
+    failTimes(5, 1_000_000);
+    // A later failure of another command triggers a write 31 minutes on,
+    // pruning the stale CMD entry
+    guardrail.record('other', false, 1_000_000 + 31 * 60_000);
+
+    const check = guardrail.check(CMD, 1_000_000 + 31 * 60_000);
+
+    expect(check.verdict).toBe('allow');
+  });
+});

--- a/tests/unit/contracts/verdicts.test.ts
+++ b/tests/unit/contracts/verdicts.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Contract tests for verdict envelopes (ADR-103)
+ *
+ * Golden samples validate; mutated samples are rejected with field-level
+ * errors; the quality-gate builder always emits a valid envelope.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  validateRiskDecision,
+  validateFindingVerdict,
+  validateCoverageGap,
+  buildRiskDecisionFromQualityGate,
+  type RiskDecision,
+  type FindingVerdict,
+  type CoverageGap,
+} from '../../../src/contracts/verdicts';
+
+const goldenRiskDecision: RiskDecision = {
+  contract: 'risk-decision@1',
+  decision: 'block',
+  riskFactors: ['coverage below threshold', '3 critical complexity hotspots'],
+  confidence: 0.9,
+  rationale: 'Quality gate failed with score 61',
+};
+
+const goldenFindingVerdict: FindingVerdict = {
+  contract: 'finding-verdict@1',
+  id: 'find-001',
+  title: 'SQL injection in report filter',
+  file: 'src/reports/filter.ts',
+  severity: 'critical',
+  confidence: 0.85,
+  evidence: ['string concatenation at filter.ts:42', 'no parameterization'],
+  verdict: 'upheld',
+  refutations: [],
+};
+
+const goldenCoverageGap: CoverageGap = {
+  contract: 'coverage-gap@1',
+  file: 'src/billing/refund.ts',
+  rangeStart: 110,
+  rangeEnd: 152,
+  riskScore: 0.8,
+  suggestedTests: ['refund over original amount', 'refund on voided invoice'],
+};
+
+describe('validateRiskDecision', () => {
+  it('should accept the golden sample', () => {
+    expect(validateRiskDecision(goldenRiskDecision)).toEqual({ valid: true, errors: [] });
+  });
+
+  it('should accept unknown additional fields (additive envelope)', () => {
+    const result = validateRiskDecision({ ...goldenRiskDecision, futureField: 42 });
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('should reject an unknown decision value', () => {
+    const result = validateRiskDecision({ ...goldenRiskDecision, decision: 'maybe' });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.join()).toContain('decision');
+  });
+
+  it('should reject confidence above 1', () => {
+    const result = validateRiskDecision({ ...goldenRiskDecision, confidence: 1.2 });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.join()).toContain('confidence');
+  });
+
+  it('should reject a missing rationale', () => {
+    const { rationale: _omitted, ...rest } = goldenRiskDecision;
+
+    expect(validateRiskDecision(rest).valid).toBe(false);
+  });
+
+  it('should reject non-objects', () => {
+    expect(validateRiskDecision('approve').valid).toBe(false);
+    expect(validateRiskDecision(null).valid).toBe(false);
+  });
+});
+
+describe('validateFindingVerdict', () => {
+  it('should accept the golden sample', () => {
+    expect(validateFindingVerdict(goldenFindingVerdict)).toEqual({ valid: true, errors: [] });
+  });
+
+  it('should reject a missing severity', () => {
+    const { severity: _omitted, ...rest } = goldenFindingVerdict;
+
+    const result = validateFindingVerdict(rest);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.join()).toContain('severity');
+  });
+
+  it('should reject non-array evidence', () => {
+    const result = validateFindingVerdict({ ...goldenFindingVerdict, evidence: 'just one string' });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.join()).toContain('evidence');
+  });
+
+  it('should reject an unknown verdict value', () => {
+    expect(validateFindingVerdict({ ...goldenFindingVerdict, verdict: 'plausible' }).valid).toBe(false);
+  });
+});
+
+describe('validateCoverageGap', () => {
+  it('should accept the golden sample', () => {
+    expect(validateCoverageGap(goldenCoverageGap)).toEqual({ valid: true, errors: [] });
+  });
+
+  it('should accept a whole-file gap without a range', () => {
+    const { rangeStart: _s, rangeEnd: _e, ...rest } = goldenCoverageGap;
+
+    expect(validateCoverageGap(rest).valid).toBe(true);
+  });
+
+  it('should reject negative riskScore', () => {
+    expect(validateCoverageGap({ ...goldenCoverageGap, riskScore: -0.1 }).valid).toBe(false);
+  });
+
+  it('should reject an inverted range', () => {
+    const result = validateCoverageGap({ ...goldenCoverageGap, rangeStart: 200, rangeEnd: 100 });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.join()).toContain('rangeEnd');
+  });
+});
+
+describe('buildRiskDecisionFromQualityGate', () => {
+  it('should approve on a passed gate and validate', () => {
+    const decision = buildRiskDecisionFromQualityGate({ passed: true, qualityScore: 92 });
+
+    expect(decision.decision).toBe('approve');
+    expect(validateRiskDecision(decision).valid).toBe(true);
+  });
+
+  it('should block on a failed gate with recommendations as risk factors', () => {
+    const decision = buildRiskDecisionFromQualityGate({
+      passed: false,
+      qualityScore: 61,
+      recommendations: ['raise branch coverage'],
+    });
+
+    expect(decision.decision).toBe('block');
+    expect(decision.riskFactors).toEqual(['raise branch coverage']);
+    expect(validateRiskDecision(decision).valid).toBe(true);
+  });
+
+  it('should escalate when the gate outcome is indeterminate', () => {
+    const decision = buildRiskDecisionFromQualityGate({});
+
+    expect(decision.decision).toBe('escalate');
+    expect(decision.confidence).toBe(0.5);
+    expect(validateRiskDecision(decision).valid).toBe(true);
+  });
+});

--- a/tests/unit/mcp/handlers/core-handlers.test.ts
+++ b/tests/unit/mcp/handlers/core-handlers.test.ts
@@ -15,8 +15,11 @@ import {
   handleFleetHealth,
   getFleetState,
   isFleetInitialized,
+  adoptExternalFleet,
   disposeFleet,
 } from '../../../../src/mcp/handlers/core-handlers';
+import type { QEKernel } from '../../../../src/kernel/interfaces';
+import type { QueenCoordinator } from '../../../../src/coordination/queen-coordinator';
 import { resetUnifiedPersistence } from '../../../../src/kernel/unified-persistence';
 import type { FleetInitParams, FleetStatusParams, FleetHealthParams } from '../../../../src/mcp/types';
 
@@ -79,6 +82,83 @@ describe('Core Handlers', { timeout: 30000 }, () => {
       expect(state.kernel).not.toBeNull();
       expect(state.queen).not.toBeNull();
       expect(state.initTime).toBeInstanceOf(Date);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // adoptExternalFleet — CLI→MCP fleet-state bridge (MCP-CLI parity)
+  // --------------------------------------------------------------------------
+
+  describe('adoptExternalFleet', () => {
+    // Minimal stubs: disposeFleet() calls dispose() on adopted components
+    const makeStubComponents = () => ({
+      kernel: { dispose: vi.fn(async () => {}) } as unknown as QEKernel,
+      queen: { dispose: vi.fn(async () => {}) } as unknown as QueenCoordinator,
+    });
+
+    afterAll(async () => {
+      await disposeFleet();
+      resetUnifiedPersistence();
+    });
+
+    it('should mark the fleet initialized when adopting external components', async () => {
+      await disposeFleet();
+      const fleetId = adoptExternalFleet(makeStubComponents());
+
+      expect(isFleetInitialized()).toBe(true);
+      expect(fleetId).toMatch(/^fleet-/);
+    });
+
+    it('should expose adopted components via getFleetState', async () => {
+      await disposeFleet();
+      const components = makeStubComponents();
+
+      adoptExternalFleet(components);
+
+      const state = getFleetState();
+      expect(state.kernel).toBe(components.kernel);
+      expect(state.queen).toBe(components.queen);
+      expect(state.initTime).toBeInstanceOf(Date);
+    });
+
+    it('should default router and workflowOrchestrator to null when omitted', async () => {
+      await disposeFleet();
+
+      adoptExternalFleet(makeStubComponents());
+
+      const state = getFleetState();
+      expect(state.router).toBeNull();
+      expect(state.workflowOrchestrator).toBeNull();
+    });
+
+    it('should default topology to hierarchical when omitted', async () => {
+      await disposeFleet();
+
+      adoptExternalFleet(makeStubComponents());
+
+      expect(getFleetState().topology).toBe('hierarchical');
+    });
+
+    it('should be idempotent when a fleet was already adopted', async () => {
+      await disposeFleet();
+      const first = makeStubComponents();
+      const firstId = adoptExternalFleet(first);
+
+      const secondId = adoptExternalFleet(makeStubComponents());
+
+      expect(secondId).toBe(firstId);
+      expect(getFleetState().kernel).toBe(first.kernel);
+    });
+
+    it('should not clobber a fleet created by handleFleetInit', async () => {
+      await disposeFleet();
+      const initResult = await handleFleetInit({ memoryBackend: 'memory' });
+      const existingKernel = getFleetState().kernel;
+
+      const adoptedId = adoptExternalFleet(makeStubComponents());
+
+      expect(adoptedId).toBe(initResult.data?.fleetId);
+      expect(getFleetState().kernel).toBe(existingKernel);
     });
   });
 

--- a/tests/unit/shared/llm/providers.test.ts
+++ b/tests/unit/shared/llm/providers.test.ts
@@ -209,6 +209,90 @@ describe('ClaudeProvider', () => {
     });
   });
 
+  describe('prompt caching (ADR-088)', () => {
+    const successResponse = (usage: Record<string, number>) => ({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          id: 'msg_test',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'cached response' }],
+          model: 'claude-sonnet-4-6',
+          stop_reason: 'end_turn',
+          usage,
+        }),
+    });
+
+    it('should send system as content blocks with ephemeral cache_control when caching enabled (default)', async () => {
+      mockFetch.mockImplementationOnce((_url, options) => {
+        const body = JSON.parse((options as RequestInit).body as string);
+        expect(body.system).toEqual([
+          {
+            type: 'text',
+            text: 'You are a QE advisor',
+            cache_control: { type: 'ephemeral' },
+          },
+        ]);
+        return Promise.resolve(successResponse({ input_tokens: 10, output_tokens: 5 }));
+      });
+
+      await provider.generate('Test', { systemPrompt: 'You are a QE advisor' });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should send system as a plain string when enableCache is false', async () => {
+      const noCacheProvider = new ClaudeProvider({ apiKey: 'test-api-key', enableCache: false });
+      mockFetch.mockImplementationOnce((_url, options) => {
+        const body = JSON.parse((options as RequestInit).body as string);
+        expect(body.system).toBe('You are a QE advisor');
+        return Promise.resolve(successResponse({ input_tokens: 10, output_tokens: 5 }));
+      });
+
+      await noCacheProvider.generate('Test', { systemPrompt: 'You are a QE advisor' });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not send a system field when no systemPrompt is given', async () => {
+      mockFetch.mockImplementationOnce((_url, options) => {
+        const body = JSON.parse((options as RequestInit).body as string);
+        expect(body.system).toBeUndefined();
+        return Promise.resolve(successResponse({ input_tokens: 10, output_tokens: 5 }));
+      });
+
+      await provider.generate('Test');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should surface cache_read and cache_creation tokens in usage', async () => {
+      mockFetch.mockResolvedValueOnce(
+        successResponse({
+          input_tokens: 12,
+          output_tokens: 5,
+          cache_creation_input_tokens: 2000,
+          cache_read_input_tokens: 8000,
+        })
+      );
+
+      const response = await provider.generate('Test', { systemPrompt: 'big prompt' });
+
+      expect(response.usage.cacheCreationTokens).toBe(2000);
+      expect(response.usage.cacheReadTokens).toBe(8000);
+      // total = uncached input + cache write + cache read + output
+      expect(response.usage.totalTokens).toBe(12 + 2000 + 8000 + 5);
+    });
+
+    it('should default cache token fields to 0 when API omits them', async () => {
+      mockFetch.mockResolvedValueOnce(successResponse({ input_tokens: 10, output_tokens: 5 }));
+
+      const response = await provider.generate('Test');
+
+      expect(response.usage.cacheCreationTokens).toBe(0);
+      expect(response.usage.cacheReadTokens).toBe(0);
+      expect(response.usage.totalTokens).toBe(15);
+    });
+  });
+
   describe('embed', () => {
     it('should throw error as Claude does not support embeddings', async () => {
       await expect(provider.embed('test')).rejects.toMatchObject({

--- a/tests/unit/shared/reasoning-scrub.test.ts
+++ b/tests/unit/shared/reasoning-scrub.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Unit tests for reasoning-tag scrubber (ADR-099)
+ *
+ * The scrubber strips extended-thinking blocks from text before it enters
+ * the learning pipeline (trajectory persistence, distillation, embeddings).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { scrubReasoningBlocks, scrubReasoningDeep } from '../../../src/shared/reasoning-scrub';
+
+describe('scrubReasoningBlocks', () => {
+  it('should strip a thinking block and keep surrounding prose', () => {
+    const input = '<thinking>secret scratchpad</thinking>real outcome';
+
+    const result = scrubReasoningBlocks(input);
+
+    expect(result).toBe('real outcome');
+  });
+
+  it('should strip think, reasoning and REASONING_SCRATCHPAD blocks', () => {
+    const input =
+      'a <think>t1</think> b <reasoning>t2</reasoning> c <REASONING_SCRATCHPAD>t3</REASONING_SCRATCHPAD> d';
+
+    const result = scrubReasoningBlocks(input);
+
+    expect(result).toBe('a b c d');
+  });
+
+  it('should match tag names case-insensitively', () => {
+    const input = 'before <THINKING>upper</THINKING> after';
+
+    const result = scrubReasoningBlocks(input);
+
+    expect(result).toBe('before after');
+  });
+
+  it('should strip multiline blocks', () => {
+    const input = 'fix applied\n<thinking>\nline one\nline two\n</thinking>\ntests green';
+
+    const result = scrubReasoningBlocks(input);
+
+    expect(result).not.toContain('line one');
+    expect(result).toContain('fix applied');
+    expect(result).toContain('tests green');
+  });
+
+  it('should strip multiple separate blocks without merging their gap', () => {
+    const input = 'keep1 <thinking>a</thinking> keep2 <thinking>b</thinking> keep3';
+
+    const result = scrubReasoningBlocks(input);
+
+    expect(result).toBe('keep1 keep2 keep3');
+  });
+
+  it('should strip an open tag carrying attributes', () => {
+    const input = 'x <thinking signature="abc">hidden</thinking> y';
+
+    const result = scrubReasoningBlocks(input);
+
+    expect(result).toBe('x y');
+  });
+
+  it('should handle nested same-tag blocks via repeated passes', () => {
+    const input = 'a <thinking>outer <thinking>inner</thinking> tail</thinking> b';
+
+    const result = scrubReasoningBlocks(input);
+
+    expect(result).not.toContain('inner');
+    expect(result).not.toContain('outer');
+    expect(result).toContain('a');
+    expect(result).toContain('b');
+  });
+
+  it('should leave prose mentioning a tag without a closing tag intact (boundary-gated)', () => {
+    const input = 'the model emits <thinking> blocks which we strip before embedding';
+
+    const result = scrubReasoningBlocks(input);
+
+    expect(result).toBe(input);
+  });
+
+  it('should leave a lone closing tag intact', () => {
+    const input = 'stray </thinking> in prose';
+
+    const result = scrubReasoningBlocks(input);
+
+    expect(result).toBe(input);
+  });
+
+  it('should not touch non-reasoning tags', () => {
+    const input = '<div>markup</div> and <test>case</test> stay';
+
+    const result = scrubReasoningBlocks(input);
+
+    expect(result).toBe(input);
+  });
+
+  it('should return clean text unchanged (identity, no whitespace reflow)', () => {
+    const input = 'indented\n    code block\n  stays';
+
+    const result = scrubReasoningBlocks(input);
+
+    expect(result).toBe(input);
+  });
+
+  it('should return empty and non-string input as-is', () => {
+    expect(scrubReasoningBlocks('')).toBe('');
+    expect(scrubReasoningBlocks(undefined as unknown as string)).toBeUndefined();
+  });
+
+  it('should tolerate whitespace before > in the closing tag', () => {
+    const input = 'a <thinking>x</thinking > b';
+
+    const result = scrubReasoningBlocks(input);
+
+    expect(result).toBe('a b');
+  });
+});
+
+describe('scrubReasoningDeep', () => {
+  it('should scrub string leaves in nested objects and arrays', () => {
+    const input = {
+      summary: '<thinking>internal</thinking>done',
+      steps: ['ok', '<reasoning>why</reasoning>applied fix'],
+      nested: { note: 'plain' },
+      count: 3,
+    };
+
+    const result = scrubReasoningDeep(input);
+
+    expect(result.summary).toBe('done');
+    expect(result.steps[1]).toBe('applied fix');
+    expect(result.nested.note).toBe('plain');
+    expect(result.count).toBe(3);
+  });
+
+  it('should pass through null and primitives unchanged', () => {
+    expect(scrubReasoningDeep(null)).toBeNull();
+    expect(scrubReasoningDeep(42)).toBe(42);
+    expect(scrubReasoningDeep(true)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

The Fable 5 / harness-parity release (#520). Headline fix: `aqe memory|agent|task|team|pipeline` CLI commands worked for the **first time** (they always failed with "Fleet not initialized" — the CLI never registered its kernel with the shared handler fleet state). Plus: prompt caching actually engages (`enableCache` was dead code), extended-thinking blocks no longer contaminate pattern embeddings, a tool-loop circuit breaker in the Bash hooks, nested-subagent (depth-5) readiness with a committed probe, structured verdict contracts with published JSON schemas, adversarially verified QCSD reviews, and `aqe arena` competitive test-strategy tournaments. Seven improvements, ADR-099–104 + ADR-088 amendment, each with a reproduction-first verification record on #520.

## Verification

Build + typecheck (local):
```
CLI bundle built successfully (v3.10.5)
MCP bundle built successfully (v3.10.5)
> tsc --noEmit   (exit 0)
```

Unit suite (local, `--bail=0`) with baseline classification — this devcontainer bind-mounts macOS-native `better_sqlite3.node`, so sqlite-backed suites cannot run locally (documented env artifact):
```
branch (working-may): Test Files 66 failed | 525 passed (592) · Tests 1208 failed | 15838 passed (17066)
baseline (v3.10.4):   Test Files 65 failed | 521 passed (587) · Tests 1203 failed | 15771 passed (16994)
failed-file set diff: 1 file (tests/unit/learning/metrics-tracker.test.ts) — verified cwd artifact,
  PASSES (5/5) from a clean-cwd worktree of this same branch. Zero regressions attributable to this release.
```

Performance gate:
```
Total: 15 | Passed: 15 | Failed: 0 | Warnings: 0 — All performance gates PASSED
```

Packed-artifact verification (npm pack → install in isolated dir — fresh Linux natives, the exact bits users get):
```
aqe --version                       → 3.10.5
aqe init --auto (fresh project)     → exit 0, .agentic-qe/ + memory.db created
aqe status / health / learning stats / agent list → all respond (HNSW Native: ✓)
aqe memory store + get (headline fix, first time ever working from CLI):
  ✓ Stored "rel-test" in namespace "scratch" → get returns {"v":"3.10.5"}
aqe arena run --seed 42             → winner s1, kill 83.3%, fitness 0.6914 (reproducible)
```

`test:ci` runs in this PR's CI on a clean Linux runner — that is the authoritative full-suite gate per project policy (local sqlite suites are env-blocked as documented above).

## Failure modes

- **Live prompt-cache reads not verified end-to-end** (no `ANTHROPIC_API_KEY` in the dev env). Covered by request-serialization tests asserting the exact `cache_control` bytes and usage mapping; live command + the minimum-cacheable-prefix caveat documented in the #520 record and ADR-088. Tracking: #520.
- **QCSD workflow execution requires a Workflow-capable harness.** Fallback to the Task-tool protocol is documented in the skill (reports marked `verification: none`); non-Workflow users keep current behavior. Validated by live run `wf_254f1271-022` (15 raw findings → 14 confirmed / 1 killed by unanimous adversarial refutation).
- **qe-arena Phase 1 is fixture-scoped** (suite-selection strategies; LLM-generated strategies and MCP `arena_run` are Phase 2, tracked in ADR-104/#520). Reproducibility contract tested (byte-identical envelopes under the same seed; jitter-prone measured-runtime penalty was caught in verification and replaced with a deterministic term — see ADR-104).
- **Nested-subagent activation depends on Anthropic lifting the upstream Task denylist.** All shipped behavior is independently useful today; the committed probe (`docs/probes/`, verdict `NO_AGENT_TOOL`) is the regression test for the gate lifting. Tracking: ADR-101/#520.

---

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.** "Unlikely" is not an acceptable substitute. If you wrote "I don't think this can happen but...", that sentence is a failure mode and needs a test or an issue link.

### Optional context

- Linked issues: #520
- Trust tier change (if any): none
- Affects published API or CLI surface: yes (new `aqe arena` command; new post-task `--parent-agent-id`/`--depth` flags; additive `riskDecision` on `quality_assess`; `TokenUsage` gains optional cache fields)
- Touches the init flow / `npm-publish.yml` / `tests/fixtures/init-corpus/`: no

See [CHANGELOG](CHANGELOG.md) for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)