### PR TITLE
feat(init): database-free OpenCode install + MCP stdio client-compat fixes

### DIFF
--- a/src/cli/handlers/init-handler.ts
+++ b/src/cli/handlers/init-handler.ts
@@ -126,6 +126,26 @@ export class InitHandler implements ICommandHandler {
         return;
       }
 
+      // Platform provisioning (--with-opencode, --with-n8n, --with-<editor>, ...)
+      // and database-free mode (--no-database / --memory memory) are implemented
+      // ONLY in the modular orchestrator. The legacy runStandardInit path neither
+      // installs platform assets nor honors the in-memory backend (it boots the
+      // full kernel and writes .agentic-qe/memory.db). Route to modular so these
+      // flags actually take effect even without --auto.
+      const platformRequested = !!(
+        options.withOpencode || options.withN8n || options.withKiro ||
+        options.withCopilot || options.withCursor || options.withCline ||
+        options.withKilocode || options.withRoocode || options.withCodex ||
+        options.withWindsurf || options.withContinuedev || options.withAllPlatforms
+      );
+      const databaseFree = options.database === false || options.memory === 'memory';
+
+      if (options.modular || platformRequested || databaseFree) {
+        console.log(chalk.blue('\n  Agentic QE v3 Initialization\n'));
+        await this.runModularInit(options, context);
+        return;
+      }
+
       // Standard init without wizard
       await this.runStandardInit(options, context);
     } catch (error) {

--- a/src/cli/handlers/init-handler.ts
+++ b/src/cli/handlers/init-handler.ts
@@ -44,7 +44,8 @@ export class InitHandler implements ICommandHandler {
       .description(this.description)
       .option('-d, --domains <domains>', 'Comma-separated list of domains to enable', 'all')
       .option('-m, --max-agents <number>', 'Maximum concurrent agents', '15')
-      .option('--memory <backend>', 'Memory backend (sqlite|agentdb|hybrid)', 'hybrid')
+      .option('--memory <backend>', 'Memory backend (sqlite|agentdb|hybrid|memory). "memory" = database-free, in-memory only.', 'hybrid')
+      .option('--no-database', 'Database-free install: alias for `--memory memory`. Skips the SQLite database phase and runs any MCP server in-memory — nothing is written to .agentic-qe/.')
       .option('--lazy', 'Enable lazy loading of domains')
       .option('--wizard', 'Run interactive setup wizard')
       .option('--auto', 'Auto-configure based on project analysis')
@@ -136,6 +137,17 @@ export class InitHandler implements ICommandHandler {
   private async runModularInit(options: InitOptions, _context: CLIContext): Promise<void> {
     const isJsonMode = options.json === true;
 
+    // Database-free mode: `--no-database` or `--memory memory`. Skips the SQLite
+    // database phase and configures any MCP server to run in-memory. Export the
+    // backend env up-front so every subsystem spawned during init honors it.
+    const memoryOnly = options.database === false || options.memory === 'memory';
+    if (memoryOnly) {
+      process.env.AQE_MEMORY_BACKEND = 'memory';
+      if (!isJsonMode) {
+        console.log(chalk.gray('  Database-free mode: in-memory backend (no .agentic-qe/memory.db)\n'));
+      }
+    }
+
     const { createModularInitOrchestrator } = await import('../../init/orchestrator.js');
     const orchestrator = createModularInitOrchestrator({
       projectRoot: process.cwd(),
@@ -157,6 +169,7 @@ export class InitHandler implements ICommandHandler {
       withContinueDev: options.withContinuedev,
       noMcp: options.noMcp && !options.withMcp,
       noGovernance: options.noGovernance,
+      memoryBackend: memoryOnly ? 'memory' : undefined,
     });
 
     console.log(chalk.white('  Analyzing project...\n'));
@@ -557,6 +570,8 @@ interface InitOptions {
   domains: string;
   maxAgents: string;
   memory: string;
+  /** commander negatable flag: `--no-database` sets this to false. */
+  database?: boolean;
   lazy?: boolean;
   wizard?: boolean;
   auto?: boolean;

--- a/src/coordination/result-saver.ts
+++ b/src/coordination/result-saver.ts
@@ -149,6 +149,11 @@ export class ResultSaver {
     const timestamp = new Date();
     const files: SavedFile[] = [];
 
+    // Database-free mode (#534): do not write .agentic-qe/results/* to disk.
+    if (process.env.AQE_MEMORY_BACKEND === 'memory') {
+      return { taskId, taskType, timestamp, files, summary: this.extractSummary(taskType, result) };
+    }
+
     // Ensure directories exist
     await this.ensureDirectories(taskType);
 

--- a/src/domains/code-intelligence/coordinator-hypergraph.ts
+++ b/src/domains/code-intelligence/coordinator-hypergraph.ts
@@ -34,11 +34,16 @@ export async function initializeHypergraph(
   const path = await import('path');
   const { findProjectRoot } = await import('../../kernel/unified-memory.js');
   const projectRoot = findProjectRoot();
-  const dbPath = hypergraphDbPath || path.join(projectRoot, '.agentic-qe', 'memory.db');
+  // Database-free mode (#534): an ephemeral in-memory hypergraph DB, never the
+  // project's .agentic-qe/memory.db.
+  const inMemory = process.env.AQE_MEMORY_BACKEND === 'memory';
+  const dbPath = inMemory ? ':memory:' : (hypergraphDbPath || path.join(projectRoot, '.agentic-qe', 'memory.db'));
 
-  const dir = path.dirname(dbPath);
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
+  if (!inMemory) {
+    const dir = path.dirname(dbPath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
   }
 
   const db = openDatabase(dbPath);

--- a/src/domains/code-intelligence/coordinator.ts
+++ b/src/domains/code-intelligence/coordinator.ts
@@ -370,12 +370,17 @@ export class CodeIntelligenceCoordinator
       const path = await import('path');
       const { findProjectRoot } = await import('../../kernel/unified-memory.js');
       const projectRoot = findProjectRoot();
-      const dbPath = this.config.hypergraphDbPath || path.join(projectRoot, '.agentic-qe', 'memory.db');
+      // Database-free mode (#534): ephemeral in-memory hypergraph DB, never the
+      // project's .agentic-qe/memory.db.
+      const inMemory = process.env.AQE_MEMORY_BACKEND === 'memory';
+      const dbPath = inMemory ? ':memory:' : (this.config.hypergraphDbPath || path.join(projectRoot, '.agentic-qe', 'memory.db'));
 
       // Ensure directory exists
-      const dir = path.dirname(dbPath);
-      if (!fs.existsSync(dir)) {
-        fs.mkdirSync(dir, { recursive: true });
+      if (!inMemory) {
+        const dir = path.dirname(dbPath);
+        if (!fs.existsSync(dir)) {
+          fs.mkdirSync(dir, { recursive: true });
+        }
       }
 
       // Create database connection

--- a/src/init/opencode-installer.ts
+++ b/src/init/opencode-installer.ts
@@ -2,18 +2,31 @@
  * OpenCode Platform Installer
  * ADR-025: Enhanced Init with Self-Configuration
  *
- * Installs OpenCode agents, skills, tools, and permissions to user projects
- * when --with-opencode flag is used. Follows the N8n installer pattern.
+ * Installs OpenCode agents and skills to user projects in OpenCode's NATIVE
+ * on-disk format (validated against OpenCode CLI v1.17.x):
+ *   - agents -> .opencode/agent/<name>.md   (markdown + YAML frontmatter; body = system prompt)
+ *   - skills -> .opencode/skills/<name>/SKILL.md  (frontmatter name+description; body = instructions)
+ *   - MCP    -> opencode.json (mcp.agentic-qe local server)
+ *
+ * The shipped source assets under <pkg>/.opencode/{agents,skills} use AQE's own
+ * YAML schema (name/description/model/systemPrompt/tools/permissions). OpenCode
+ * does NOT load that schema, so this installer CONVERTS them at install time.
+ *
+ * Tools are intentionally NOT installed: AQE's .opencode/tools/*.ts use a custom
+ * `{name, parameters, execute}` shape and call ctx.callTool('mcp:agentic-qe:*'),
+ * which is incompatible with OpenCode's `tool()` API and redundant once the MCP
+ * server is connected (the underlying tools are exposed directly).
  */
 
 import {
   existsSync,
   mkdirSync,
   readdirSync,
+  readFileSync,
   writeFileSync,
-  copyFileSync,
 } from 'fs';
 import { join } from 'path';
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import { toErrorMessage } from '../shared/error-utils.js';
 import { findPackageRoot } from './find-package-root.js';
 
@@ -28,10 +41,21 @@ export interface OpenCodeInstallerOptions {
   installAgents?: boolean;
   /** Install OpenCode skill definitions (default: true) */
   installSkills?: boolean;
-  /** Install OpenCode tool wrappers (default: true) */
+  /**
+   * Install AQE tool wrappers. Default false — AQE's tool .ts files are not in
+   * OpenCode's `tool()` format and are redundant with the MCP server. Kept as an
+   * option only for backward compatibility; enabling it copies incompatible files.
+   */
   installTools?: boolean;
   /** Overwrite existing files (default: false) */
   overwrite?: boolean;
+  /**
+   * Memory backend the generated opencode.json MCP server should use at runtime.
+   * 'memory' => fully database-free install: AQE_MEMORY_BACKEND=memory and no
+   * AQE_MEMORY_PATH, so the MCP server keeps everything in-memory and writes
+   * nothing under .agentic-qe/. Default (undefined) preserves persistent SQLite.
+   */
+  memoryBackend?: 'memory' | 'sqlite' | 'agentdb' | 'hybrid';
 }
 
 export interface OpenCodeInstallResult {
@@ -43,6 +67,21 @@ export interface OpenCodeInstallResult {
   errors: string[];
   targetDir: string;
 }
+
+// OpenCode-valid per-agent permission keys. AQE keys outside this set are dropped
+// or remapped (see PERM_KEY_MAP). In particular `mcp:agentic-qe:*` patterns are
+// dropped — OpenCode does not interpret MCP tool patterns in the permission block.
+const VALID_PERMISSION_KEYS = new Set([
+  'read', 'edit', 'glob', 'grep', 'list', 'bash', 'task',
+  'external_directory', 'todowrite', 'webfetch', 'websearch',
+  'lsp', 'skill', 'question', 'doom_loop',
+]);
+
+// Remap AQE permission keys to OpenCode equivalents.
+const PERM_KEY_MAP: Record<string, string> = {
+  fetch: 'webfetch',
+  write: 'edit', // OpenCode has no separate 'write' permission; file writes are 'edit'
+};
 
 // ============================================================================
 // OpenCode Installer Class
@@ -58,7 +97,7 @@ export class OpenCodeInstaller {
     this.options = {
       installAgents: true,
       installSkills: true,
-      installTools: true,
+      installTools: false,
       overwrite: false,
       ...options,
     };
@@ -70,7 +109,7 @@ export class OpenCodeInstaller {
   // ==========================================================================
 
   /**
-   * Find the source .opencode/ directory containing agents/skills/tools to install.
+   * Find the source .opencode/ directory containing agents/skills to install.
    * Resolves relative to the package installation directory (not CWD) so that
    * globally-installed and bundled CLI paths all work correctly (#361).
    */
@@ -81,24 +120,20 @@ export class OpenCodeInstaller {
     const possiblePaths: string[] = [];
 
     if (pkgRoot) {
-      // OpenCode assets live at the package root .opencode/ directory
       possiblePaths.push(join(pkgRoot, '.opencode'));
     }
 
-    // Local install: in node_modules
     possiblePaths.push(
       join(this.projectRoot, 'node_modules/agentic-qe/.opencode'),
     );
 
     for (const path of possiblePaths) {
-      // Never use the target directory as the source
       if (path === targetDir) continue;
       if (this.isValidSourceDir(path)) {
         return path;
       }
     }
 
-    // Return the first package path even if not found — install() will report the error
     return possiblePaths[0] ?? join(this.projectRoot, 'node_modules/agentic-qe/.opencode');
   }
 
@@ -116,7 +151,7 @@ export class OpenCodeInstaller {
   // ==========================================================================
 
   /**
-   * Install OpenCode agents, skills, tools, and permissions
+   * Install OpenCode agents, skills, and MCP config (native OpenCode format).
    */
   async install(): Promise<OpenCodeInstallResult> {
     const targetDir = join(this.projectRoot, '.opencode');
@@ -137,33 +172,25 @@ export class OpenCodeInstaller {
         return result;
       }
 
-      // Install agents
+      // Per-agent permission overrides shipped in permissions.yaml (defaults +
+      // per-agent). Merged with each agent's own `permissions` field.
+      const permissionsYaml = this.loadPermissionsYaml();
+
       if (this.options.installAgents) {
-        const agentResult = this.installAgents(targetDir);
+        const agentResult = this.installAgents(targetDir, permissionsYaml);
         result.agentsInstalled = agentResult.installed;
         result.errors.push(...agentResult.errors);
+        // Per-agent permissions are folded into each agent's frontmatter.
+        result.permissionsInstalled = result.agentsInstalled.length > 0;
       }
 
-      // Install skills
       if (this.options.installSkills) {
         const skillResult = this.installSkills(targetDir);
         result.skillsInstalled = skillResult.installed;
         result.errors.push(...skillResult.errors);
       }
 
-      // Install tools
-      if (this.options.installTools) {
-        const toolResult = this.installTools(targetDir);
-        result.toolsInstalled = toolResult.installed;
-        result.errors.push(...toolResult.errors);
-      }
-
-      // Install permissions
-      const permResult = this.installPermissions(targetDir);
-      result.permissionsInstalled = permResult.installed;
-      result.errors.push(...permResult.errors);
-
-      // Generate opencode.json MCP config if not exists
+      // Generate opencode.json MCP config if not present.
       this.generateOpenCodeConfig();
     } catch (error) {
       result.success = false;
@@ -173,48 +200,113 @@ export class OpenCodeInstaller {
     return result;
   }
 
+  // ==========================================================================
+  // Permission helpers
+  // ==========================================================================
+
   /**
-   * Install agent YAML files from .opencode/agents/
+   * Load the shipped permissions.yaml (defaults + per-agent overrides). Returns
+   * { defaults, agents } or empty maps if the file is missing/unparseable.
    */
-  private installAgents(targetDir: string): { installed: string[]; errors: string[] } {
+  private loadPermissionsYaml(): { defaults: Record<string, unknown>; agents: Record<string, Record<string, unknown>> } {
+    const empty = { defaults: {}, agents: {} };
+    const file = join(this.sourceDir, 'permissions.yaml');
+    if (!existsSync(file)) return empty;
+    try {
+      const parsed = parseYaml(readFileSync(file, 'utf-8')) as { defaults?: Record<string, unknown>; agents?: Record<string, Record<string, unknown>> };
+      return { defaults: parsed?.defaults ?? {}, agents: parsed?.agents ?? {} };
+    } catch {
+      return empty;
+    }
+  }
+
+  /**
+   * Build an OpenCode-valid `permission` frontmatter object by merging
+   * defaults -> agent.permissions (from agent yaml) -> permissions.yaml override,
+   * remapping keys and dropping anything OpenCode does not understand.
+   */
+  private buildPermission(
+    agentName: string,
+    agentPerms: Record<string, unknown> | undefined,
+    permissionsYaml: { defaults: Record<string, unknown>; agents: Record<string, Record<string, unknown>> },
+  ): Record<string, unknown> {
+    const merged: Record<string, unknown> = {
+      ...permissionsYaml.defaults,
+      ...(agentPerms ?? {}),
+      ...(permissionsYaml.agents[agentName] ?? {}),
+    };
+
+    const out: Record<string, unknown> = {};
+    for (const [rawKey, value] of Object.entries(merged)) {
+      // Drop MCP tool patterns and any other unsupported key.
+      if (rawKey.includes(':')) continue;
+      const key = PERM_KEY_MAP[rawKey] ?? rawKey;
+      if (!VALID_PERMISSION_KEYS.has(key)) continue;
+      // 'allow' | 'ask' | 'deny' (string) or object map for bash etc.
+      out[key] = value;
+    }
+    return out;
+  }
+
+  // ==========================================================================
+  // Agents: <name>.yaml -> .opencode/agent/<name>.md
+  // ==========================================================================
+
+  private installAgents(
+    targetDir: string,
+    permissionsYaml: { defaults: Record<string, unknown>; agents: Record<string, Record<string, unknown>> },
+  ): { installed: string[]; errors: string[] } {
     const installed: string[] = [];
     const errors: string[] = [];
     const sourceAgentsDir = join(this.sourceDir, 'agents');
-    const targetAgentsDir = join(targetDir, 'agents');
+    const targetAgentsDir = join(targetDir, 'agent'); // OpenCode native: singular 'agent'
 
     if (!existsSync(sourceAgentsDir)) {
       errors.push(`Source agents directory not found: ${sourceAgentsDir}`);
       return { installed, errors };
     }
-
     if (!existsSync(targetAgentsDir)) {
       mkdirSync(targetAgentsDir, { recursive: true });
     }
 
-    const files = readdirSync(sourceAgentsDir).filter(f => f.endsWith('.yaml'));
-
-    for (const file of files) {
-      const sourceFile = join(sourceAgentsDir, file);
-      const targetFile = join(targetAgentsDir, file);
-
-      if (existsSync(targetFile) && !this.options.overwrite) {
-        continue;
-      }
-
+    for (const file of readdirSync(sourceAgentsDir).filter(f => f.endsWith('.yaml'))) {
       try {
-        copyFileSync(sourceFile, targetFile);
-        installed.push(file.replace('.yaml', ''));
+        const data = parseYaml(readFileSync(join(sourceAgentsDir, file), 'utf-8')) as {
+          name?: string;
+          description?: string;
+          systemPrompt?: string;
+          permissions?: Record<string, unknown>;
+        };
+        const name = data.name || file.replace(/\.yaml$/, '');
+        const targetFile = join(targetAgentsDir, `${name}.md`);
+        if (existsSync(targetFile) && !this.options.overwrite) continue;
+
+        const frontmatter: Record<string, unknown> = {
+          description: (data.description || name).replace(/\s+/g, ' ').trim(),
+          mode: 'subagent',
+        };
+        // NOTE: `model` is intentionally omitted so agents inherit the user's
+        // default OpenCode model. AQE ships model "claude-sonnet-4-6" which may
+        // not resolve in OpenCode's provider registry; inheriting avoids
+        // hard-failing the agent at invocation time.
+        const permission = this.buildPermission(name, data.permissions, permissionsYaml);
+        if (Object.keys(permission).length > 0) frontmatter.permission = permission;
+
+        const body = (data.systemPrompt || '').trimEnd() + '\n';
+        writeFileSync(targetFile, this.renderFrontmatter(frontmatter) + '\n' + body);
+        installed.push(name);
       } catch (error) {
-        errors.push(`Failed to install agent ${file}: ${toErrorMessage(error)}`);
+        errors.push(`Failed to convert agent ${file}: ${toErrorMessage(error)}`);
       }
     }
 
     return { installed, errors };
   }
 
-  /**
-   * Install skill YAML files from .opencode/skills/
-   */
+  // ==========================================================================
+  // Skills: <name>.yaml -> .opencode/skills/<name>/SKILL.md
+  // ==========================================================================
+
   private installSkills(targetDir: string): { installed: string[]; errors: string[] } {
     const installed: string[] = [];
     const errors: string[] = [];
@@ -225,118 +317,94 @@ export class OpenCodeInstaller {
       errors.push(`Source skills directory not found: ${sourceSkillsDir}`);
       return { installed, errors };
     }
-
     if (!existsSync(targetSkillsDir)) {
       mkdirSync(targetSkillsDir, { recursive: true });
     }
 
-    const files = readdirSync(sourceSkillsDir).filter(f => f.endsWith('.yaml'));
-
-    for (const file of files) {
-      const sourceFile = join(sourceSkillsDir, file);
-      const targetFile = join(targetSkillsDir, file);
-
-      if (existsSync(targetFile) && !this.options.overwrite) {
-        continue;
-      }
-
+    for (const file of readdirSync(sourceSkillsDir).filter(f => f.endsWith('.yaml'))) {
       try {
-        copyFileSync(sourceFile, targetFile);
-        installed.push(file.replace('.yaml', ''));
+        const data = parseYaml(readFileSync(join(sourceSkillsDir, file), 'utf-8')) as {
+          name?: string;
+          description?: string;
+          steps?: Array<{ name?: string; description?: string; prompt?: string }>;
+        };
+        const name = (data.name || file.replace(/\.yaml$/, '')).toLowerCase();
+        // OpenCode requires: ^[a-z0-9]+(-[a-z0-9]+)*$ and name === directory.
+        if (!/^[a-z0-9]+(-[a-z0-9]+)*$/.test(name)) {
+          errors.push(`Skipped skill with non-conforming name: ${name}`);
+          continue;
+        }
+        const skillDir = join(targetSkillsDir, name);
+        const targetFile = join(skillDir, 'SKILL.md');
+        if (existsSync(targetFile) && !this.options.overwrite) continue;
+        if (!existsSync(skillDir)) mkdirSync(skillDir, { recursive: true });
+
+        let description = (data.description || name).replace(/\s+/g, ' ').trim();
+        if (description.length > 1024) description = description.slice(0, 1021) + '...';
+
+        let body = '';
+        for (const step of data.steps ?? []) {
+          body += `## ${step.name || 'step'}\n\n`;
+          const text = (step.prompt || step.description || '').trimEnd();
+          if (text) body += `${text}\n\n`;
+        }
+        if (!body.trim()) body = `${data.description || name}\n`;
+
+        writeFileSync(
+          targetFile,
+          this.renderFrontmatter({ name, description }) + '\n' + body.trimEnd() + '\n',
+        );
+        installed.push(name);
       } catch (error) {
-        errors.push(`Failed to install skill ${file}: ${toErrorMessage(error)}`);
+        errors.push(`Failed to convert skill ${file}: ${toErrorMessage(error)}`);
       }
     }
 
     return { installed, errors };
   }
 
-  /**
-   * Install tool wrapper files from .opencode/tools/
-   */
-  private installTools(targetDir: string): { installed: string[]; errors: string[] } {
-    const installed: string[] = [];
-    const errors: string[] = [];
-    const sourceToolsDir = join(this.sourceDir, 'tools');
-    const targetToolsDir = join(targetDir, 'tools');
+  // ==========================================================================
+  // Frontmatter rendering
+  // ==========================================================================
 
-    if (!existsSync(sourceToolsDir)) {
-      errors.push(`Source tools directory not found: ${sourceToolsDir}`);
-      return { installed, errors };
-    }
-
-    if (!existsSync(targetToolsDir)) {
-      mkdirSync(targetToolsDir, { recursive: true });
-    }
-
-    const files = readdirSync(sourceToolsDir).filter(f => f.endsWith('.ts'));
-
-    for (const file of files) {
-      const sourceFile = join(sourceToolsDir, file);
-      const targetFile = join(targetToolsDir, file);
-
-      if (existsSync(targetFile) && !this.options.overwrite) {
-        continue;
-      }
-
-      try {
-        copyFileSync(sourceFile, targetFile);
-        installed.push(file.replace('.ts', ''));
-      } catch (error) {
-        errors.push(`Failed to install tool ${file}: ${toErrorMessage(error)}`);
-      }
-    }
-
-    return { installed, errors };
+  /** Render a frontmatter object as a `---`-delimited YAML block. */
+  private renderFrontmatter(obj: Record<string, unknown>): string {
+    return `---\n${stringifyYaml(obj).trimEnd()}\n---\n`;
   }
 
-  /**
-   * Install permissions.yaml to target .opencode/ directory
-   */
-  private installPermissions(targetDir: string): { installed: boolean; errors: string[] } {
-    const errors: string[] = [];
-    const sourceFile = join(this.sourceDir, 'permissions.yaml');
-    const targetFile = join(targetDir, 'permissions.yaml');
-
-    if (!existsSync(sourceFile)) {
-      return { installed: false, errors: [] };
-    }
-
-    if (existsSync(targetFile) && !this.options.overwrite) {
-      return { installed: false, errors: [] };
-    }
-
-    try {
-      if (!existsSync(targetDir)) {
-        mkdirSync(targetDir, { recursive: true });
-      }
-      copyFileSync(sourceFile, targetFile);
-      return { installed: true, errors: [] };
-    } catch (error) {
-      errors.push(`Failed to install permissions.yaml: ${toErrorMessage(error)}`);
-      return { installed: false, errors };
-    }
-  }
+  // ==========================================================================
+  // opencode.json MCP config
+  // ==========================================================================
 
   /**
-   * Generate opencode.json MCP config if it does not already exist
+   * Generate opencode.json MCP config if it does not already exist.
    */
   private generateOpenCodeConfig(): void {
     const configPath = join(this.projectRoot, 'opencode.json');
+    if (existsSync(configPath)) return;
 
-    if (existsSync(configPath)) {
-      return;
-    }
+    // Database-free install: in-memory backend => no AQE_MEMORY_PATH, set
+    // AQE_MEMORY_BACKEND=memory so the MCP server writes nothing to disk.
+    // Otherwise preserve the historical persistent SQLite path.
+    const environment: Record<string, string> =
+      this.options.memoryBackend === 'memory'
+        ? { AQE_MEMORY_BACKEND: 'memory', AQE_V3_MODE: 'true' }
+        : { AQE_MEMORY_PATH: '.agentic-qe/memory.db', AQE_V3_MODE: 'true' };
 
     const config = {
+      $schema: 'https://opencode.ai/config.json',
       mcp: {
         'agentic-qe': {
           type: 'local',
-          command: ['npx', 'agentic-qe', 'mcp'],
-          environment: {
-            AQE_MEMORY_PATH: '.agentic-qe/memory.db',
-            AQE_V3_MODE: 'true',
-          },
+          // Use the dedicated `aqe-mcp` bin, which runs the MCP server bundle
+          // directly. The `agentic-qe mcp` subcommand instead double-spawns the
+          // server (stdio:'inherit'), which corrupts stdin delivery and makes
+          // OpenCode's client fail with "Failed to get tools". A higher timeout
+          // accommodates the server's subsystem boot.
+          command: ['aqe-mcp'],
+          environment,
+          enabled: true,
+          timeout: 60000,
         },
       },
     };

--- a/src/init/orchestrator.ts
+++ b/src/init/orchestrator.ts
@@ -70,6 +70,7 @@ export class ModularInitOrchestrator {
         wizardAnswers: options.wizardAnswers,
         noGovernance: options.noGovernance,
         noMcp: options.noMcp,
+        memoryBackend: options.memoryBackend,
       },
       config: {},
       enhancements: {

--- a/src/init/phases/04-database.ts
+++ b/src/init/phases/04-database.ts
@@ -40,6 +40,14 @@ export class DatabasePhase extends BasePhase<DatabaseResult> {
   readonly critical = true;
   readonly requiresPhases = ['configuration'] as const;
 
+  /**
+   * Database-free mode (`--no-database` / memoryBackend: 'memory'): skip the
+   * SQLite database entirely. Nothing is written under .agentic-qe/.
+   */
+  async shouldRun(context: InitContext): Promise<boolean> {
+    return context.options.memoryBackend !== 'memory';
+  }
+
   protected async run(context: InitContext): Promise<DatabaseResult> {
     const { projectRoot } = context;
 

--- a/src/init/phases/05-learning.ts
+++ b/src/init/phases/05-learning.ts
@@ -31,6 +31,8 @@ export class LearningPhase extends BasePhase<LearningResult> {
   readonly requiresPhases = ['database', 'configuration'] as const;
 
   async shouldRun(context: InitContext): Promise<boolean> {
+    // Database-free mode has no persistent store to seed patterns into.
+    if (context.options.memoryBackend === 'memory') return false;
     const config = context.config as AQEInitConfig;
     return config?.learning?.enabled ?? true;
   }

--- a/src/init/phases/06-code-intelligence.ts
+++ b/src/init/phases/06-code-intelligence.ts
@@ -102,6 +102,12 @@ export class CodeIntelligencePhase extends BasePhase<CodeIntelligenceResult> {
    *     for the case where the corpus misses something in the wild.
    */
   async shouldRun(context: InitContext): Promise<boolean> {
+    // Database-free mode: the knowledge graph is persisted to the SQLite DB,
+    // which does not exist here. Build it later with `aqe code index`.
+    if (context.options.memoryBackend === 'memory') {
+      context.services.log('  Code intelligence skipped (database-free mode)');
+      return false;
+    }
     const envSkip = process.env.AQE_SKIP_CODE_INDEX;
     if (envSkip === '1' || envSkip === 'true') {
       context.services.log('  Code intelligence skipped (AQE_SKIP_CODE_INDEX=1)');

--- a/src/init/phases/09-assets.ts
+++ b/src/init/phases/09-assets.ts
@@ -218,8 +218,12 @@ export class AssetsPhase extends BasePhase<AssetsResult> {
         projectRoot,
         installAgents: true,
         installSkills: true,
-        installTools: true,
+        // AQE tool .ts files are not in OpenCode's tool() format and are
+        // redundant with the MCP server — never install them.
+        installTools: false,
         overwrite: shouldOverwrite,
+        // Database-free install => MCP server configured to run in-memory.
+        memoryBackend: options.memoryBackend === 'memory' ? 'memory' : undefined,
       });
 
       const ocResult = await openCodeInstaller.install();

--- a/src/init/phases/10-workers.ts
+++ b/src/init/phases/10-workers.ts
@@ -44,6 +44,9 @@ export class WorkersPhase extends BasePhase<WorkersResult> {
   readonly requiresPhases = ['configuration'] as const;
 
   async shouldRun(context: InitContext): Promise<boolean> {
+    // Background workers persist to the SQLite DB, which is absent in
+    // database-free mode.
+    if (context.options.memoryBackend === 'memory') return false;
     const config = context.config as AQEInitConfig;
     return config?.workers?.daemonAutoStart && (config?.workers?.enabled?.length ?? 0) > 0;
   }

--- a/src/init/phases/12-verification.ts
+++ b/src/init/phases/12-verification.ts
@@ -42,11 +42,14 @@ export class VerificationPhase extends BasePhase<VerificationResult> {
 
     const checks: { name: string; passed: boolean }[] = [];
 
-    // Check database exists
+    // Database-free mode: there is no SQLite database to verify or write to.
+    const memOnly = context.options.memoryBackend === 'memory';
+
+    // Check database exists (in-memory mode has none — treated as satisfied).
     const dbPath = join(projectRoot, '.agentic-qe', 'memory.db');
     checks.push({
-      name: 'Database exists',
-      passed: existsSync(dbPath),
+      name: memOnly ? 'Database (in-memory mode)' : 'Database exists',
+      passed: memOnly || existsSync(dbPath),
     });
 
     // Check .agentic-qe directory
@@ -65,8 +68,11 @@ export class VerificationPhase extends BasePhase<VerificationResult> {
       passed: existsSync(configPath),
     });
 
-    // Write version marker
-    const versionWritten = await this.writeVersionToDb(config.version, projectRoot);
+    // Write version marker. Skipped in database-free mode — there is no
+    // memory.db; the version is still recorded in config.yaml above.
+    const versionWritten = memOnly
+      ? true
+      : await this.writeVersionToDb(config.version, projectRoot);
     checks.push({
       name: 'Version marker',
       passed: versionWritten,

--- a/src/init/phases/phase-interface.ts
+++ b/src/init/phases/phase-interface.ts
@@ -144,6 +144,12 @@ export interface InitOptions {
   noMcp?: boolean;
   /** @deprecated Use default behavior instead — MCP is now enabled by default */
   withMcp?: boolean;
+  /**
+   * Memory backend for this install. 'memory' => database-free: the SQLite
+   * database phase is skipped and any MCP config is written to run in-memory.
+   * Undefined preserves the default persistent backend. Set via `--no-database`.
+   */
+  memoryBackend?: 'memory' | 'sqlite' | 'agentdb' | 'hybrid';
 }
 
 /**

--- a/src/integrations/ruvector/rvf-native-adapter.ts
+++ b/src/integrations/ruvector/rvf-native-adapter.ts
@@ -570,5 +570,13 @@ export function openRvfStoreReadonly(path: string): RvfNativeAdapter {
 
 /** Check whether the native binding is loadable on this platform */
 export function isRvfNativeAvailable(): boolean {
+  // Database-free mode (#534): report RVF as unavailable so every consumer
+  // (RVF pattern store, dual-writer, agent memory branches) takes its existing
+  // "no native RVF" degraded path and writes nothing to disk — no patterns.rvf,
+  // brain.rvf, or branches/*.rvf. This is the single central gate for all
+  // on-disk RVF stores.
+  if (process.env.AQE_MEMORY_BACKEND === 'memory') {
+    return false;
+  }
   return getNative() !== null;
 }

--- a/src/integrations/ruvector/shared-rvf-dual-writer.ts
+++ b/src/integrations/ruvector/shared-rvf-dual-writer.ts
@@ -62,6 +62,12 @@ export async function getSharedRvfDualWriter(): Promise<RvfDualWriter | null> {
         return null;
       }
 
+      // Database-free mode (#534): no on-disk RVF store (brain.rvf). The unified
+      // DB is already in-memory, so there is nothing to dual-write to disk.
+      if (process.env.AQE_MEMORY_BACKEND === 'memory') {
+        return null;
+      }
+
       // Auto-detect native availability (dynamic import to avoid bundling .node files)
       const { isRvfNativeAvailable } = await import('./rvf-native-adapter.js');
       if (!isRvfNativeAvailable()) {

--- a/src/kernel/kernel.ts
+++ b/src/kernel/kernel.ts
@@ -200,8 +200,10 @@ export class QEKernelImpl implements QEKernel {
     const projectRoot = findProjectRoot();
     const dataDir = this._config.dataDir || path.join(projectRoot, '.agentic-qe');
 
-    // Ensure data directory exists
-    if (!fs.existsSync(dataDir)) {
+    // Ensure data directory exists. Skipped in database-free mode so the
+    // project's .agentic-qe/ is never created (the memory branch below uses a
+    // throwaway temp DB outside the project).
+    if (this._config.memoryBackend !== 'memory' && !fs.existsSync(dataDir)) {
       fs.mkdirSync(dataDir, { recursive: true });
     }
 

--- a/src/kernel/unified-memory.ts
+++ b/src/kernel/unified-memory.ts
@@ -183,6 +183,15 @@ export class UnifiedMemoryManager {
     const resolvedDefaults = getResolvedDefaultConfig();
     this.config = { ...resolvedDefaults, ...config };
 
+    // Database-free mode (#534): keep ALL unified persistence in an ephemeral
+    // in-memory SQLite DB. Handlers/domains that reach for UnifiedMemoryManager
+    // (core-handlers, trajectory-judge, test-generator, experience-capture, …)
+    // keep working, but nothing is ever written under .agentic-qe/.
+    if (process.env.AQE_MEMORY_BACKEND === 'memory') {
+      this.config.dbPath = ':memory:';
+      return;
+    }
+
     if (!path.isAbsolute(this.config.dbPath)) {
       const projectRoot = findProjectRoot();
       this.config.dbPath = path.join(projectRoot, this.config.dbPath);
@@ -241,60 +250,68 @@ export class UnifiedMemoryManager {
     signal?.throwIfAborted();
 
     try {
-      // SAFETY: Detect test processes trying to open the production DB.
-      // If AQE_PROJECT_ROOT is set to a temp dir (vitest isolation) but the
-      // dbPath resolves to the REAL project's .agentic-qe/memory.db, redirect.
-      // Only redirect production paths — leave explicitly-set temp paths alone.
-      const envRoot = process.env.AQE_PROJECT_ROOT;
-      if (envRoot) {
-        const resolvedPath = path.resolve(this.config.dbPath);
-        const resolvedRoot = path.resolve(envRoot);
-        // Only redirect if path points OUTSIDE the env root AND into a real
-        // .agentic-qe directory (not another temp test dir)
-        if (!resolvedPath.startsWith(resolvedRoot) &&
-            !resolvedPath.startsWith(os.tmpdir()) &&
-            resolvedPath.includes('.agentic-qe')) {
-          console.error(
-            `[UnifiedMemory] WARNING: DB path "${this.config.dbPath}" points to a ` +
-            `production .agentic-qe/ while AQE_PROJECT_ROOT="${envRoot}". ` +
-            `Redirecting to test-safe path.`
-          );
-          this.config.dbPath = path.join(envRoot, '.agentic-qe', 'memory.db');
-        }
-      }
-
-      const dir = path.dirname(this.config.dbPath);
-      if (!fs.existsSync(dir)) {
-        fs.mkdirSync(dir, { recursive: true });
-      }
-
-      // DATA LOSS PREVENTION: If the DB file already exists, record its size
-      // before opening. better-sqlite3's `new Database(path)` creates a fresh
-      // empty file when the path doesn't exist. If we expected an existing DB
-      // (dir exists, .agentic-qe present) but the file is missing, something
-      // deleted it — warn loudly and look for the most recent backup.
-      const dbExistedBefore = fs.existsSync(this.config.dbPath);
+      // Database-free mode (#534): ':memory:' is ephemeral — skip ALL filesystem
+      // work (dir creation, path redirect, backup recovery, size accounting).
+      const inMemory = this.config.dbPath === ':memory:';
+      let dir = '';
+      let dbExistedBefore = false;
       let dbSizeBefore = 0;
-      if (dbExistedBefore) {
-        dbSizeBefore = fs.statSync(this.config.dbPath).size;
-      } else if (fs.existsSync(dir)) {
-        // The .agentic-qe directory exists but memory.db is missing — suspect data loss
-        const backups = this.findRecentBackups(dir);
-        if (backups.length > 0) {
-          const newest = backups[0];
-          console.error(
-            `[UnifiedMemory] CRITICAL: Database file missing but directory exists!\n` +
-            `  Expected: ${this.config.dbPath}\n` +
-            `  Found ${backups.length} backup(s), newest: ${newest.path} (${(newest.size / 1024 / 1024).toFixed(1)}MB)\n` +
-            `  Restoring from backup to prevent data loss...`
-          );
-          fs.copyFileSync(newest.path, this.config.dbPath);
-          // Remove stale WAL/SHM that may belong to the old file
-          for (const suffix of ['-wal', '-shm']) {
-            const walPath = this.config.dbPath + suffix;
-            if (fs.existsSync(walPath)) fs.unlinkSync(walPath);
+
+      if (!inMemory) {
+        // SAFETY: Detect test processes trying to open the production DB.
+        // If AQE_PROJECT_ROOT is set to a temp dir (vitest isolation) but the
+        // dbPath resolves to the REAL project's .agentic-qe/memory.db, redirect.
+        // Only redirect production paths — leave explicitly-set temp paths alone.
+        const envRoot = process.env.AQE_PROJECT_ROOT;
+        if (envRoot) {
+          const resolvedPath = path.resolve(this.config.dbPath);
+          const resolvedRoot = path.resolve(envRoot);
+          // Only redirect if path points OUTSIDE the env root AND into a real
+          // .agentic-qe directory (not another temp test dir)
+          if (!resolvedPath.startsWith(resolvedRoot) &&
+              !resolvedPath.startsWith(os.tmpdir()) &&
+              resolvedPath.includes('.agentic-qe')) {
+            console.error(
+              `[UnifiedMemory] WARNING: DB path "${this.config.dbPath}" points to a ` +
+              `production .agentic-qe/ while AQE_PROJECT_ROOT="${envRoot}". ` +
+              `Redirecting to test-safe path.`
+            );
+            this.config.dbPath = path.join(envRoot, '.agentic-qe', 'memory.db');
           }
-          dbSizeBefore = newest.size;
+        }
+
+        dir = path.dirname(this.config.dbPath);
+        if (!fs.existsSync(dir)) {
+          fs.mkdirSync(dir, { recursive: true });
+        }
+
+        // DATA LOSS PREVENTION: If the DB file already exists, record its size
+        // before opening. better-sqlite3's `new Database(path)` creates a fresh
+        // empty file when the path doesn't exist. If we expected an existing DB
+        // (dir exists, .agentic-qe present) but the file is missing, something
+        // deleted it — warn loudly and look for the most recent backup.
+        dbExistedBefore = fs.existsSync(this.config.dbPath);
+        if (dbExistedBefore) {
+          dbSizeBefore = fs.statSync(this.config.dbPath).size;
+        } else if (fs.existsSync(dir)) {
+          // The .agentic-qe directory exists but memory.db is missing — suspect data loss
+          const backups = this.findRecentBackups(dir);
+          if (backups.length > 0) {
+            const newest = backups[0];
+            console.error(
+              `[UnifiedMemory] CRITICAL: Database file missing but directory exists!\n` +
+              `  Expected: ${this.config.dbPath}\n` +
+              `  Found ${backups.length} backup(s), newest: ${newest.path} (${(newest.size / 1024 / 1024).toFixed(1)}MB)\n` +
+              `  Restoring from backup to prevent data loss...`
+            );
+            fs.copyFileSync(newest.path, this.config.dbPath);
+            // Remove stale WAL/SHM that may belong to the old file
+            for (const suffix of ['-wal', '-shm']) {
+              const walPath = this.config.dbPath + suffix;
+              if (fs.existsSync(walPath)) fs.unlinkSync(walPath);
+            }
+            dbSizeBefore = newest.size;
+          }
         }
       }
 
@@ -407,6 +424,8 @@ export class UnifiedMemoryManager {
   }
 
   private warnIfDuplicateDatabases(): void {
+    // Database-free mode has no on-disk canonical DB to compare against.
+    if (this.config.dbPath === ':memory:') return;
     try {
       const projectRoot = findProjectRoot();
       const canonicalDb = path.resolve(this.config.dbPath);

--- a/src/learning/rvf-pattern-store.ts
+++ b/src/learning/rvf-pattern-store.ts
@@ -102,6 +102,15 @@ export class RvfPatternStore implements IPatternStore {
   async initialize(): Promise<void> {
     if (this.initialized) return;
 
+    // Database-free mode (#534): never create an on-disk patterns.rvf (+ .idmap/.lock).
+    // Run adapter-less — the store degrades to metadata-only (the same graceful
+    // path used when the RVF native binding is unavailable), writing nothing.
+    if (process.env.AQE_MEMORY_BACKEND === 'memory') {
+      this.adapter = null;
+      this.initialized = true;
+      return;
+    }
+
     try {
       this.adapter = this.createAdapter(
         this.rvfPath,

--- a/src/mcp/entry.ts
+++ b/src/mcp/entry.ts
@@ -118,11 +118,38 @@ async function main(): Promise<void> {
     return true;
   }) as typeof process.stderr.write;
 
+  // CRITICAL (stdio MCP framing): stdout must carry ONLY JSON-RPC messages.
+  // Lazily-loaded subsystems use console.log() for diagnostics (e.g.
+  // "[ParserRegistry] tree-sitter…", "[AdversarialDefense]…", "[Daemon] Not
+  // running"). Those stray lines interleave with the JSON-RPC stream and make
+  // strict clients (OpenCode, the official MCP SDK) fail with "Failed to get
+  // tools". console.log/info/debug default to stdout, so re-route them to the
+  // (filtered) stderr. JSON-RPC responses are written via the transport's
+  // process.stdout.write directly and are unaffected.
+  const routeConsoleToStderr = (...args: unknown[]): void => {
+    process.stderr.write(
+      args.map(a => (typeof a === 'string' ? a : (() => { try { return JSON.stringify(a); } catch { return String(a); } })())).join(' ') + '\n',
+    );
+  };
+  console.log = routeConsoleToStderr as typeof console.log;
+  console.info = routeConsoleToStderr as typeof console.info;
+  console.debug = routeConsoleToStderr as typeof console.debug;
+
   try {
     // IMP-06: Run independent init tasks in parallel via parallelPrefetch.
     // Token tracking, experience capture, infra-healing, and fleet init are
     // all independent — total startup time is bounded by the slowest task
     // rather than the sum of all tasks.
+    // Database-free mode (AQE_MEMORY_BACKEND=memory): boot lean. Skip every
+    // subsystem that opens/writes the SQLite memory.db (persistent token
+    // tracking, experience capture, background workers, ReasoningBank prewarm,
+    // QualityDaemon). This keeps .agentic-qe/ untouched AND avoids the
+    // SQLite-lock contention that made tools/list hang for some MCP clients.
+    const memOnly = process.env.AQE_MEMORY_BACKEND === 'memory';
+    if (memOnly) {
+      originalStderrWrite('[MCP] Database-free mode: in-memory backend, lean boot\n');
+    }
+
     originalStderrWrite('[MCP] Initializing subsystems in parallel...\n');
     const prefetchResult = await parallelPrefetch([
       {
@@ -131,7 +158,7 @@ async function main(): Promise<void> {
         fn: async () => {
           await bootstrapTokenTracking({
             enableOptimization: true,
-            enablePersistence: true,
+            enablePersistence: !memOnly,
             verbose: process.env.AQE_VERBOSE === 'true',
           });
         },
@@ -140,9 +167,10 @@ async function main(): Promise<void> {
         // ADR-051: Initialize experience capture and unified memory BEFORE server starts.
         // This ensures all tool invocations (domain, memory, core) write to v3 memory.db
         // from the first request, rather than lazy-initializing on first domain tool call.
+        // Skipped in database-free mode (it opens memory.db).
         name: 'experience-capture',
         fn: async () => {
-          await initializeExperienceCapture();
+          if (!memOnly) await initializeExperienceCapture();
         },
       },
       {
@@ -187,9 +215,16 @@ async function main(): Promise<void> {
         },
       },
       {
-        // Auto-initialize fleet so tools work without requiring fleet_init call
+        // Auto-initialize fleet so tools work without requiring fleet_init call.
+        // Skipped in database-free mode: the kernel boot wires up ReasoningBank/
+        // SONA which open the unified memory.db and write patterns.rvf. Tools
+        // still register; anything needing a fleet lazily inits on fleet_init.
         name: 'fleet-init',
         fn: async () => {
+          if (memOnly) {
+            originalStderrWrite('[MCP] Fleet auto-init skipped (database-free mode)\n');
+            return;
+          }
           const fleetResult = await handleFleetInit({
             topology: 'hierarchical',
             maxAgents: 15,
@@ -227,7 +262,7 @@ async function main(): Promise<void> {
     // its initialize() (config-load + memory wiring) only runs when
     // explicitly called. Doing it here means hook events fire through a
     // fully-initialized executor from the first MCP request.
-    try {
+    if (!memOnly) try {
       const { getCrossPhaseHookExecutor } = await import('../hooks/cross-phase-hooks.js');
       await getCrossPhaseHookExecutor().initialize();
       originalStderrWrite('[MCP] CrossPhaseHooks initialized (eager init via patch 010)\n');
@@ -240,7 +275,7 @@ async function main(): Promise<void> {
     // builds the singleton + EnhancedReasoningBankAdapter.initialize() +
     // HNSW A index population. Without this, the first task_orchestrate pays
     // the cold-start cost and routing falls through to context-only matches.
-    void (async () => {
+    if (!memOnly) void (async () => {
       try {
         const { getReasoningBankService } = await import('./services/reasoning-bank-service.js');
         await getReasoningBankService();
@@ -251,7 +286,9 @@ async function main(): Promise<void> {
     })();
 
     // IMP-10: Start background workers (heartbeat scheduler, etc.)
-    try {
+    // Skipped in database-free mode — every worker persists to memory.db and
+    // the QualityDaemon opens UnifiedMemoryManager (SQLite).
+    if (!memOnly) try {
       const { getDaemon } = await import('../workers/daemon.js');
       // ADR-001 Bug A fix: use the canonical getDaemon() default. Passing
       // `{ autoStart: false }` here would neuter workerManager.startAll() —

--- a/src/mcp/entry.ts
+++ b/src/mcp/entry.ts
@@ -140,14 +140,15 @@ async function main(): Promise<void> {
     // Token tracking, experience capture, infra-healing, and fleet init are
     // all independent — total startup time is bounded by the slowest task
     // rather than the sum of all tasks.
-    // Database-free mode (AQE_MEMORY_BACKEND=memory): boot lean. Skip every
-    // subsystem that opens/writes the SQLite memory.db (persistent token
-    // tracking, experience capture, background workers, ReasoningBank prewarm,
-    // QualityDaemon). This keeps .agentic-qe/ untouched AND avoids the
-    // SQLite-lock contention that made tools/list hang for some MCP clients.
+    // Database-free mode (AQE_MEMORY_BACKEND=memory): boot the SAME subsystems as
+    // normal — fleet, experience capture, ReasoningBank, workers, CrossPhaseHooks —
+    // but every persistence layer (unified memory, RVF, hypergraph, sessions,
+    // results) is gated to run in-memory and write nothing under .agentic-qe/.
+    // This keeps full functional parity (health, domains, memory delete,
+    // cross-phase stats) while remaining database-free.
     const memOnly = process.env.AQE_MEMORY_BACKEND === 'memory';
     if (memOnly) {
-      originalStderrWrite('[MCP] Database-free mode: in-memory backend, lean boot\n');
+      originalStderrWrite('[MCP] Database-free mode: in-memory backend (full feature parity)\n');
     }
 
     originalStderrWrite('[MCP] Initializing subsystems in parallel...\n');
@@ -165,12 +166,12 @@ async function main(): Promise<void> {
       },
       {
         // ADR-051: Initialize experience capture and unified memory BEFORE server starts.
-        // This ensures all tool invocations (domain, memory, core) write to v3 memory.db
-        // from the first request, rather than lazy-initializing on first domain tool call.
-        // Skipped in database-free mode (it opens memory.db).
+        // This ensures all tool invocations (domain, memory, core) use unified memory
+        // from the first request. In database-free mode unified memory is an ephemeral
+        // :memory: DB, so this is safe and keeps full functional parity.
         name: 'experience-capture',
         fn: async () => {
-          if (!memOnly) await initializeExperienceCapture();
+          await initializeExperienceCapture();
         },
       },
       {
@@ -215,19 +216,17 @@ async function main(): Promise<void> {
         },
       },
       {
-        // Auto-initialize fleet so tools work without requiring fleet_init call.
-        // Skipped in database-free mode: the kernel boot wires up ReasoningBank/
-        // SONA which open the unified memory.db and write patterns.rvf. Tools
-        // still register; anything needing a fleet lazily inits on fleet_init.
+        // Auto-initialize fleet so tools work without requiring an explicit
+        // fleet_init call. In database-free mode the kernel runs on the in-memory
+        // backend (and unified memory / RVF are gated to write nothing), so the
+        // fleet boots normally without touching .agentic-qe/.
         name: 'fleet-init',
         fn: async () => {
-          if (memOnly) {
-            originalStderrWrite('[MCP] Fleet auto-init skipped (database-free mode)\n');
-            return;
-          }
           const fleetResult = await handleFleetInit({
             topology: 'hierarchical',
             maxAgents: 15,
+            // handleFleetInit forces the in-memory kernel backend when
+            // AQE_MEMORY_BACKEND=memory, so 'hybrid' here is self-correcting.
             memoryBackend: 'hybrid',
             lazyLoading: true,
           });
@@ -262,7 +261,7 @@ async function main(): Promise<void> {
     // its initialize() (config-load + memory wiring) only runs when
     // explicitly called. Doing it here means hook events fire through a
     // fully-initialized executor from the first MCP request.
-    if (!memOnly) try {
+    try {
       const { getCrossPhaseHookExecutor } = await import('../hooks/cross-phase-hooks.js');
       await getCrossPhaseHookExecutor().initialize();
       originalStderrWrite('[MCP] CrossPhaseHooks initialized (eager init via patch 010)\n');
@@ -275,7 +274,7 @@ async function main(): Promise<void> {
     // builds the singleton + EnhancedReasoningBankAdapter.initialize() +
     // HNSW A index population. Without this, the first task_orchestrate pays
     // the cold-start cost and routing falls through to context-only matches.
-    if (!memOnly) void (async () => {
+    void (async () => {
       try {
         const { getReasoningBankService } = await import('./services/reasoning-bank-service.js');
         await getReasoningBankService();
@@ -285,10 +284,10 @@ async function main(): Promise<void> {
       }
     })();
 
-    // IMP-10: Start background workers (heartbeat scheduler, etc.)
-    // Skipped in database-free mode — every worker persists to memory.db and
-    // the QualityDaemon opens UnifiedMemoryManager (SQLite).
-    if (!memOnly) try {
+    // IMP-10: Start background workers (heartbeat scheduler, etc.). In
+    // database-free mode they run against the in-memory unified store, so they
+    // persist nothing to disk while keeping QualityDaemon/health functional.
+    try {
       const { getDaemon } = await import('../workers/daemon.js');
       // ADR-001 Bug A fix: use the canonical getDaemon() default. Passing
       // `{ autoStart: false }` here would neuter workerManager.startAll() —

--- a/src/mcp/handlers/core-handlers.ts
+++ b/src/mcp/handlers/core-handlers.ts
@@ -209,10 +209,15 @@ export async function handleFleetInit(
     const enabledDomains: DomainName[] = params.enabledDomains || [...ALL_DOMAINS];
     const userFacingDomains: DomainName[] = enabledDomains.filter(d => d !== 'coordination') as DomainName[];
 
-    // Create kernel
+    // Create kernel. Database-free mode (#534): force the in-memory backend so a
+    // fleet_init tool call never builds a SQLite-backed kernel that writes
+    // .agentic-qe/memory.db. Explicit params still win when not in memory mode.
+    const memoryBackend = process.env.AQE_MEMORY_BACKEND === 'memory'
+      ? 'memory'
+      : (params.memoryBackend || 'hybrid');
     state.kernel = new QEKernelImpl({
       maxConcurrentAgents: params.maxAgents || 15,
-      memoryBackend: params.memoryBackend || 'hybrid',
+      memoryBackend,
       hnswEnabled: true,
       lazyLoading: params.lazyLoading !== false,
       enabledDomains,

--- a/src/mcp/protocol-server.ts
+++ b/src/mcp/protocol-server.ts
@@ -527,8 +527,18 @@ export class MCPProtocolServer {
 
     this.initialized = true;
 
+    // Protocol-version negotiation (MCP spec): echo the client's requested
+    // version when we support it, otherwise fall back to our latest. Returning a
+    // hardcoded future version made strict SDK clients (e.g. OpenCode) reject the
+    // handshake with "Failed to get tools". Unknown/missing => latest supported.
+    const SUPPORTED_PROTOCOL_VERSIONS = ['2025-11-25', '2025-06-18', '2025-03-26', '2024-11-05'];
+    const requested = typeof params.protocolVersion === 'string' ? params.protocolVersion : undefined;
+    const negotiated = requested && SUPPORTED_PROTOCOL_VERSIONS.includes(requested)
+      ? requested
+      : SUPPORTED_PROTOCOL_VERSIONS[0];
+
     return {
-      protocolVersion: '2025-11-25',
+      protocolVersion: negotiated,
       capabilities: this.getCapabilities(),
       serverInfo: this.getServerInfo(),
     };

--- a/src/mcp/services/session-store.ts
+++ b/src/mcp/services/session-store.ts
@@ -60,6 +60,10 @@ export class SessionStore {
   private flushTimer: ReturnType<typeof setTimeout> | null = null;
   private closed = false;
 
+  // Database-free mode (#534): keep session bookkeeping in memory but never
+  // write .agentic-qe/sessions/*.jsonl to disk.
+  private readonly persistDisabled: boolean = process.env.AQE_MEMORY_BACKEND === 'memory';
+
   constructor(sessionDir?: string) {
     this.sessionDir = sessionDir ?? DEFAULT_SESSION_DIR;
   }
@@ -114,6 +118,11 @@ export class SessionStore {
     this.entryCount++;
     this.lastActivityAt = fullEntry.timestamp;
     this.currentState = fullEntry.state;
+
+    // Database-free mode: bookkeeping done above; skip all disk I/O.
+    if (this.persistDisabled) {
+      return uuid;
+    }
 
     const line = JSON.stringify(fullEntry) + '\n';
 

--- a/src/mcp/tools/base.ts
+++ b/src/mcp/tools/base.ts
@@ -10,7 +10,17 @@ import { DomainName } from '../../shared/types';
 import { ToolResult, ToolResultMetadata } from '../types';
 import { MemoryBackend } from '../../kernel/interfaces';
 import { HybridMemoryBackend } from '../../kernel/hybrid-backend';
+import { InMemoryBackend } from '../../kernel/memory-backend.js';
 import { findProjectRoot } from '../../kernel/unified-memory.js';
+
+/**
+ * Database-free mode: when AQE_MEMORY_BACKEND=memory, the MCP server keeps all
+ * state in-memory and writes nothing under .agentic-qe/. Used by `aqe init
+ * --no-database` and the in-memory opencode.json MCP config.
+ */
+export function isMemoryOnlyMode(): boolean {
+  return process.env.AQE_MEMORY_BACKEND === 'memory';
+}
 import * as path from 'path';
 import * as fs from 'fs';
 import { toErrorMessage } from '../../shared/error-utils.js';
@@ -54,6 +64,14 @@ export async function getSharedMemoryBackend(): Promise<MemoryBackend> {
 
   // Initialize new backend
   memoryInitPromise = (async () => {
+    // Database-free mode: pure in-memory backend, no directory, no SQLite file.
+    if (isMemoryOnlyMode()) {
+      const backend = new InMemoryBackend();
+      await backend.initialize();
+      sharedMemoryBackend = backend;
+      return backend;
+    }
+
     const projectRoot = findProjectRoot();
     const dataDir = path.join(projectRoot, '.agentic-qe');
 


### PR DESCRIPTION
## What this does

Makes `aqe init --with-opencode --no-database` (alias `--memory memory`) produce a **working, genuinely database-free OpenCode install** — verified end-to-end against a real project on OpenCode 1.17.6, including actually *using* the agents/skills/MCP tools (not just install + boot).

| Check | Result |
|---|---|
| Init writes no database | ✓ `.agentic-qe/` holds only `config.yaml` |
| Agents load (`opencode agent list`) | ✓ 59 |
| Skills load (`opencode debug skill`) | ✓ 84 |
| MCP server connects (`opencode mcp list`) | ✓ connected, 86 tools |
| Exercising tools (memory, `fleet_init`, `agent_spawn`, `task_orchestrate`) | ✓ **zero** files under `.agentic-qe/` |
| `aqe_health` in memory mode | ✓ healthy, `memory.connected:true`, 14 domains |
| Default (persistent) mode | ✓ unchanged — still writes `memory.db` |

## Issues addressed

- **Fixes #527** — MCP stdio server wasn't spec-compliant: subsystem `console.log` leaked onto stdout (corrupting JSON-RPC framing) and `initialize` hardcoded `protocolVersion`. Both made strict clients (OpenCode, official SDK) fail with "Failed to get tools". Now: console stdout routed to stderr, and `protocolVersion` is negotiated.
- **Fixes #529** — OpenCode provisioning shipped a non-loadable format. Now converts at install time to native `.opencode/agent/*.md` + `.opencode/skills/<name>/SKILL.md` (with per-agent permission frontmatter); incompatible tool wrappers dropped.
- **Closes #530** — `--no-database` / `--memory memory` database-free mode, opt-in and wired through the modular orchestrator.
- **Fixes #534** — database-free mode now holds **across the whole runtime**, not just init/boot. Every persistence path that previously ignored `AQE_MEMORY_BACKEND=memory` is gated: UnifiedMemoryManager to ephemeral `:memory:`; RVF (central `isRvfNativeAvailable` gate) off (no `brain.rvf`/`patterns.rvf`/`branches/`); code-intelligence hypergraph to `:memory:`; `fleet_init` kernel to in-memory backend; session-store/result-saver to no writes. With persistence fully in-memory, the server boots the **same** subsystems as normal mode (fleet, ReasoningBank, workers, CrossPhaseHooks), so it stays fully functional (`aqe_health` healthy, 14 domains) while writing nothing.
- **Mitigates #528** — generated `opencode.json` invokes the `aqe-mcp` bin directly, sidestepping the `agentic-qe mcp` double-spawn that drops stdin. The in-process fix to `mcp.ts` is left as a focused follow-up (#528).

Also routes platform/database-free installs to the modular orchestrator so `--with-opencode`/`--no-database` take effect without requiring `--auto`.

## Safety / scope

- **All database-free behavior is opt-in** (gated on `AQE_MEMORY_BACKEND=memory`). The default persistent path is unchanged and re-verified.
- The stdout-purity fix (#527) applies in all modes — a general MCP correctness improvement.
- `tsc --noEmit` passes clean. 8 commits, 23 files.

## Known follow-ups (out of scope here)

- **#528** — make `agentic-qe mcp` run in-process (this PR only mitigates via `aqe-mcp`).
- **#532** — platform installs are additive, not exclusive (always installs the Claude Code surface); need a per-platform/only mode.
- **#533** — propagate `AQE_MEMORY_BACKEND=memory` to **all** generated MCP client configs (`.mcp.json`, editors), not just `opencode.json`.
- **#535** — pre-existing MCP tool bugs found during smoke testing (`memory_delete` no-op, `cross_phase_stats`, GOAP, test-gen quality, coherence text) — reproduce regardless of backend.

## Not included
- Tool wrappers (`.opencode/tools/*.ts`) are intentionally not installed — incompatible with OpenCode's `tool()` API and redundant with the MCP server.


## Failure modes

Each failure mode this change introduces or touches is covered by a test in the verification table above, or by a linked tracking issue:

- **stdout framing regression in any MCP mode (#527)** — covered: MCP transport unit tests + `opencode mcp list` connects with 86 tools.
- **OpenCode assets ship in a non-loadable format (#529)** — covered: `opencode agent list` loads 59, `opencode debug skill` loads 84.
- **A persistence path ignores `AQE_MEMORY_BACKEND=memory` (#534)** — covered: after exercising memory / `fleet_init` / `agent_spawn` / `task_orchestrate`, zero files appear under `.agentic-qe/`.
- **Default persistent mode regresses** — covered: default mode re-verified, still writes `memory.db`.
- **Dropping `installTools` for OpenCode breaks agent/skill loading** — covered: install with tool wrappers omitted still loads 59 agents + 84 skills and connects 86 MCP tools.
- **`agentic-qe mcp` double-spawn drops stdin (#528)** — mitigated via the `aqe-mcp` bin; in-process fix tracked in #528.
- **Other generated MCP client configs don't receive the `memory` backend (#533)** — tracked in #533.
- **Platform installs are additive, not exclusive (#532)** — tracked in #532.
- **Pre-existing MCP tool bugs surfaced during smoke testing (#535)** — tracked in #535.

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.** "Unlikely" is not an acceptable substitute. If you wrote "I don't think this can happen but...", that sentence is a failure mode and needs a test or an issue link.

### Optional context

- Linked issues: #527, #529, #530, #534, #528, #532, #533, #535
- Affects published API or CLI surface: yes — `aqe init --with-opencode --no-database` (alias `--memory memory`)
- Touches the init flow: yes
