### PR TITLE
chore(release): v3.10.8

### DIFF
--- a/.claude/skills/skills-manifest.json
+++ b/.claude/skills/skills-manifest.json
@@ -939,7 +939,7 @@
   },
   "metadata": {
     "generatedBy": "Agentic QE Fleet",
-    "fleetVersion": "3.10.7",
+    "fleetVersion": "3.10.8",
     "manifestVersion": "1.4.0",
     "lastUpdated": "2026-04-13T00:00:00.000Z",
     "contributors": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,54 @@ All notable changes to the Agentic QE project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.10.8] - 2026-06-16
+
+A database-free OpenCode install and a set of MCP stdio client-compatibility
+fixes (community contribution from @nagoodman), plus a dependency-security pass
+that clears two production high-severity advisories.
+
+### Added
+
+- **Database-free install mode** — `aqe init --with-opencode --no-database`
+  (alias `--memory memory`). Produces a fully working OpenCode install that
+  writes nothing under `.agentic-qe/`: every persistence path (memory manager,
+  RVF, code-intelligence hypergraph, fleet kernel, session/result stores) runs
+  in-memory, while the server still boots the same subsystems (fleet,
+  ReasoningBank, workers) so it stays healthy with all 14 domains. Opt-in; the
+  default persistent mode is unchanged. (#530, #534)
+
+### Fixed
+
+- **MCP stdio server is now spec-compliant for strict clients.** Subsystem
+  `console.log` output was leaking onto stdout and corrupting JSON-RPC framing,
+  and `initialize` hardcoded the protocol version — both made strict clients
+  (OpenCode, the official MCP SDK) fail with "Failed to get tools". Console
+  output is now routed to stderr and `protocolVersion` is negotiated. Applies in
+  all modes. (#527)
+- **OpenCode provisioning now ships a loadable format.** Agents and skills are
+  converted at install time to native `.opencode/agent/*.md` and
+  `.opencode/skills/<name>/SKILL.md` with per-agent permission frontmatter. (#529)
+- **protobufjs and ws production CVEs.** Cleared two high-severity advisories
+  flagged by the supply-chain audit gate: protobufjs (GHSA-f38q-mgvj-vph7,
+  GHSA-wcpc-wj8m-hjx6) → 7.6.4 and ws (GHSA-96hv-2xvq-fx4p) → 8.21.0, via
+  overrides that stay within each package's current major.
+
+### Changed
+
+- **OpenCode installs no longer copy non-loadable `.opencode/tools/*.ts`
+  wrappers.** They were never loadable by OpenCode's `tool()` API and are
+  redundant with the MCP server, which exposes the same tools. (#531)
+- Bumped `vite` 8.0.9 → 8.0.16 (dev dependency). (supersedes #536)
+
+### Known follow-ups
+
+- #528 — make `agentic-qe mcp` run in-process (currently mitigated by invoking
+  the `aqe-mcp` bin directly).
+- #532 — platform installs are additive, not exclusive.
+- #533 — propagate `AQE_MEMORY_BACKEND=memory` to all generated MCP client
+  configs, not just `opencode.json`.
+- #535 — pre-existing MCP tool bugs surfaced during smoke testing.
+
 ## [3.10.7] - 2026-06-12
 
 A learning-integrity and supply-chain release. Two independent bugs were

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -4,6 +4,7 @@ All Agentic QE release notes organized by version.
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| [v3.10.8](v3.10.8.md) | 2026-06-16 | Database-free OpenCode install (`--no-database`/`--memory memory`, #530/#534) + MCP stdio client-compat fixes (#527 stdout purity + negotiated protocol, #529 loadable OpenCode assets) from @nagoodman; cleared protobufjs + ws production CVEs; vite → 8.0.16. |
 | [v3.10.7](v3.10.7.md) | 2026-06-12 | Learning-integrity + supply chain: fix silent self-learning loss (hook swallowed native-binary errors; SONA reward feedback was inert, fixed via `@ruvector/sona` 0.1.7); shift-left consumer-tarball audit gate; refresh QE skill evals to current models. |
 | [v3.10.6](v3.10.6.md) | 2026-06-11 | Pattern Space cross-pollination (#522): evidence-class labels on findings, pass/fail safety eval for data-protection rules, shipped-agent invariant CI, benchmark lineage + interaction benchmark, kept-nulls learning. ADR-105–110. |
 | [v3.10.5](v3.10.5.md) | 2026-06-10 | Fable 5 parity (#520): CLI fleet/memory commands fixed, prompt caching wired, reasoning-scrub for clean learning, adversarial QCSD reviews, `aqe arena` tournaments. ADR-099–104. |

--- a/docs/releases/v3.10.8.md
+++ b/docs/releases/v3.10.8.md
@@ -1,0 +1,51 @@
+# v3.10.8 Release Notes
+
+**Release Date:** 2026-06-16
+
+## Highlights
+
+A database-free OpenCode install and MCP stdio client-compatibility fixes
+(community contribution from @nagoodman), plus a dependency-security pass that
+clears two production high-severity advisories (protobufjs, ws).
+
+## Added
+
+- **Database-free install mode** — `aqe init --with-opencode --no-database`
+  (alias `--memory memory`). The install writes nothing under `.agentic-qe/`:
+  every persistence path (memory manager, RVF, code-intelligence hypergraph,
+  fleet kernel, session/result stores) runs in-memory, while the server still
+  boots the same subsystems (fleet, ReasoningBank, workers) so it stays healthy
+  with all 14 domains. Opt-in — the default persistent mode is unchanged.
+  (#530, #534)
+
+## Fixed
+
+- **MCP stdio server is now spec-compliant for strict clients.** Subsystem
+  `console.log` was leaking onto stdout and corrupting JSON-RPC framing, and
+  `initialize` hardcoded the protocol version — both made strict clients
+  (OpenCode, the official MCP SDK) fail with "Failed to get tools". Console
+  output is routed to stderr and `protocolVersion` is negotiated. Applies in all
+  modes. (#527)
+- **OpenCode provisioning now ships a loadable format** — agents and skills are
+  converted at install time to native `.opencode/agent/*.md` and
+  `.opencode/skills/<name>/SKILL.md` with per-agent permission frontmatter. (#529)
+- **protobufjs and ws production CVEs** — cleared two high-severity advisories
+  from the supply-chain audit gate: protobufjs (GHSA-f38q-mgvj-vph7,
+  GHSA-wcpc-wj8m-hjx6) → 7.6.4 and ws (GHSA-96hv-2xvq-fx4p) → 8.21.0, via
+  overrides staying within each package's current major.
+
+## Changed
+
+- **OpenCode installs no longer copy non-loadable `.opencode/tools/*.ts`
+  wrappers** — they were never loadable by OpenCode's `tool()` API and are
+  redundant with the MCP server, which exposes the same tools. (#531)
+- Bumped `vite` 8.0.9 → 8.0.16 (dev dependency). (supersedes #536)
+
+## Known follow-ups
+
+- #528 — make `agentic-qe mcp` run in-process (currently mitigated by invoking
+  the `aqe-mcp` bin directly).
+- #532 — platform installs are additive, not exclusive.
+- #533 — propagate `AQE_MEMORY_BACKEND=memory` to all generated MCP client
+  configs, not just `opencode.json`.
+- #535 — pre-existing MCP tool bugs surfaced during smoke testing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentic-qe",
-  "version": "3.10.7",
+  "version": "3.10.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentic-qe",
-      "version": "3.10.7",
+      "version": "3.10.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-qe",
-  "version": "3.10.7",
+  "version": "3.10.8",
   "description": "Agentic Quality Engineering V3 - Domain-Driven Design Architecture with 13 Bounded Contexts, O(log n) coverage analysis, ReasoningBank learning, 60 specialized QE agents, mathematical Coherence verification, deep Claude Flow integration",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Release v3.10.8. Rolls up three already-merged-to-main PRs: database-free OpenCode install + MCP stdio client-compat fixes (#531, @nagoodman), the protobufjs + ws production CVE clearance (#537), and the vite 8.0.16 dev bump (#538, supersedes #536). This PR is the version bump + CHANGELOG + release notes.

## Verification

- **Version audit clean** — version string lives only in `package.json`, `package-lock.json`, and `skills-manifest.json` (`fleetVersion`); all three bumped to 3.10.8. No hardcoded version strings elsewhere in source.
- **Component PRs each passed full CI on main** before merge: #537 (Security Audit + Consumer-side tarball audit green), #531 (all MCP unit/integration/journey/contract/postgres suites green — every real test passed; only fork-token comment steps and the known timing-flake Coverage Analysis were non-green), #538 (all green except the same timing flake).
- **Supply-chain gate confirmed** — `npm audit --omit=dev --audit-level=high` → 0 vulnerabilities on main after #537.
- **Build/typecheck/test deferred to CI** — local build is unreliable in this Codespace (host-shared `node_modules` carries non-Linux native binaries, per project constraints). `npm-publish.yml` is the authoritative gate: it runs `typecheck` + `build` + `test:unit:fast` + `test:integration:fast` on a clean Linux runner before publishing.

## Failure modes

- **Publish workflow fails on a flaky perf-timing test** — not covered by the publish gate: `npm-publish.yml` runs `test:unit:fast` + `test:integration:fast`, neither of which includes the timing-sensitive `tests/performance/milestone1-baselines` or `tests/unit/integrations/ruvector/hopfield-memory` tests that flake on slow CI runners. Those only run in the broader Coverage Analysis PR check.
- **A version string was missed** — covered by the version audit above (only 3 files carry it; all updated).
- **Published package broken on clean install** — covered by `npm-publish.yml`'s build + dist-bundle verification and the post-publish isolated-install check.

---

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.** "Unlikely" is not an acceptable substitute. If you wrote "I don't think this can happen but...", that sentence is a failure mode and needs a test or an issue link.

### Optional context

- Linked issues: #527, #529, #530, #534, #531, #537 (supersedes #536)
- Affects published API or CLI surface: yes — new `aqe init --with-opencode --no-database` mode
- Touches the init flow / `npm-publish.yml` / `tests/fixtures/init-corpus/`: yes (init flow, via #531)

See [CHANGELOG](CHANGELOG.md) for details.
