### PR TITLE
chore(release): v3.10.9

### DIFF
--- a/.claude/skills/skills-manifest.json
+++ b/.claude/skills/skills-manifest.json
@@ -939,7 +939,7 @@
   },
   "metadata": {
     "generatedBy": "Agentic QE Fleet",
-    "fleetVersion": "3.10.8",
+    "fleetVersion": "3.10.9",
     "manifestVersion": "1.4.0",
     "lastUpdated": "2026-04-13T00:00:00.000Z",
     "contributors": [

--- a/.github/workflows/mcp-tools-test.yml
+++ b/.github/workflows/mcp-tools-test.yml
@@ -141,6 +141,10 @@ jobs:
       - uses: actions/setup-node@v4
         with: { node-version: '24.13.0', cache: 'npm' }
       - run: npm ci
+      # C3: integration tests under tests/integration/mcp drive the BUILT
+      # bundles (dist/cli + dist/mcp). Without this build step they were
+      # silently skipping (describe.skipIf(!BUILT)) — a false green.
+      - run: npm run build
 
       - name: Run MCP integration tests
         run: |
@@ -155,7 +159,9 @@ jobs:
           exit $EXIT
         env:
           NODE_OPTIONS: '--max-old-space-size=1024'
-        continue-on-error: true
+        # C3: was `continue-on-error: true`, which let real failures pass as
+        # green. Removed so this job is an actual gate. The exit-124 hang
+        # tolerance above still absorbs the known vitest-hang flake.
 
       - name: Generate test report
         uses: dorny/test-reporter@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,43 @@ All notable changes to the Agentic QE project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.10.8] - 2026-06-16
+## [3.10.9] - 2026-06-17
+
+MCP server reliability and database-free completeness, all from community-reported
+issues (@nagoodman). The `agentic-qe mcp` command now serves real MCP clients, a
+stale-cache bug that made `memory_delete` look broken is fixed, database-free mode
+now reaches every editor's MCP config, and a new opt-in lets you install for a
+single platform without the Claude Code surface.
+
+### Added
+
+- **`--no-claude` exclusive install mode** — `aqe init --no-claude --with-<platform>`
+  suppresses the default Claude Code surface (`.claude/`, `.mcp.json`, `CLAUDE.md`,
+  governance, hooks) so the `--with-*` flags become the only install targets — e.g.
+  a clean OpenCode-only project. Opt-in; the default install is unchanged. (#532)
+
+### Fixed
+
+- **`agentic-qe mcp` now works with programmatic MCP clients.** The command
+  double-spawned the server with inherited stdio, so a piped-stdin client received
+  EOF right after `initialize` and never got `tools/list`. The server now runs
+  in-process (like the `aqe-mcp` bin), and a failed startup exits non-zero instead
+  of hanging. (#528)
+- **`memory_delete` is no longer masked by a stale cached read.** Delete worked, but
+  the session cache served a stale `memory_retrieve` afterward (the tell-tale
+  identical timestamp), making delete look like a no-op. Mutating tools now
+  invalidate their domain's cached reads. (#535)
+- **Database-free mode reaches every MCP config, not just OpenCode.** `--no-database`
+  now propagates `AQE_MEMORY_BACKEND=memory` to `.mcp.json` (Claude Code), Cursor,
+  Cline, Continue.dev, Kilo Code, Roo Code, Windsurf, Codex, Copilot, and Kiro — so
+  launching the server through any client no longer recreates `.agentic-qe/memory.db`
+  at runtime. The default persistent backend is unchanged. (#533)
+
+### Changed
+
+- **`js-yaml` dev dependency bumped to 4.2.0.** (#540)
+
+
 
 A database-free OpenCode install and a set of MCP stdio client-compatibility
 fixes (community contribution from @nagoodman), plus a dependency-security pass

--- a/docs/metaharness/05-cross-pollination-goap-plan.md
+++ b/docs/metaharness/05-cross-pollination-goap-plan.md
@@ -1,0 +1,215 @@
+# Cross-Pollination GOAP Plan — AQE ⇄ MetaHarness
+
+**Source of intent:** [`04-six-hats-cross-pollination.md`](./04-six-hats-cross-pollination.md) (Blue Hat action table + sequence).
+**Method:** Goal-Oriented Action Planning — A* through a precondition/effect state space, gated on an empirical decision point.
+**Repos:** AQE `/workspaces/agentic-qe` · MetaHarness `/workspaces/agent-harness-generator` (`metaharness@0.1.7`).
+**Date:** 2026-06-15. **Status:** PLAN (not executed).
+
+---
+
+## Goal state — what "done" looks like
+
+The ecosystem realizes the *verified* subset of the cross-pollination, never on faith:
+
+- **G1.** AQE practices the MCP governance MetaHarness preaches: a default-deny allowlist for its ~90 `mcp__agentic-qe__*` tools, derived from a real `mcp-scan` of its own surface, with HIGH findings resolved or explicitly accepted.
+- **G2.** AQE's blind-refuter verification primitive ships as a standalone, domain-agnostic package (`@ruvector/adversarial-verify`) reusable by both projects.
+- **G3.** An empirical verdict exists (DRACO-for-QE) on whether a verification-gated QE harness beats both *vanilla model* and *bare AQE-install* on objective QE scorers. **This is the gate that authorizes everything in Phase 2+.**
+- **G4 (only if G3 passes).** Per-repo QE tuning (genome→skill subset), `adversarial-verify` embedded as a MetaHarness output gate, a version contract + shared CI, a shippable `vertical:qe` harness, and a *real* `witnessVerify`.
+- **G-ABORT.** If G3 shows `vertical:qe ≤ vanilla` (the DRACO pattern repeats), Phase 2/3 are **not** built; #1/#2/#5 ship as standalone wins and the learning is recorded.
+
+**Success is defined by evidence, not delivery:** the headline `vertical:qe` is a *conditional* goal, not a committed one.
+
+---
+
+## Current state (grounded, verified 2026-06-15)
+
+| Fact | Evidence |
+|---|---|
+| Blind-refuter pipeline exists, single file | `.claude/workflows/qcsd-development-review.js` (7.3 KB): N refuters, blind, default-refuted, ⌈N/2⌉ kill, deterministic JS synthesis |
+| Verdict contract exists | `schemas/finding-verdict.schema.json` (`finding-verdict@1`, ADR-103); refuters per ADR-074 |
+| AQE MCP surface is large & real | `src/mcp/protocol-server.ts`, `src/mcp/tools/registry.ts` (`QE_TOOLS`), `src/mcp/qe-tool-bridge.ts`; ~90 tools |
+| AQE has per-*role* allowlists only, no per-repo scan | `src/mcp/tool-scoping.ts` (role allowlists incl. `allowAll` for admin tiers) |
+| AQE installs the full fleet wholesale | `src/init/*-installer.ts` (no per-repo subsetting) |
+| AQE generated-install policy files | `.claude/settings.json`, `.mcp.json` |
+| AQE has a real, tested Ed25519 chain (internal events only) | `src/audit/witness-chain.ts` |
+| MetaHarness scanner / genome / bench all real | `packages/create-agent-harness/src/{mcp-scan,genome,genome-scorers}.ts`; `packages/bench/draco` + `packages/bench/src/draco/` |
+| MetaHarness vertical templates are thin scaffolds; no QE vertical | `examples-packages/coding` (test-writer role ~7 LoC); no `vertical:qe` |
+| DRACO measured generic harness *loses* to vanilla at frontier | ADR-038 (Accepted): vanilla 0.7143 > fusion 0.6472 > harness 0.6126 |
+| MetaHarness witness ships degraded (no JS verifier wired) | `witness-client.ts:74/86`, `publish.ts:106 TODO` (see qcsd-development/05-security-scan HIGH-1) |
+| **No AQE↔MetaHarness integration exists today** | zero repo refs to `metaharness`/`vertical:qe` before this folder |
+
+---
+
+## Gap analysis
+
+| Goal | Gap to close |
+|---|---|
+| G1 | AQE never ran a tool-level security scan on itself; no default-deny allowlist artifact; no CI gate |
+| G2 | The refuter logic is trapped in one workflow file, coupled to QCSD-dev phase, agent-driven, kill-rate uncalibrated |
+| G3 | No QE-specific benchmark exists; DRACO is generic deep-research; no fixed QE task corpus or objective scorer harness |
+| G4 | No genome→skill mapping; no output-gate hook in MetaHarness verticals; no version contract; no `vertical:qe`; witnessVerify unwired |
+
+---
+
+## Action inventory (preconditions · effects · cost)
+
+> Cost legend: **S** ≤ ~2 days · **M** ~1–2 weeks · **L** ~3+ weeks. Risk = chance of forcing a replan.
+
+| # | Action | Pre | Effect | Cost | Risk | Dir |
+|---|---|---|---|---|---|---|
+| A1 | `mcp-scan` AQE's ~90 tools → default-deny allowlist | MetaHarness `mcp-scan` runnable; AQE tool registry readable | G1; dogfood artifact | S | Low | B→A |
+| A2 | Extract `@ruvector/adversarial-verify` | refuter file + schema stable | G2; reusable primitive | M | Low–Med | A→shared |
+| A3 | **DRACO-for-QE benchmark** (vanilla / AQE-install / vertical:qe / +verify) | A2 (for the +verify arm); QE corpus defined | G3 verdict (**the gate**) | M | Low (valuable either way) | both |
+| A4 | Genome → QE-skill subset recommender | A3 PASS; genome profile + skill→profile map | per-repo tuning | M | Med | both |
+| A5 | MetaHarness embeds `adversarial-verify` as optional output gate | A2 published | verticals get earns-its-cost verification | S | Low | A→B |
+| A8 | Version contract + shared integration CI | intent to deeply couple | safe coupling substrate | M | — (enabler) | both |
+| A6 | `vertical:qe` minted harness | **A3 PASS** + A4 + A5 + A8 | headline composite product | L | **High** | both |
+| A7 | Finish `witnessVerify` w/ AQE Ed25519 chain; sign delivered findings | A6 (or standalone) | real provenance, not theater | L | Med | A→B then B→A |
+
+---
+
+## The plan (A* sequence with the empirical gate)
+
+```
+Phase 0  (now, parallel, zero cross-coupling):   A1  ||  A2
+Phase 1  (THE GATE):                             A3  DRACO-for-QE
+            ├─ if vertical:qe  >  vanilla AND > AQE-install ─► proceed to Phase 2
+            └─ if vertical:qe ≤ vanilla ───────────────────► ABORT (see below)
+Phase 2  (only on PASS, parallel):               A4  ||  A5
+Phase 3  (only if Phase 2 lands, sequential):    A8 → A6 → A7
+```
+
+**ABORT condition (G-ABORT):** if A3 shows `vertical:qe ≤ vanilla` on the QE scorers, **STOP at Phase 2**. Ship A1, A2, A5 as standalone wins (they pay off regardless), record the negative result as an ADR (mirroring DRACO's honesty), and do **NOT** build A6/A4-as-product. The composite is conditional, not committed.
+
+**Highest-leverage first move:** A2 (extract `adversarial-verify`), with A1 as a same-sprint quick win — both deliver value with *no coupling* of the two pre-1.0 projects.
+
+---
+
+## Per-action: implementation · integration · verification
+
+### A1 — `mcp-scan` AQE on itself → default-deny allowlist  *(Phase 0, B→A, S)*
+**Implementation**
+1. Build MetaHarness once (`cd /workspaces/agent-harness-generator && npm run build`) so `harness mcp-scan` runs.
+2. Emit a policy snapshot of AQE's surface: enumerate `QE_TOOLS` from `src/mcp/tools/registry.ts` + role rules in `src/mcp/tool-scoping.ts` into the `.harness/mcp-policy.json` / `.claude/settings.json` shape `scanMcp` expects.
+3. Run `harness mcp-scan` against it; capture HIGH/MED/LOW.
+4. Triage HIGH (expect: not-default-deny, `allowAll` admin tiers, wildcard `mcp__*`, any shell-allow). Author a **default-deny** allowlist that opts *in* only the tools each role needs.
+5. Wire `mcp-scan` (exit 1 on HIGH) as an AQE CI gate.
+
+**Integration points:** `src/mcp/tools/registry.ts`, `src/mcp/tool-scoping.ts`, `.claude/settings.json`, `.mcp.json`, AQE CI workflow.
+**Verification:** (a) scan runs and produces a report; (b) post-allowlist re-scan = **0 HIGH**; (c) full QE suite still green under the tightened allowlist (no tool starved); (d) CI fails on a deliberately-reintroduced HIGH. **Deliverable:** the scan report doubles as a co-marketing artifact (largest real MCP surface scanned).
+
+### A2 — Extract `@ruvector/adversarial-verify`  *(Phase 0, A→shared, M)*
+**Implementation**
+1. Factor the pure logic out of `.claude/workflows/qcsd-development-review.js`: `verify(findings, {refuters:N, killThreshold:⌈N/2⌉, judge})` → `finding-verdict@1` envelopes.
+2. Define a host-agnostic `Judge` interface (inject the LLM call) so the package has no AQE/agent dependency; keep deterministic JS synthesis in-package.
+3. Vendor `schemas/finding-verdict.schema.json`; validate output at the boundary.
+4. Harden beyond the single QCSD-dev phase: parametrize the claim/evidence shape; remove phase-specific assumptions.
+5. **Calibrate the kill-rate**: build a labeled fixture set (known-true + known-false findings) and measure false-kill / false-keep; tune default `N` and threshold; document the operating point.
+6. Publish under `@ruvector/*`; AQE re-consumes it in its workflow (dogfood).
+
+**Integration points:** new package; AQE workflow imports it back; MetaHarness consumes it in A5.
+**Verification:** (a) unit tests on synthesis (k-of-n math, default-refuted on uncertainty); (b) calibration report (false-kill rate on the labeled set, target stated); (c) AQE's `qcsd-development-review` produces *identical* verdicts after swapping to the package (regression parity); (d) zero AQE/Claude-Code import in the package (grep).
+
+### A3 — DRACO-for-QE benchmark  *(Phase 1 — THE GATE, both, M)*
+**Implementation**
+1. Define a fixed QE corpus: N repos/modules with ground-truth (known bugs/mutants, known coverage gaps).
+2. Objective scorers (no LLM judge needed): **coverage delta, mutation kill-rate, false-finding rate**, latency, token cost.
+3. Four arms: (a) vanilla model, (b) bare AQE-install, (c) `vertical:qe` prototype, (d) `vertical:qe` + `adversarial-verify`.
+4. Reuse MetaHarness DRACO harness shape (`packages/bench/src/draco/`) for runner/scorer/ablation plumbing.
+5. Run with confidence intervals (n≥20 per arm), publish results as an ADR — **including a negative result** if that's what happens.
+
+**Integration points:** `packages/bench/` (MetaHarness) or an AQE `bench/` mirror; A2 for arm (d).
+**Verification / gate criteria:** arm (c) or (d) must **beat both (a) vanilla and (b) AQE-install** on the primary scorers with margin beyond noise. **PASS → Phase 2. FAIL/TIE → ABORT.** Either outcome is a shippable finding.
+
+### A4 — Genome → QE-skill subset recommender  *(Phase 2, both, M)*
+**Implementation**
+1. Consume MetaHarness `repo-profile.json` (languages, CI, test commands, MCP surface) from `genome.ts`/`analyze-repo.ts`.
+2. Author a deterministic, explainable skill→profile mapping (e.g. SAP repo → `qe-sap-rfc-tester`+`qe-sod-analyzer`; React → `qe-visual-tester`+`qe-accessibility-auditor`).
+3. Emit a recommended *subset* of AQE's 60 agents / ~70 skills with rationale per pick.
+4. Feed the subset into AQE installers (`src/init/*-installer.ts`) to replace wholesale install.
+
+**Integration points:** `genome.ts` (read), `src/init/*-installer.ts` (write), skill catalog.
+**Verification:** (a) deterministic output for a fixed profile (no `Math.random`/`Date.now`); (b) curated golden repos get the expected subset; (c) recommended subset still passes that repo's QE smoke; (d) explanation present for every pick.
+
+### A5 — MetaHarness embeds `adversarial-verify` as output gate  *(Phase 2, A→B, S)*
+**Implementation**
+1. Add an optional per-vertical `verify` hook that routes a finding/claim through `@ruvector/adversarial-verify` before the harness acts/emits.
+2. Make it opt-in in the vertical template config; default off for cheap verticals.
+3. Surface verdicts in harness output + (later) witness.
+
+**Integration points:** MetaHarness vertical template config; host adapters (`packages/host-*`); A2 package.
+**Verification:** (a) a seeded false claim is killed by the gate; (b) a true claim survives; (c) gate is no-op when disabled (cost neutral); (d) added latency/token cost measured and documented.
+
+### A8 — Version contract + shared integration CI  *(Phase 3 prereq, both, M)*
+**Implementation**
+1. Pin stable contracts: AQE tool-signature manifest, MetaHarness genome/host-adapter schema, the (real) witness format.
+2. SemVer + compat matrix; deprecation policy; single named owner for `vertical:qe`.
+3. Shared CI job that runs **both** repos' tests against the integration on each change.
+
+**Integration points:** both repos' CI; a published contract schema.
+**Verification:** (a) a breaking change in either contract fails the shared CI; (b) compat matrix documented; (c) owner + deprecation policy recorded in an ADR.
+
+### A6 — `vertical:qe` minted harness  *(Phase 3, both, L, GATED on A3 PASS)*
+**Implementation**
+1. Author a `vertical:qe` template backed by AQE's MCP engine, the A4 recommender, and the A5 verify gate.
+2. `npx metaharness my-repo --template vertical:qe` → branded, genome-tuned, mcp-scanned QE harness with only the repo's needed agents.
+3. Ship default-deny MCP (reconcile AQE's ~90-tool surface with MetaHarness's minimal-surface posture — real design work, not wiring).
+
+**Integration points:** MetaHarness template catalog + host adapters; AQE MCP engine; A4/A5/A8.
+**Verification:** (a) minted harness passes `harness validate` + `mcp-scan` (0 HIGH); (b) re-runs the A3 scorers and **still beats vanilla** on a *held-out* repo set (no overfit to the benchmark); (c) `harness upgrade` survives a hand-edit; (d) no version-skew break under A8 CI.
+
+### A7 — Finish `witnessVerify` with AQE's Ed25519 chain  *(Phase 3, A→B then B→A, L)*
+**Implementation**
+1. Point AQE's working `src/audit/witness-chain.ts` at *delivered findings* (not just internal events).
+2. Contribute a working JS verifier back to MetaHarness to resolve `publish.ts:106 TODO` and replace the `witness-client.ts` degraded `{valid:true}` path — **fail closed** when no verifier (ties to qcsd-development HIGH-1).
+3. Wire verify into `vertical:qe` publish.
+
+**Integration points:** `src/audit/witness-chain.ts` (AQE), `witness-client.ts`/`publish.ts` (MetaHarness).
+**Verification:** (a) a tampered witness **throws** on publish (the HIGH-1 regression test); (b) sign→verify round-trip on delivered findings; (c) no path returns `valid:true` without real crypto.
+
+---
+
+## Risk factors & replanning triggers
+
+- **R1 (gate fails):** A3 shows no QE win → ABORT to Phase 2; convert A6 effort into shipping A5 as a standalone product. *(Primary, planned-for branch.)*
+- **R2 (refuter over-kills):** A2 calibration shows high false-kill → keep AQE-internal until tuned; don't publish a mis-calibrated primitive.
+- **R3 (governance clash):** A1/A6 reveal AQE's ~90-tool surface can't be reconciled with default-deny without crippling QE → scope `vertical:qe` to a curated tool subset; re-plan A6.
+- **R4 (version skew):** two pre-1.0 projects drift → A8 must precede A6; if A8 slips, do not start A6.
+- **R5 (opportunity cost):** integration displaces unfinished cores (AQE's 4 missing QCSD phases; MetaHarness's 8 unwired kernel subsystems + witness) → cap cross-pollination at Phase 0/2 standalone wins until cores stabilize.
+
+**Replanning triggers:** any action's precondition no longer holds; A3 result (the big fork); calibration/governance findings in A1/A2; A8 contract instability.
+
+## Fallback
+
+If deep coupling proves unwise at any point, the **decoupled wins stand alone**: A1 (AQE self-governance), A2 (`@ruvector/adversarial-verify` as ecosystem IP), and A5 (verify gate for any vertical) each deliver value with zero composite product. That is the floor; the `vertical:qe` factory (A6) is the conditional ceiling.
+
+---
+
+*Plan prepared via GOAP grounded in a file-level audit of both repos. No code executed beyond read-only verification of integration points. Phase 2+ is conditional on the A3 empirical gate — by design.*
+
+---
+
+## Plan update — 2026-06-17 (after pulling MetaHarness main + Ruv's ADR-150)
+
+**Trigger:** pulled MetaHarness `main` (+57 commits, `367ce6e → 61e6819`, now `v0.1.15`) and analyzed Ruv's **ADR-150** "Ruflo × MetaHarness Integration — OIA-Layered Walkthrough" ([gist](https://gist.github.com/ruvnet/9056701d13d5a5b5148d0459ff10b7c3)). ADR-150 does *into ruflo* what this plan proposes for AQE, so several actions are now de-risked or already built upstream.
+
+### The A3 gate just got a strong prior — it leans **G-ABORT**
+
+`ADR-038` is now **Accepted** in the pulled MetaHarness tree: the DRACO ceiling finding is *airtight and mechanistic* — at the frontier, vanilla (0.7143) > fusion (0.6472) > generic harness (0.6126), and every optimization arm (augment-verify→prune, self-consistency best-of-N, composite per-dimension selection) landed **within noise or lost** to vanilla. This is exactly the pattern the A3 gate was built to detect. **The DRACO-for-QE benchmark has NOT been run**, so the gate is not formally closed — but the upstream prior now strongly predicts a tie/loss for a generic `vertical:qe`. **Recommendation: treat A6 as unlikely-to-build; front-load the standalone wins (A1/A2/A5) and only run A3 to confirm the negative before formally invoking G-ABORT.**
+
+### Actions changed by upstream work
+
+| # | Was | Now (post-pull) |
+|---|---|---|
+| A1 | Build an `mcp-scan` self-governance gate from scratch | **Consume, don't build.** MetaHarness ships `mcp-scan --json` (`cf72072`, v0.1.15), the `metaharness score <repo>` scorecard (ADR-041), and 7 OIA MCP tools incl. `metaharness_mcp_scan` / `metaharness_threat_model`. A1 shrinks to: run these against AQE's ~90-tool surface + wire the CI gate. |
+| A3 | Open empirical question | Strong prior toward FAIL (ADR-038 Accepted). Still worth running to *confirm* the negative cheaply. |
+| A6 | Conditional ceiling | **Likely not built** — the prior predicts no QE win at the frontier. |
+
+### New candidate actions lifted from ADR-150 (standalone, no coupling)
+
+- **A9 — Graceful-degradation architecture** *(S, low risk)*: adopt ADR-150's `optionalDependencies` + `MODULE_NOT_FOUND → {degraded:true}` + CI "absent drill" pattern. Pays off twice: (1) fixes the `@ruvector/ruvllm` optional-dep fragility that keeps breaking Dependabot lockfiles (it broke PR #540), and (2) is the clean substrate for database-free mode (issues #533/#535). Highest leverage of the new items.
+- **A10 — KRR cost-optimal router** *(M, med risk)*: lift ADR-150 L3 (Kernel Ridge Regression + k-NN quality predict + Thompson-sampling bandit shadow + 3-criterion AND-gate promotion: `quality +>2% AND cost +<1% AND p95 +<5%`) into AQE's `model_route`/`routing_economics`. AQE router confidence sits at ~40% across 2165 requests — concrete upside.
+
+### Cross-link
+
+ADR-150's discovered `spawnSync` `shell:false` bug (args-with-spaces silently triggered graceful degradation, masking a real failure) is the **same bug class** as AQE **#528** (`agentic-qe mcp` double-spawned with `stdio:'inherit'`, dropping stdin → premature shutdown). #528 is fixed on `fix/528-mcp-in-process` (server now runs in-process; reproduction + regression test added). Lesson carried over: *graceful degradation is insufficient on its own — prove the non-degraded path works.*

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -4,6 +4,7 @@ All Agentic QE release notes organized by version.
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| [v3.10.9](v3.10.9.md) | 2026-06-17 | MCP reliability + db-free completeness (@nagoodman): `agentic-qe mcp` runs in-process so real clients get `tools/list` (#528); `memory_delete` no longer masked by stale session cache (#535); `--no-database` reaches all editor MCP configs (#533); new `--no-claude` exclusive install (#532). |
 | [v3.10.8](v3.10.8.md) | 2026-06-16 | Database-free OpenCode install (`--no-database`/`--memory memory`, #530/#534) + MCP stdio client-compat fixes (#527 stdout purity + negotiated protocol, #529 loadable OpenCode assets) from @nagoodman; cleared protobufjs + ws production CVEs; vite → 8.0.16. |
 | [v3.10.7](v3.10.7.md) | 2026-06-12 | Learning-integrity + supply chain: fix silent self-learning loss (hook swallowed native-binary errors; SONA reward feedback was inert, fixed via `@ruvector/sona` 0.1.7); shift-left consumer-tarball audit gate; refresh QE skill evals to current models. |
 | [v3.10.6](v3.10.6.md) | 2026-06-11 | Pattern Space cross-pollination (#522): evidence-class labels on findings, pass/fail safety eval for data-protection rules, shipped-agent invariant CI, benchmark lineage + interaction benchmark, kept-nulls learning. ADR-105–110. |

--- a/docs/releases/v3.10.9.md
+++ b/docs/releases/v3.10.9.md
@@ -1,0 +1,49 @@
+# v3.10.9 Release Notes
+
+**Release Date:** 2026-06-17
+
+## Highlights
+
+MCP server reliability and database-free completeness, all from community-reported
+issues (@nagoodman): `agentic-qe mcp` now serves real MCP clients, a stale-cache bug
+that made `memory_delete` look broken is fixed, database-free mode now reaches every
+editor's MCP config, and a new opt-in installs for a single platform without the
+Claude Code surface.
+
+## Added
+
+- **`--no-claude` exclusive install mode** — `aqe init --no-claude --with-<platform>`
+  suppresses the default Claude Code surface (`.claude/` skills+agents, `.mcp.json`,
+  `CLAUDE.md`, governance, hooks) so the `--with-*` flags become the only install
+  targets — e.g. a clean OpenCode-only project. Opt-in; the default install is
+  byte-for-byte unchanged. (#532)
+
+## Fixed
+
+- **`agentic-qe mcp` now works with programmatic MCP clients.** The subcommand
+  double-spawned the server with inherited stdio, so a piped-stdin client received
+  `stdin-eof` immediately after answering `initialize` and never received
+  `tools/list`. The server now runs **in-process** (matching the working `aqe-mcp`
+  bin), and a failed startup exits non-zero instead of hanging. (#528)
+- **`memory_delete` is no longer masked by a stale cached read.** The delete itself
+  always worked — but `memory_retrieve` is cacheable, and a delete didn't invalidate
+  the cached read, so a follow-up retrieve served the stale "found" entry (the
+  tell-tale identical timestamp). Mutating tools now invalidate their domain's cached
+  reads. (#535)
+- **Database-free mode reaches every MCP config, not just OpenCode.** `aqe init
+  --no-database` now propagates `AQE_MEMORY_BACKEND=memory` to `.mcp.json` (Claude
+  Code), Cursor, Cline, Continue.dev (including the merge-into-existing path), Kilo
+  Code, Roo Code, Windsurf, Codex, Copilot, and Kiro — so launching the server
+  through any client no longer recreates `.agentic-qe/memory.db` at runtime. The
+  default persistent backend is unchanged. (#533)
+
+## Changed
+
+- **`js-yaml` dev dependency bumped to 4.2.0** (Dependabot, with the lockfile's pruned
+  optional platform binaries restored). (#540)
+
+## Notes
+
+The in-process MCP fix (#528) and the cache fix (#535) ship with integration tests
+that drive the real protocol server, and those tests now run in CI (a prior gap where
+they silently skipped without a build step has been closed).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentic-qe",
-  "version": "3.10.8",
+  "version": "3.10.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentic-qe",
-      "version": "3.10.8",
+      "version": "3.10.9",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "test:all": "npm test -- --run",
     "test:mcp": "npm run test:unit:mcp",
     "test:mcp:integration": "npm test -- --run tests/integration/mcp/",
-    "test:integration:fast": "NODE_OPTIONS='--max-old-space-size=2048 --expose-gc' vitest run tests/integration/mcp/fleet-init-wires-daemon.test.ts tests/integration/workers/workers-reach-domains.test.ts tests/integration/learning/coordinator-roundtrip.test.ts tests/integration/bridge/bridge-end-to-end.test.ts",
+    "test:integration:fast": "NODE_OPTIONS='--max-old-space-size=2048 --expose-gc' vitest run tests/integration/mcp/fleet-init-wires-daemon.test.ts tests/integration/mcp/mcp-cli-inprocess.test.ts tests/integration/mcp/memory-delete-cache-invalidation.test.ts tests/integration/workers/workers-reach-domains.test.ts tests/integration/learning/coordinator-roundtrip.test.ts tests/integration/bridge/bridge-end-to-end.test.ts",
     "test:integration": "NODE_OPTIONS='--max-old-space-size=4096 --expose-gc' vitest run tests/integration/ --exclude='**/browser/**' --exclude='**/browser-integration/**' --exclude='**/*.e2e.test.ts'",
     "mcp:validate": "node scripts/smoke-mcp-protocol.mjs",
     "mcp:parity": "node scripts/audit-mcp-tool-parity.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-qe",
-  "version": "3.10.8",
+  "version": "3.10.9",
   "description": "Agentic Quality Engineering V3 - Domain-Driven Design Architecture with 13 Bounded Contexts, O(log n) coverage analysis, ReasoningBank learning, 60 specialized QE agents, mathematical Coherence verification, deep Claude Flow integration",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -10,10 +10,9 @@
  */
 
 import { Command } from 'commander';
-import { spawn } from 'child_process';
 import { join, dirname } from 'path';
 import { existsSync } from 'fs';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import { findPackageRoot } from '../../init/find-package-root.js';
 
 /**
@@ -25,14 +24,11 @@ export function createMcpCommand(): Command {
     .option('--http <port>', 'Also start HTTP server for AG-UI/A2A protocols', '0')
     .option('--verbose', 'Enable verbose logging')
     .action(async (options) => {
-      // Set up environment
-      const env: Record<string, string> = {
-        ...process.env as Record<string, string>,
-        AQE_HTTP_PORT: options.http || '0',
-      };
-
+      // Configure the server via env BEFORE importing the entry — entry.ts
+      // reads these at startup.
+      process.env.AQE_HTTP_PORT = options.http || '0';
       if (options.verbose) {
-        env.AQE_VERBOSE = 'true';
+        process.env.AQE_VERBOSE = 'true';
       }
 
       // Find the MCP entry point
@@ -44,32 +40,31 @@ export function createMcpCommand(): Command {
         process.exit(1);
       }
 
-      // Determine how to run the entry point
-      const isBundle = entryPath.endsWith('.js');
-      const command = 'node';
-      const args = isBundle
-        ? [entryPath]
-        : ['--import', 'tsx', entryPath];
-
-      // Spawn the MCP server, inheriting stdio for JSON-RPC communication
-      const child = spawn(command, args, {
-        env,
-        stdio: 'inherit',
-        cwd: process.cwd(),
-      });
-
-      child.on('error', (error) => {
-        console.error('Failed to start MCP server:', error.message);
+      // Run the MCP server IN-PROCESS instead of spawning a child (issue #528).
+      //
+      // The old path spawned `node <entry>` with stdio:'inherit'. With a piped
+      // stdin (any programmatic MCP client), the grandchild saw `stdin-eof`
+      // immediately after answering `initialize` and the Issue #513 stdin-EOF
+      // guard in entry.ts shut it down before it could serve `tools/list`.
+      // Importing the entry runs its top-level `main()`, which starts the
+      // server on THIS process's real stdio and installs its own
+      // signal/stdin shutdown handlers. The dynamic import resolves as soon as
+      // module evaluation kicks off `main()`; the server then keeps the
+      // process alive on stdin. This matches the working `aqe-mcp` bin, which
+      // runs the bundle directly.
+      try {
+        await import(pathToFileURL(entryPath).href);
+      } catch (error) {
+        console.error('Failed to start MCP server:', (error as Error).message);
         process.exit(1);
-      });
+      }
 
-      child.on('exit', (code) => {
-        process.exit(code ?? 0);
-      });
-
-      // Forward signals to child
-      process.on('SIGINT', () => child.kill('SIGINT'));
-      process.on('SIGTERM', () => child.kill('SIGTERM'));
+      // entry.ts kicks off `main()` fire-and-forget, so the import above
+      // resolves while the server's async init is still in flight. Keep this
+      // action pending forever so the CLI wrapper doesn't return (and exit)
+      // out from under the server. entry.ts owns shutdown — its signal and
+      // stdin-EOF handlers call process.exit when the client disconnects.
+      await new Promise<never>(() => { /* server owns the process lifecycle */ });
     });
 
   return cmd;

--- a/src/cli/handlers/init-handler.ts
+++ b/src/cli/handlers/init-handler.ts
@@ -72,6 +72,7 @@ export class InitHandler implements ICommandHandler {
       .option('--with-claude-flow', 'Force Claude Flow integration setup')
       .option('--skip-claude-flow', 'Skip Claude Flow integration')
       .option('--no-governance', 'Skip governance configuration (ADR-058)')
+      .option('--no-claude', 'Suppress the default Claude Code surface (.claude/, .mcp.json, CLAUDE.md, governance, hooks) so --with-<platform> flags are the only install targets (#532)')
       .option('--modular', 'Use new modular init system (default for --auto)')
       .action(async (options) => {
         await this.execute(options, context);
@@ -168,6 +169,23 @@ export class InitHandler implements ICommandHandler {
       }
     }
 
+    // #532: `--no-claude` suppresses the default Claude Code surface so the
+    // `--with-<platform>` flags become the only targets. Commander maps the
+    // negatable flag to `options.claude === false`. Warn if it would produce an
+    // empty install (no platform selected) so the user isn't surprised.
+    const noClaude = options.claude === false;
+    if (noClaude) {
+      const anyPlatform = Boolean(
+        options.withOpencode || options.withN8n || options.withKiro ||
+        options.withCopilot || options.withCursor || options.withCline ||
+        options.withKilocode || options.withRoocode || options.withCodex ||
+        options.withWindsurf || options.withContinuedev || options.withAllPlatforms,
+      );
+      if (!anyPlatform && !isJsonMode) {
+        console.log(chalk.yellow('  --no-claude set without any --with-<platform>: this install will write almost nothing.\n'));
+      }
+    }
+
     const { createModularInitOrchestrator } = await import('../../init/orchestrator.js');
     const orchestrator = createModularInitOrchestrator({
       projectRoot: process.cwd(),
@@ -189,6 +207,7 @@ export class InitHandler implements ICommandHandler {
       withContinueDev: options.withContinuedev,
       noMcp: options.noMcp && !options.withMcp,
       noGovernance: options.noGovernance,
+      noClaude,
       memoryBackend: memoryOnly ? 'memory' : undefined,
     });
 
@@ -617,6 +636,8 @@ interface InitOptions {
   withClaudeFlow?: boolean;
   skipClaudeFlow?: boolean;
   noGovernance?: boolean;
+  /** commander negatable flag: `--no-claude` sets this to false (#532). */
+  claude?: boolean;
   modular?: boolean;
 }
 

--- a/src/cli/handlers/init-handler.ts
+++ b/src/cli/handlers/init-handler.ts
@@ -140,8 +140,13 @@ export class InitHandler implements ICommandHandler {
         options.withWindsurf || options.withContinuedev || options.withAllPlatforms
       );
       const databaseFree = options.database === false || options.memory === 'memory';
+      // #532: `--no-claude` (commander negatable → options.claude === false) is
+      // only honored by the modular orchestrator. Route there too, or the flag
+      // silently falls through to runStandardInit and installs the full Claude
+      // surface it was meant to suppress.
+      const noClaudeRequested = options.claude === false;
 
-      if (options.modular || platformRequested || databaseFree) {
+      if (options.modular || platformRequested || databaseFree || noClaudeRequested) {
         console.log(chalk.blue('\n  Agentic QE v3 Initialization\n'));
         await this.runModularInit(options, context);
         return;

--- a/src/init/cline-installer.ts
+++ b/src/init/cline-installer.ts
@@ -21,6 +21,11 @@ import {
 export interface ClineInstallerOptions {
   projectRoot: string;
   overwrite?: boolean;
+  /**
+   * Memory backend for this install. 'memory' => database-free: the MCP config
+   * is written to run in-memory (AQE_MEMORY_BACKEND=memory, no AQE_MEMORY_PATH). (#533)
+   */
+  memoryBackend?: 'memory' | 'sqlite' | 'agentdb' | 'hybrid';
 }
 
 export interface ClineInstallResult {
@@ -39,11 +44,13 @@ export interface ClineInstallResult {
 export class ClineInstaller {
   private projectRoot: string;
   private overwrite: boolean;
+  private options: ClineInstallerOptions;
   private generator: PlatformConfigGenerator;
 
   constructor(options: ClineInstallerOptions) {
     this.projectRoot = options.projectRoot;
     this.overwrite = options.overwrite ?? false;
+    this.options = options;
     this.generator = createPlatformConfigGenerator();
   }
 
@@ -59,7 +66,7 @@ export class ClineInstaller {
 
     try {
       // Generate MCP config
-      const mcpConfig = this.generator.generateMcpConfig('cline');
+      const mcpConfig = this.generator.generateMcpConfig('cline', { memoryBackend: this.options.memoryBackend });
       const configPath = join(this.projectRoot, mcpConfig.path);
       result.configPath = configPath;
 

--- a/src/init/codex-installer.ts
+++ b/src/init/codex-installer.ts
@@ -21,6 +21,11 @@ import {
 export interface CodexInstallerOptions {
   projectRoot: string;
   overwrite?: boolean;
+  /**
+   * Memory backend for this install. 'memory' => database-free: the MCP config
+   * is written to run in-memory (AQE_MEMORY_BACKEND=memory, no AQE_MEMORY_PATH). (#533)
+   */
+  memoryBackend?: 'memory' | 'sqlite' | 'agentdb' | 'hybrid';
 }
 
 export interface CodexInstallResult {
@@ -39,11 +44,13 @@ export interface CodexInstallResult {
 export class CodexInstaller {
   private projectRoot: string;
   private overwrite: boolean;
+  private options: CodexInstallerOptions;
   private generator: PlatformConfigGenerator;
 
   constructor(options: CodexInstallerOptions) {
     this.projectRoot = options.projectRoot;
     this.overwrite = options.overwrite ?? false;
+    this.options = options;
     this.generator = createPlatformConfigGenerator();
   }
 
@@ -59,7 +66,7 @@ export class CodexInstaller {
 
     try {
       // Generate TOML MCP config
-      const mcpConfig = this.generator.generateMcpConfig('codex');
+      const mcpConfig = this.generator.generateMcpConfig('codex', { memoryBackend: this.options.memoryBackend });
       const configPath = join(this.projectRoot, mcpConfig.path);
       result.configPath = configPath;
 

--- a/src/init/continuedev-installer.ts
+++ b/src/init/continuedev-installer.ts
@@ -21,6 +21,11 @@ import {
 export interface ContinueDevInstallerOptions {
   projectRoot: string;
   overwrite?: boolean;
+  /**
+   * Memory backend for this install. 'memory' => database-free: the MCP config
+   * is written to run in-memory (AQE_MEMORY_BACKEND=memory, no AQE_MEMORY_PATH). (#533)
+   */
+  memoryBackend?: 'memory' | 'sqlite' | 'agentdb' | 'hybrid';
 }
 
 export interface ContinueDevInstallResult {
@@ -39,11 +44,13 @@ export interface ContinueDevInstallResult {
 export class ContinueDevInstaller {
   private projectRoot: string;
   private overwrite: boolean;
+  private options: ContinueDevInstallerOptions;
   private generator: PlatformConfigGenerator;
 
   constructor(options: ContinueDevInstallerOptions) {
     this.projectRoot = options.projectRoot;
     this.overwrite = options.overwrite ?? false;
+    this.options = options;
     this.generator = createPlatformConfigGenerator();
   }
 
@@ -59,7 +66,7 @@ export class ContinueDevInstaller {
 
     try {
       // Generate YAML MCP config
-      const mcpConfig = this.generator.generateMcpConfig('continuedev');
+      const mcpConfig = this.generator.generateMcpConfig('continuedev', { memoryBackend: this.options.memoryBackend });
       const configPath = join(this.projectRoot, mcpConfig.path);
       result.configPath = configPath;
 

--- a/src/init/continuedev-installer.ts
+++ b/src/init/continuedev-installer.ts
@@ -123,6 +123,12 @@ export class ContinueDevInstaller {
       // If existing config already has mcpServers key, append just the server entry
       // to avoid duplicate mcpServers keys (which produces invalid YAML)
       if (existing.includes('mcpServers:')) {
+        // #533: honor database-free mode on the merge path too — otherwise this
+        // hardcoded entry re-introduces AQE_MEMORY_PATH and the server recreates
+        // memory.db at runtime, defeating a --no-database install.
+        const envBlock = this.options.memoryBackend === 'memory'
+          ? `      AQE_MEMORY_BACKEND: memory\n      AQE_V3_MODE: "true"`
+          : `      AQE_MEMORY_PATH: .agentic-qe/memory.db\n      AQE_V3_MODE: "true"`;
         const serverEntry = `  - name: agentic-qe
     command: npx
     args:
@@ -130,8 +136,7 @@ export class ContinueDevInstaller {
       - agentic-qe@latest
       - mcp
     env:
-      AQE_MEMORY_PATH: .agentic-qe/memory.db
-      AQE_V3_MODE: "true"`;
+${envBlock}`;
         return existing.trimEnd() + '\n' + serverEntry + '\n';
       }
 

--- a/src/init/copilot-installer.ts
+++ b/src/init/copilot-installer.ts
@@ -21,6 +21,11 @@ import {
 export interface CopilotInstallerOptions {
   projectRoot: string;
   overwrite?: boolean;
+  /**
+   * Memory backend for this install. 'memory' => database-free: the MCP config
+   * is written to run in-memory (AQE_MEMORY_BACKEND=memory, no AQE_MEMORY_PATH). (#533)
+   */
+  memoryBackend?: 'memory' | 'sqlite' | 'agentdb' | 'hybrid';
 }
 
 export interface CopilotInstallResult {
@@ -39,11 +44,13 @@ export interface CopilotInstallResult {
 export class CopilotInstaller {
   private projectRoot: string;
   private overwrite: boolean;
+  private options: CopilotInstallerOptions;
   private generator: PlatformConfigGenerator;
 
   constructor(options: CopilotInstallerOptions) {
     this.projectRoot = options.projectRoot;
     this.overwrite = options.overwrite ?? false;
+    this.options = options;
     this.generator = createPlatformConfigGenerator();
   }
 
@@ -59,7 +66,7 @@ export class CopilotInstaller {
 
     try {
       // Generate MCP config
-      const mcpConfig = this.generator.generateMcpConfig('copilot');
+      const mcpConfig = this.generator.generateMcpConfig('copilot', { memoryBackend: this.options.memoryBackend });
       const configPath = join(this.projectRoot, mcpConfig.path);
       result.configPath = configPath;
 

--- a/src/init/cursor-installer.ts
+++ b/src/init/cursor-installer.ts
@@ -21,6 +21,11 @@ import {
 export interface CursorInstallerOptions {
   projectRoot: string;
   overwrite?: boolean;
+  /**
+   * Memory backend for this install. 'memory' => database-free: the MCP config
+   * is written to run in-memory (AQE_MEMORY_BACKEND=memory, no AQE_MEMORY_PATH). (#533)
+   */
+  memoryBackend?: 'memory' | 'sqlite' | 'agentdb' | 'hybrid';
 }
 
 export interface CursorInstallResult {
@@ -39,11 +44,13 @@ export interface CursorInstallResult {
 export class CursorInstaller {
   private projectRoot: string;
   private overwrite: boolean;
+  private options: CursorInstallerOptions;
   private generator: PlatformConfigGenerator;
 
   constructor(options: CursorInstallerOptions) {
     this.projectRoot = options.projectRoot;
     this.overwrite = options.overwrite ?? false;
+    this.options = options;
     this.generator = createPlatformConfigGenerator();
   }
 
@@ -59,7 +66,7 @@ export class CursorInstaller {
 
     try {
       // Generate MCP config
-      const mcpConfig = this.generator.generateMcpConfig('cursor');
+      const mcpConfig = this.generator.generateMcpConfig('cursor', { memoryBackend: this.options.memoryBackend });
       const configPath = join(this.projectRoot, mcpConfig.path);
       result.configPath = configPath;
 

--- a/src/init/kilocode-installer.ts
+++ b/src/init/kilocode-installer.ts
@@ -21,6 +21,11 @@ import {
 export interface KiloCodeInstallerOptions {
   projectRoot: string;
   overwrite?: boolean;
+  /**
+   * Memory backend for this install. 'memory' => database-free: the MCP config
+   * is written to run in-memory (AQE_MEMORY_BACKEND=memory, no AQE_MEMORY_PATH). (#533)
+   */
+  memoryBackend?: 'memory' | 'sqlite' | 'agentdb' | 'hybrid';
 }
 
 export interface KiloCodeInstallResult {
@@ -39,11 +44,13 @@ export interface KiloCodeInstallResult {
 export class KiloCodeInstaller {
   private projectRoot: string;
   private overwrite: boolean;
+  private options: KiloCodeInstallerOptions;
   private generator: PlatformConfigGenerator;
 
   constructor(options: KiloCodeInstallerOptions) {
     this.projectRoot = options.projectRoot;
     this.overwrite = options.overwrite ?? false;
+    this.options = options;
     this.generator = createPlatformConfigGenerator();
   }
 
@@ -59,7 +66,7 @@ export class KiloCodeInstaller {
 
     try {
       // Generate MCP config
-      const mcpConfig = this.generator.generateMcpConfig('kilocode');
+      const mcpConfig = this.generator.generateMcpConfig('kilocode', { memoryBackend: this.options.memoryBackend });
       const configPath = join(this.projectRoot, mcpConfig.path);
       result.configPath = configPath;
 

--- a/src/init/kiro-installer.ts
+++ b/src/init/kiro-installer.ts
@@ -39,6 +39,11 @@ export interface KiroInstallerOptions {
   installSteering?: boolean;
   /** Overwrite existing files (default: false) */
   overwrite?: boolean;
+  /**
+   * Memory backend for this install. 'memory' => database-free: the Kiro MCP
+   * config runs the server in-memory (AQE_MEMORY_BACKEND=memory). (#533)
+   */
+  memoryBackend?: 'memory' | 'sqlite' | 'agentdb' | 'hybrid';
 }
 
 export interface KiroInstallResult {
@@ -213,10 +218,10 @@ export class KiroInstaller {
         'agentic-qe': {
           command: 'npx',
           args: ['-y', 'agentic-qe@latest', 'mcp'],
-          env: {
-            AQE_MEMORY_PATH: '.agentic-qe/memory.db',
-            AQE_V3_MODE: 'true',
-          },
+          // Issue #533: database-free installs run the MCP server in-memory.
+          env: this.options.memoryBackend === 'memory'
+            ? { AQE_MEMORY_BACKEND: 'memory', AQE_V3_MODE: 'true' }
+            : { AQE_MEMORY_PATH: '.agentic-qe/memory.db', AQE_V3_MODE: 'true' },
           disabled: false,
           autoApprove: [
             'fleet_init',

--- a/src/init/orchestrator.ts
+++ b/src/init/orchestrator.ts
@@ -70,6 +70,7 @@ export class ModularInitOrchestrator {
         wizardAnswers: options.wizardAnswers,
         noGovernance: options.noGovernance,
         noMcp: options.noMcp,
+        noClaude: options.noClaude,
         memoryBackend: options.memoryBackend,
       },
       config: {},

--- a/src/init/phases/07-hooks.ts
+++ b/src/init/phases/07-hooks.ts
@@ -46,6 +46,11 @@ export class HooksPhase extends BasePhase<HooksResult> {
   readonly requiresPhases = ['configuration'] as const;
 
   async shouldRun(context: InitContext): Promise<boolean> {
+    // #532: hooks write into .claude/ — part of the Claude Code surface.
+    if (context.options.noClaude) {
+      context.services.log('  Hooks skipped (--no-claude)');
+      return false;
+    }
     const config = context.config as AQEInitConfig;
     return config?.hooks?.claudeCode ?? true;
   }

--- a/src/init/phases/08-mcp.ts
+++ b/src/init/phases/08-mcp.ts
@@ -40,6 +40,12 @@ export class MCPPhase extends BasePhase<MCPResult> {
   protected async run(context: InitContext): Promise<MCPResult> {
     const { projectRoot } = context;
 
+    // #532: --no-claude suppresses the Claude Code surface, including .mcp.json.
+    if (context.options.noClaude) {
+      context.services.log('  MCP: skipped (--no-claude — .mcp.json is the Claude Code surface)');
+      return { configured: false, mcpPath: '', serverName: '' };
+    }
+
     // MCP is enabled by default — skip only with --no-mcp
     if (context.options.noMcp) {
       context.services.log('  MCP: skipped (--no-mcp)');
@@ -54,14 +60,29 @@ export class MCPPhase extends BasePhase<MCPResult> {
     // AQE MCP server configuration
     // AQE_PROJECT_ROOT omitted — runtime discovery via findProjectRoot() is
     // portable across machines, devcontainers, and CI (#321)
+    //
+    // Issue #533: in database-free mode (--no-database / memoryBackend:'memory')
+    // the server must run in-memory and must not have learning/workers forced
+    // on (those persist to SQLite, recreating .agentic-qe/memory.db at runtime
+    // and defeating the db-free install). Those phases are already skipped at
+    // install time; mirror that in the generated env.
+    const dbFree = context.options.memoryBackend === 'memory';
+    const env: Record<string, string> = dbFree
+      ? {
+          AQE_MEMORY_BACKEND: 'memory',
+          AQE_LEARNING_ENABLED: 'false',
+          AQE_WORKERS_ENABLED: 'false',
+          NODE_ENV: 'production',
+        }
+      : {
+          AQE_LEARNING_ENABLED: 'true',
+          AQE_WORKERS_ENABLED: 'true',
+          NODE_ENV: 'production',
+        };
     const aqeServerConfig = {
       command: 'aqe-mcp',
       args: [],
-      env: {
-        AQE_LEARNING_ENABLED: 'true',
-        AQE_WORKERS_ENABLED: 'true',
-        NODE_ENV: 'production',
-      },
+      env,
     };
 
     // Write to .mcp.json at project root (the only location Claude Code reads)
@@ -88,8 +109,14 @@ export class MCPPhase extends BasePhase<MCPResult> {
 
     context.services.log(`  MCP config: ${rootMcpPath}`);
     context.services.log(`  Server: agentic-qe`);
-    context.services.log(`  Learning: enabled`);
-    context.services.log(`  Workers: enabled`);
+    if (dbFree) {
+      context.services.log(`  Memory backend: in-memory (database-free)`);
+      context.services.log(`  Learning: disabled (db-free)`);
+      context.services.log(`  Workers: disabled (db-free)`);
+    } else {
+      context.services.log(`  Learning: enabled`);
+      context.services.log(`  Workers: enabled`);
+    }
 
     return {
       configured: true,

--- a/src/init/phases/09-assets.ts
+++ b/src/init/phases/09-assets.ts
@@ -71,8 +71,8 @@ export class AssetsPhase extends BasePhase<AssetsResult> {
       context.services.log(`  Version upgrade detected: updating skills and agents`);
     }
 
-    // Install skills
-    if (config.skills.install) {
+    // Install skills (Claude Code surface — skipped with --no-claude, #532)
+    if (!options.noClaude && config.skills.install) {
       const skillsInstaller = createSkillsInstaller({
         projectRoot,
         installV2Skills: config.skills.installV2,
@@ -88,27 +88,29 @@ export class AssetsPhase extends BasePhase<AssetsResult> {
       }
     }
 
-    // Install agents
-    try {
-      const agentsInstaller = createAgentsInstaller({
-        projectRoot,
-        installQEAgents: true,
-        installSubagents: true,
-        overwrite: shouldOverwrite,
-      });
+    // Install agents (Claude Code surface — skipped with --no-claude, #532)
+    if (!options.noClaude) {
+      try {
+        const agentsInstaller = createAgentsInstaller({
+          projectRoot,
+          installQEAgents: true,
+          installSubagents: true,
+          overwrite: shouldOverwrite,
+        });
 
-      const agentsResult = await agentsInstaller.install();
-      agentsInstalled = agentsResult.installed.length;
+        const agentsResult = await agentsInstaller.install();
+        agentsInstalled = agentsResult.installed.length;
 
-      if (agentsResult.errors.length > 0) {
-        context.services.warn(`Agents warnings: ${agentsResult.errors.join(', ')}`);
+        if (agentsResult.errors.length > 0) {
+          context.services.warn(`Agents warnings: ${agentsResult.errors.join(', ')}`);
+        }
+      } catch (error) {
+        context.services.warn(`Agents install error: ${error instanceof Error ? error.message : error}`);
       }
-    } catch (error) {
-      context.services.warn(`Agents install error: ${error instanceof Error ? error.message : error}`);
-    }
 
-    // Initialize overlay configs in agent registry for runtime use
-    initializeOverlays(projectRoot);
+      // Initialize overlay configs in agent registry for runtime use
+      initializeOverlays(projectRoot);
+    }
 
     // Install Vibium browser engine for the qe-browser fleet skill.
     // Graceful — never fails init if Vibium cannot be installed.
@@ -257,6 +259,7 @@ export class AssetsPhase extends BasePhase<AssetsResult> {
         installHooks: true,
         installSteering: true,
         overwrite: shouldOverwrite,
+        memoryBackend: options.memoryBackend === 'memory' ? 'memory' : undefined,
       });
 
       const kiroResult = await kiroInstaller.install();
@@ -282,7 +285,7 @@ export class AssetsPhase extends BasePhase<AssetsResult> {
 
     if (options.withCopilot || (options.autoMode && existsSync(join(projectRoot, '.vscode')))) {
       const { createCopilotInstaller } = await import('../copilot-installer.js');
-      const installer = createCopilotInstaller({ projectRoot, overwrite: shouldOverwrite });
+      const installer = createCopilotInstaller({ projectRoot, overwrite: shouldOverwrite, memoryBackend: options.memoryBackend === 'memory' ? 'memory' : undefined });
       const res = await installer.install();
       if (res.mcpConfigured) platformsConfigured.push('copilot');
       if (res.errors.length > 0) context.services.warn(`Copilot warnings: ${res.errors.join(', ')}`);
@@ -292,7 +295,7 @@ export class AssetsPhase extends BasePhase<AssetsResult> {
 
     if (options.withCursor || (options.autoMode && existsSync(join(projectRoot, '.cursor')))) {
       const { createCursorInstaller } = await import('../cursor-installer.js');
-      const installer = createCursorInstaller({ projectRoot, overwrite: shouldOverwrite });
+      const installer = createCursorInstaller({ projectRoot, overwrite: shouldOverwrite, memoryBackend: options.memoryBackend === 'memory' ? 'memory' : undefined });
       const res = await installer.install();
       if (res.mcpConfigured) platformsConfigured.push('cursor');
       if (res.errors.length > 0) context.services.warn(`Cursor warnings: ${res.errors.join(', ')}`);
@@ -302,7 +305,7 @@ export class AssetsPhase extends BasePhase<AssetsResult> {
 
     if (options.withCline) {
       const { createClineInstaller } = await import('../cline-installer.js');
-      const installer = createClineInstaller({ projectRoot, overwrite: shouldOverwrite });
+      const installer = createClineInstaller({ projectRoot, overwrite: shouldOverwrite, memoryBackend: options.memoryBackend === 'memory' ? 'memory' : undefined });
       const res = await installer.install();
       if (res.mcpConfigured) platformsConfigured.push('cline');
       if (res.errors.length > 0) context.services.warn(`Cline warnings: ${res.errors.join(', ')}`);
@@ -312,7 +315,7 @@ export class AssetsPhase extends BasePhase<AssetsResult> {
 
     if (options.withKiloCode || (options.autoMode && existsSync(join(projectRoot, '.kilocode')))) {
       const { createKiloCodeInstaller } = await import('../kilocode-installer.js');
-      const installer = createKiloCodeInstaller({ projectRoot, overwrite: shouldOverwrite });
+      const installer = createKiloCodeInstaller({ projectRoot, overwrite: shouldOverwrite, memoryBackend: options.memoryBackend === 'memory' ? 'memory' : undefined });
       const res = await installer.install();
       if (res.mcpConfigured) platformsConfigured.push('kilocode');
       if (res.errors.length > 0) context.services.warn(`Kilo Code warnings: ${res.errors.join(', ')}`);
@@ -322,7 +325,7 @@ export class AssetsPhase extends BasePhase<AssetsResult> {
 
     if (options.withRooCode || (options.autoMode && existsSync(join(projectRoot, '.roo')))) {
       const { createRooCodeInstaller } = await import('../roocode-installer.js');
-      const installer = createRooCodeInstaller({ projectRoot, overwrite: shouldOverwrite });
+      const installer = createRooCodeInstaller({ projectRoot, overwrite: shouldOverwrite, memoryBackend: options.memoryBackend === 'memory' ? 'memory' : undefined });
       const res = await installer.install();
       if (res.mcpConfigured) platformsConfigured.push('roocode');
       if (res.errors.length > 0) context.services.warn(`Roo Code warnings: ${res.errors.join(', ')}`);
@@ -333,7 +336,7 @@ export class AssetsPhase extends BasePhase<AssetsResult> {
     // P2 platforms: Codex (TOML), Windsurf (JSON), Continue.dev (YAML)
     if (options.withCodex || (options.autoMode && existsSync(join(projectRoot, '.codex')))) {
       const { createCodexInstaller } = await import('../codex-installer.js');
-      const installer = createCodexInstaller({ projectRoot, overwrite: shouldOverwrite });
+      const installer = createCodexInstaller({ projectRoot, overwrite: shouldOverwrite, memoryBackend: options.memoryBackend === 'memory' ? 'memory' : undefined });
       const res = await installer.install();
       if (res.mcpConfigured) platformsConfigured.push('codex');
       if (res.errors.length > 0) context.services.warn(`Codex warnings: ${res.errors.join(', ')}`);
@@ -343,7 +346,7 @@ export class AssetsPhase extends BasePhase<AssetsResult> {
 
     if (options.withWindsurf || (options.autoMode && existsSync(join(projectRoot, '.windsurf')))) {
       const { createWindsurfInstaller } = await import('../windsurf-installer.js');
-      const installer = createWindsurfInstaller({ projectRoot, overwrite: shouldOverwrite });
+      const installer = createWindsurfInstaller({ projectRoot, overwrite: shouldOverwrite, memoryBackend: options.memoryBackend === 'memory' ? 'memory' : undefined });
       const res = await installer.install();
       if (res.mcpConfigured) platformsConfigured.push('windsurf');
       if (res.errors.length > 0) context.services.warn(`Windsurf warnings: ${res.errors.join(', ')}`);
@@ -353,7 +356,7 @@ export class AssetsPhase extends BasePhase<AssetsResult> {
 
     if (options.withContinueDev || (options.autoMode && existsSync(join(projectRoot, '.continue')))) {
       const { createContinueDevInstaller } = await import('../continuedev-installer.js');
-      const installer = createContinueDevInstaller({ projectRoot, overwrite: shouldOverwrite });
+      const installer = createContinueDevInstaller({ projectRoot, overwrite: shouldOverwrite, memoryBackend: options.memoryBackend === 'memory' ? 'memory' : undefined });
       const res = await installer.install();
       if (res.mcpConfigured) platformsConfigured.push('continuedev');
       if (res.errors.length > 0) context.services.warn(`Continue.dev warnings: ${res.errors.join(', ')}`);

--- a/src/init/phases/11-claude-md.ts
+++ b/src/init/phases/11-claude-md.ts
@@ -28,6 +28,15 @@ export class ClaudeMdPhase extends BasePhase<ClaudeMdResult> {
   readonly critical = false;
   readonly requiresPhases = ['configuration'] as const;
 
+  async shouldRun(context: InitContext): Promise<boolean> {
+    // #532: --no-claude suppresses the Claude Code surface, including CLAUDE.md.
+    if (context.options.noClaude) {
+      context.services.log('  CLAUDE.md skipped (--no-claude)');
+      return false;
+    }
+    return true;
+  }
+
   protected async run(context: InitContext): Promise<ClaudeMdResult> {
     const config = context.config as AQEInitConfig;
     const { projectRoot } = context;

--- a/src/init/phases/13-governance.ts
+++ b/src/init/phases/13-governance.ts
@@ -54,6 +54,12 @@ export class GovernancePhase extends BasePhase<GovernanceResult> {
    * Run unless --no-governance flag is set
    */
   async shouldRun(context: InitContext): Promise<boolean> {
+    // #532: governance is part of the Claude Code surface — skip with --no-claude.
+    if (context.options.noClaude) {
+      context.services.log('  Governance skipped (--no-claude)');
+      return false;
+    }
+
     // Check for --no-governance flag (via noGovernance option)
     if (context.options.noGovernance) {
       context.services.log('  Governance skipped (--no-governance flag)');

--- a/src/init/phases/phase-interface.ts
+++ b/src/init/phases/phase-interface.ts
@@ -142,6 +142,14 @@ export interface InitOptions {
   withAllPlatforms?: boolean;
   /** Skip MCP server config (MCP is enabled by default) */
   noMcp?: boolean;
+  /**
+   * Suppress the default Claude Code surface (#532). When true, init does NOT
+   * write `.claude/` skills+agents, `.mcp.json`, `CLAUDE.md`, governance, or
+   * hooks — making `--with-<platform>` flags the only install targets (e.g. an
+   * OpenCode-only install). Opt-in via `--no-claude`; default install is
+   * unchanged. Pairs naturally with `--no-database`.
+   */
+  noClaude?: boolean;
   /** @deprecated Use default behavior instead — MCP is now enabled by default */
   withMcp?: boolean;
   /**

--- a/src/init/platform-config-generator.ts
+++ b/src/init/platform-config-generator.ts
@@ -174,14 +174,23 @@ const SAFE_AUTO_APPROVE_TOOLS = [
 // MCP Server Entry
 // ============================================================================
 
-function getMcpServerEntry(withAutoApprove: boolean): Record<string, unknown> {
+/**
+ * Build the MCP server env. Issue #533: in database-free mode the server must
+ * run in-memory (AQE_MEMORY_BACKEND=memory) and must NOT be pointed at a
+ * persistent db path — otherwise launching via this client recreates
+ * .agentic-qe/memory.db at runtime and defeats the --no-database install.
+ */
+function getMcpServerEnv(dbFree: boolean): Record<string, string> {
+  return dbFree
+    ? { AQE_MEMORY_BACKEND: 'memory', AQE_V3_MODE: 'true' }
+    : { AQE_MEMORY_PATH: '.agentic-qe/memory.db', AQE_V3_MODE: 'true' };
+}
+
+function getMcpServerEntry(withAutoApprove: boolean, dbFree: boolean): Record<string, unknown> {
   const entry: Record<string, unknown> = {
     command: 'npx',
     args: ['-y', 'agentic-qe@latest', 'mcp'],
-    env: {
-      AQE_MEMORY_PATH: '.agentic-qe/memory.db',
-      AQE_V3_MODE: 'true',
-    },
+    env: getMcpServerEnv(dbFree),
   };
 
   if (withAutoApprove) {
@@ -196,8 +205,8 @@ function getMcpServerEntry(withAutoApprove: boolean): Record<string, unknown> {
 // Config Generators
 // ============================================================================
 
-function generateJsonConfig(platform: PlatformDefinition): string {
-  const serverEntry = getMcpServerEntry(platform.supportsAutoApprove);
+function generateJsonConfig(platform: PlatformDefinition, dbFree: boolean): string {
+  const serverEntry = getMcpServerEntry(platform.supportsAutoApprove, dbFree);
 
   if (platform.id === 'copilot') {
     // Copilot uses "servers" key with "type": "stdio"
@@ -220,7 +229,10 @@ function generateJsonConfig(platform: PlatformDefinition): string {
   return JSON.stringify(config, null, 2) + '\n';
 }
 
-function generateTomlConfig(): string {
+function generateTomlConfig(dbFree: boolean): string {
+  const envLines = dbFree
+    ? `AQE_MEMORY_BACKEND = "memory"\nAQE_V3_MODE = "true"`
+    : `AQE_MEMORY_PATH = ".agentic-qe/memory.db"\nAQE_V3_MODE = "true"`;
   return `# Agentic QE MCP Server
 [mcp_servers.agentic-qe]
 type = "stdio"
@@ -228,12 +240,14 @@ command = "npx"
 args = ["-y", "agentic-qe@latest", "mcp"]
 
 [mcp_servers.agentic-qe.env]
-AQE_MEMORY_PATH = ".agentic-qe/memory.db"
-AQE_V3_MODE = "true"
+${envLines}
 `;
 }
 
-function generateYamlConfig(): string {
+function generateYamlConfig(dbFree: boolean): string {
+  const envLines = dbFree
+    ? `      AQE_MEMORY_BACKEND: memory\n      AQE_V3_MODE: "true"`
+    : `      AQE_MEMORY_PATH: .agentic-qe/memory.db\n      AQE_V3_MODE: "true"`;
   return `# Agentic QE MCP Server
 mcpServers:
   - name: agentic-qe
@@ -243,8 +257,7 @@ mcpServers:
       - agentic-qe@latest
       - mcp
     env:
-      AQE_MEMORY_PATH: .agentic-qe/memory.db
-      AQE_V3_MODE: "true"
+${envLines}
 `;
 }
 
@@ -335,20 +348,25 @@ export class PlatformConfigGenerator {
   /**
    * Generate the MCP config for a platform
    */
-  generateMcpConfig(platformId: PlatformId): GeneratedConfig {
+  generateMcpConfig(
+    platformId: PlatformId,
+    opts?: { memoryBackend?: 'memory' | 'sqlite' | 'agentdb' | 'hybrid' },
+  ): GeneratedConfig {
     const platform = this.getPlatform(platformId);
+    // Issue #533: database-free installs propagate AQE_MEMORY_BACKEND=memory.
+    const dbFree = opts?.memoryBackend === 'memory';
 
     let content: string;
     switch (platform.configFormat) {
       case 'toml':
-        content = generateTomlConfig();
+        content = generateTomlConfig(dbFree);
         break;
       case 'yaml':
-        content = generateYamlConfig();
+        content = generateYamlConfig(dbFree);
         break;
       case 'json':
       default:
-        content = generateJsonConfig(platform);
+        content = generateJsonConfig(platform, dbFree);
         break;
     }
 

--- a/src/init/roocode-installer.ts
+++ b/src/init/roocode-installer.ts
@@ -21,6 +21,11 @@ import {
 export interface RooCodeInstallerOptions {
   projectRoot: string;
   overwrite?: boolean;
+  /**
+   * Memory backend for this install. 'memory' => database-free: the MCP config
+   * is written to run in-memory (AQE_MEMORY_BACKEND=memory, no AQE_MEMORY_PATH). (#533)
+   */
+  memoryBackend?: 'memory' | 'sqlite' | 'agentdb' | 'hybrid';
 }
 
 export interface RooCodeInstallResult {
@@ -39,11 +44,13 @@ export interface RooCodeInstallResult {
 export class RooCodeInstaller {
   private projectRoot: string;
   private overwrite: boolean;
+  private options: RooCodeInstallerOptions;
   private generator: PlatformConfigGenerator;
 
   constructor(options: RooCodeInstallerOptions) {
     this.projectRoot = options.projectRoot;
     this.overwrite = options.overwrite ?? false;
+    this.options = options;
     this.generator = createPlatformConfigGenerator();
   }
 
@@ -59,7 +66,7 @@ export class RooCodeInstaller {
 
     try {
       // Generate MCP config
-      const mcpConfig = this.generator.generateMcpConfig('roocode');
+      const mcpConfig = this.generator.generateMcpConfig('roocode', { memoryBackend: this.options.memoryBackend });
       const configPath = join(this.projectRoot, mcpConfig.path);
       result.configPath = configPath;
 

--- a/src/init/windsurf-installer.ts
+++ b/src/init/windsurf-installer.ts
@@ -21,6 +21,11 @@ import {
 export interface WindsurfInstallerOptions {
   projectRoot: string;
   overwrite?: boolean;
+  /**
+   * Memory backend for this install. 'memory' => database-free: the MCP config
+   * is written to run in-memory (AQE_MEMORY_BACKEND=memory, no AQE_MEMORY_PATH). (#533)
+   */
+  memoryBackend?: 'memory' | 'sqlite' | 'agentdb' | 'hybrid';
 }
 
 export interface WindsurfInstallResult {
@@ -39,11 +44,13 @@ export interface WindsurfInstallResult {
 export class WindsurfInstaller {
   private projectRoot: string;
   private overwrite: boolean;
+  private options: WindsurfInstallerOptions;
   private generator: PlatformConfigGenerator;
 
   constructor(options: WindsurfInstallerOptions) {
     this.projectRoot = options.projectRoot;
     this.overwrite = options.overwrite ?? false;
+    this.options = options;
     this.generator = createPlatformConfigGenerator();
   }
 
@@ -59,7 +66,7 @@ export class WindsurfInstaller {
 
     try {
       // Generate MCP config (project-level .windsurf/mcp_config.json)
-      const mcpConfig = this.generator.generateMcpConfig('windsurf');
+      const mcpConfig = this.generator.generateMcpConfig('windsurf', { memoryBackend: this.options.memoryBackend });
       const configPath = join(this.projectRoot, mcpConfig.path);
       result.configPath = configPath;
 

--- a/src/mcp/entry.ts
+++ b/src/mcp/entry.ts
@@ -364,4 +364,13 @@ async function main(): Promise<void> {
   }
 }
 
-main();
+// H3: main() runs fire-and-forget, so a rejection that escapes its internal
+// try/catch would otherwise hit the unhandledRejection handler above — which
+// deliberately keeps the server alive at *runtime*. A failed *startup* must
+// instead exit non-zero, especially on the in-process `agentic-qe mcp` path
+// (#528) where the CLI wrapper awaits a never-resolving promise and would
+// otherwise hang with a half-dead server and a zero exit code.
+main().catch((error) => {
+  process.stderr.write(`[MCP Entry] Fatal startup error: ${error instanceof Error ? error.stack || error.message : String(error)}\n`);
+  process.exit(1);
+});

--- a/src/mcp/protocol-server.ts
+++ b/src/mcp/protocol-server.ts
@@ -671,6 +671,23 @@ export class MCPProtocolServer {
       // IMP-00: Execute post-tool-result middleware
       const processedResult = await this.middlewareChain.executePostHooks(processedCtx, result);
 
+      // Issue #535: a mutating tool must evict its domain's cached reads, or a
+      // follow-up read (e.g. memory_retrieve after memory_delete) serves a
+      // stale "found" result and the write looks like a no-op. Writes aren't
+      // cacheable themselves; gate on a mutation-verb suffix and invalidate the
+      // same domain the sibling reads were cached under. Best-effort.
+      if (!cacheable && process.env.AQE_SESSION_CACHE !== 'off' &&
+          /_(store|delete|set|share|update|remove|clear|promote|cleanup)$/.test(name) &&
+          this.isSuccessfulResult(processedResult)) {
+        try {
+          const { getSessionCache } = await import('../optimization/session-cache.js');
+          const { domain } = parseToolDomainAction(name);
+          getSessionCache().invalidateDomain(domain);
+        } catch {
+          // never block tool execution on cache invalidation
+        }
+      }
+
       // Issue #473: Store successful results for future cache hits.
       // Only cache successful results — error objects shouldn't be served back.
       if (cacheable && cacheFingerprint && this.isSuccessfulResult(processedResult)) {

--- a/src/optimization/session-cache.ts
+++ b/src/optimization/session-cache.ts
@@ -216,6 +216,26 @@ export class SessionOperationCache {
     this.misses = 0;
   }
 
+  /**
+   * Invalidate every cached entry for a domain. Issue #535: a mutating tool
+   * (e.g. memory_delete / memory_store) must evict the sibling read entries in
+   * its domain, or a follow-up memory_retrieve serves a stale "found" result
+   * from cache and the delete looks like a no-op. Also drops the persisted
+   * rows so a later loadFromDb() can't resurrect the stale entries. Returns the
+   * number of entries removed.
+   */
+  invalidateDomain(domain: string): number {
+    let removed = 0;
+    for (const [key, entry] of this.cache) {
+      if (entry.domain === domain) {
+        this.cache.delete(key);
+        this.deletePersisted(entry.fingerprint);
+        removed++;
+      }
+    }
+    return removed;
+  }
+
   /** Evict the oldest entry by cachedAt */
   private evictOldest(): void {
     let oldestKey: string | null = null;
@@ -240,6 +260,19 @@ export class SessionOperationCache {
       ).run(`session_cache:${entry.fingerprint}`, JSON.stringify(entry), Date.now());
     } catch {
       /* non-critical - cache works without persistence */
+    }
+  }
+
+  /** Delete a single persisted entry from kv_store (used by invalidateDomain). */
+  private deletePersisted(fingerprint: string): void {
+    try {
+      const db = tryGetDb();
+      if (!db) return;
+      db.prepare(
+        `DELETE FROM kv_store WHERE namespace = 'session_cache' AND key = ?`
+      ).run(`session_cache:${fingerprint}`);
+    } catch {
+      /* non-critical */
     }
   }
 }

--- a/tests/integration/mcp/mcp-cli-inprocess.test.ts
+++ b/tests/integration/mcp/mcp-cli-inprocess.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Integration Regression: `agentic-qe mcp` runs the server IN-PROCESS (issue #528).
+ *
+ * The `mcp` subcommand used to double-spawn `node dist/mcp/bundle.js` with
+ * stdio:'inherit'. With a piped stdin (any programmatic MCP client), the
+ * grandchild saw `stdin-eof` right after answering `initialize` and shut down
+ * (the Issue #513 guard) before it could serve `tools/list`. The fix runs the
+ * entry in-process so the server owns the real stdin — matching the `aqe-mcp`
+ * bin. This test drives the BUILT CLI exactly as a stdio client would.
+ *
+ * Requires the build artifacts (dist/cli/bundle.js + dist/mcp/bundle.js);
+ * skips when they are absent so it never fails an unbuilt checkout.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = join(__dirname, '..', '..', '..');
+const CLI_BUNDLE = join(ROOT, 'dist', 'cli', 'bundle.js');
+const MCP_BUNDLE = join(ROOT, 'dist', 'mcp', 'bundle.js');
+const BUILT = existsSync(CLI_BUNDLE) && existsSync(MCP_BUNDLE);
+
+interface DriveResult {
+  initialize: boolean;
+  toolsList: boolean;
+  toolCount: number;
+  exitCode: number | null;
+}
+
+/**
+ * Spawn `node <args>`, write initialize + initialized + tools/list, then EOF
+ * stdin (the exact #528 trigger). Resolve with which responses came back.
+ */
+function driveMcp(args: string[]): Promise<DriveResult> {
+  return new Promise((resolve) => {
+    const child = spawn('node', args, { cwd: ROOT, stdio: ['pipe', 'pipe', 'ignore'] });
+    const result: DriveResult = { initialize: false, toolsList: false, toolCount: 0, exitCode: null };
+
+    const messages = [
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-11-25', capabilities: {}, clientInfo: { name: 'reg-528', version: '1.0' } } },
+      { jsonrpc: '2.0', method: 'notifications/initialized' },
+      { jsonrpc: '2.0', id: 2, method: 'tools/list' },
+    ];
+    child.stdin.write(messages.map((m) => JSON.stringify(m)).join('\n') + '\n');
+    child.stdin.end(); // EOF — the premature-shutdown trigger
+
+    let buf = '';
+    child.stdout.on('data', (d: Buffer) => {
+      buf += d.toString();
+      let nl: number;
+      while ((nl = buf.indexOf('\n')) >= 0) {
+        const line = buf.slice(0, nl).trim();
+        buf = buf.slice(nl + 1);
+        if (!line) continue;
+        try {
+          const msg = JSON.parse(line);
+          if (msg.id === 1 && msg.result) result.initialize = true;
+          if (msg.id === 2 && msg.result) {
+            result.toolsList = true;
+            result.toolCount = (msg.result.tools || []).length;
+          }
+        } catch { /* server logs non-JSON to stderr; ignore stray stdout lines */ }
+      }
+    });
+
+    const timer = setTimeout(() => { try { child.kill('SIGKILL'); } catch { /* noop */ } resolve(result); }, 45000);
+    child.on('exit', (code) => { clearTimeout(timer); result.exitCode = code; resolve(result); });
+  });
+}
+
+describe.skipIf(!BUILT)('#528 — `agentic-qe mcp` serves tools/list over piped stdin', () => {
+  it('answers initialize AND tools/list (not just initialize) when stdin EOFs', async () => {
+    // Act
+    const res = await driveMcp([CLI_BUNDLE, 'mcp']);
+
+    // Assert — the regression was: initialize answered, tools/list never did.
+    expect(res.initialize).toBe(true);
+    expect(res.toolsList).toBe(true);
+    expect(res.toolCount).toBeGreaterThan(0);
+  }, 60000);
+
+  it('exposes the same tool surface as the direct `aqe-mcp` bundle (CLI/MCP parity)', async () => {
+    // Act
+    const viaCli = await driveMcp([CLI_BUNDLE, 'mcp']);
+    const viaBundle = await driveMcp([MCP_BUNDLE]);
+
+    // Assert — both entry paths expose the same tools.
+    expect(viaCli.toolsList).toBe(true);
+    expect(viaBundle.toolsList).toBe(true);
+    expect(viaCli.toolCount).toBe(viaBundle.toolCount);
+  }, 90000);
+});

--- a/tests/integration/mcp/mcp-cli-inprocess.test.ts
+++ b/tests/integration/mcp/mcp-cli-inprocess.test.ts
@@ -20,6 +20,10 @@ const ROOT = join(__dirname, '..', '..', '..');
 const CLI_BUNDLE = join(ROOT, 'dist', 'cli', 'bundle.js');
 const MCP_BUNDLE = join(ROOT, 'dist', 'mcp', 'bundle.js');
 const BUILT = existsSync(CLI_BUNDLE) && existsSync(MCP_BUNDLE);
+// C3: skip only for local unbuilt checkouts. In CI the bundles MUST exist
+// (the workflow builds first) — if they don't, fail loudly rather than skip,
+// so a missing build step can never silently turn this guard green again.
+const SKIP = !BUILT && !process.env.CI;
 
 interface DriveResult {
   initialize: boolean;
@@ -69,7 +73,7 @@ function driveMcp(args: string[]): Promise<DriveResult> {
   });
 }
 
-describe.skipIf(!BUILT)('#528 — `agentic-qe mcp` serves tools/list over piped stdin', () => {
+describe.skipIf(SKIP)('#528 — `agentic-qe mcp` serves tools/list over piped stdin', () => {
   it('answers initialize AND tools/list (not just initialize) when stdin EOFs', async () => {
     // Act
     const res = await driveMcp([CLI_BUNDLE, 'mcp']);

--- a/tests/integration/mcp/memory-delete-cache-invalidation.test.ts
+++ b/tests/integration/mcp/memory-delete-cache-invalidation.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Integration Regression: `memory_delete` is not masked by the session cache (#535).
+ *
+ * The smoke report saw `memory_delete` return {deleted:true} while an immediate
+ * `memory_retrieve` still returned the value (with an *identical* timestamp).
+ * Root cause: `memory_retrieve` is isConcurrencySafe → its result is cached by
+ * the Issue-#473 session cache, and `memory_delete` did not invalidate it, so
+ * the follow-up read served the stale cached "found" result. The delete itself
+ * worked. Fix: mutating tools invalidate their domain's cached reads.
+ *
+ * This drives the BUILT MCP bundle through real JSON-RPC tool calls with the
+ * session cache ENABLED (the default) — the condition that exposed the bug.
+ * Skips when the bundle is absent so it never fails an unbuilt checkout.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = join(__dirname, '..', '..', '..');
+const MCP_BUNDLE = join(ROOT, 'dist', 'mcp', 'bundle.js');
+const BUILT = existsSync(MCP_BUNDLE);
+
+interface ToolResponses { [id: number]: any }
+
+/**
+ * Drive the MCP bundle through a fixed JSON-RPC script, returning each
+ * tool/call's parsed inner result keyed by request id. Stdin stays open until
+ * every scripted response arrives, then the server is killed.
+ */
+function driveTools(calls: Array<{ id: number; name: string; arguments: Record<string, unknown> }>): Promise<ToolResponses> {
+  return new Promise((resolve) => {
+    // Cache ON: explicitly clear any "off" inherited from the environment.
+    const env = { ...process.env, AQE_SESSION_CACHE: 'on' };
+    const child = spawn('node', [MCP_BUNDLE], { cwd: ROOT, stdio: ['pipe', 'pipe', 'ignore'], env });
+    const responses: ToolResponses = {};
+    const expected = new Set(calls.map((c) => c.id));
+
+    const script = [
+      { id: 1, method: 'initialize', params: { protocolVersion: '2025-11-25', capabilities: {}, clientInfo: { name: 'reg535', version: '1.0' } } },
+      { method: 'notifications/initialized' },
+      ...calls.map((c) => ({ id: c.id, method: 'tools/call', params: { name: c.name, arguments: c.arguments } })),
+    ];
+    let i = 0;
+    const sendNext = () => {
+      if (i >= script.length) return;
+      child.stdin.write(JSON.stringify({ jsonrpc: '2.0', ...script[i] }) + '\n');
+      i++;
+      if (script[i - 1] && (script[i - 1] as { method: string }).method === 'notifications/initialized') sendNext();
+    };
+
+    let buf = '';
+    child.stdout.on('data', (d: Buffer) => {
+      buf += d.toString();
+      let nl: number;
+      while ((nl = buf.indexOf('\n')) >= 0) {
+        const line = buf.slice(0, nl).trim();
+        buf = buf.slice(nl + 1);
+        if (!line) continue;
+        let msg: any;
+        try { msg = JSON.parse(line); } catch { continue; }
+        if (msg.id === undefined) continue;
+        if (expected.has(msg.id)) {
+          const text = msg.result?.content?.[0]?.text;
+          try { responses[msg.id] = JSON.parse(text); } catch { responses[msg.id] = msg.result ?? msg.error; }
+        }
+        sendNext();
+        if (Object.keys(responses).length === expected.size) {
+          setTimeout(() => { try { child.kill('SIGKILL'); } catch { /* noop */ } resolve(responses); }, 100);
+        }
+      }
+    });
+
+    sendNext(); // initialize
+    setTimeout(() => { try { child.kill('SIGKILL'); } catch { /* noop */ } resolve(responses); }, 45000);
+  });
+}
+
+describe.skipIf(!BUILT)('#535 — memory_delete is not masked by the session cache', () => {
+  it('retrieve after delete returns found:false even with the cache enabled', async () => {
+    // Arrange + Act — store, read (populates cache), delete, read again.
+    const ns = 'reg535';
+    const key = 'k1';
+    const r = await driveTools([
+      { id: 10, name: 'memory_store', arguments: { key, value: 'v535', namespace: ns } },
+      { id: 11, name: 'memory_retrieve', arguments: { key, namespace: ns } },
+      { id: 12, name: 'memory_delete', arguments: { key, namespace: ns } },
+      { id: 13, name: 'memory_retrieve', arguments: { key, namespace: ns } },
+    ]);
+
+    // Assert — store + first read succeed, delete reports success, and the
+    // post-delete read is a genuine miss (not a stale cache hit).
+    expect(r[10]?.data?.stored).toBe(true);
+    expect(r[11]?.data?.found).toBe(true);
+    expect(r[12]?.data?.deleted).toBe(true);
+    expect(r[13]?.data?.found).toBe(false);
+  }, 60000);
+});

--- a/tests/integration/mcp/memory-delete-cache-invalidation.test.ts
+++ b/tests/integration/mcp/memory-delete-cache-invalidation.test.ts
@@ -20,6 +20,9 @@ import { join } from 'node:path';
 const ROOT = join(__dirname, '..', '..', '..');
 const MCP_BUNDLE = join(ROOT, 'dist', 'mcp', 'bundle.js');
 const BUILT = existsSync(MCP_BUNDLE);
+// C3: skip only for local unbuilt checkouts. In CI the bundle MUST exist (the
+// workflow builds first) — fail loudly rather than silently skip if it doesn't.
+const SKIP = !BUILT && !process.env.CI;
 
 interface ToolResponses { [id: number]: any }
 
@@ -76,7 +79,7 @@ function driveTools(calls: Array<{ id: number; name: string; arguments: Record<s
   });
 }
 
-describe.skipIf(!BUILT)('#535 — memory_delete is not masked by the session cache', () => {
+describe.skipIf(SKIP)('#535 — memory_delete is not masked by the session cache', () => {
   it('retrieve after delete returns found:false even with the cache enabled', async () => {
     // Arrange + Act — store, read (populates cache), delete, read again.
     const ns = 'reg535';

--- a/tests/unit/init/continuedev-installer.test.ts
+++ b/tests/unit/init/continuedev-installer.test.ts
@@ -173,6 +173,24 @@ describe('ContinueDevInstaller', () => {
       expect(content).toContain('agentic-qe');
     });
 
+    it('honors database-free mode on the merge branch — no AQE_MEMORY_PATH (#533/C2)', async () => {
+      mockExistsSync.mockReturnValue(true);
+      const existingYaml = `mcpServers:\n  - name: other-server\n    command: other\n`;
+      mockReadFileSync.mockReturnValue(existingYaml);
+
+      const { createContinueDevInstaller } = await import('../../../src/init/continuedev-installer.js');
+      const installer = createContinueDevInstaller({ projectRoot, overwrite: true, memoryBackend: 'memory' });
+      await installer.install();
+
+      const configCall = mockWriteFileSync.mock.calls.find(
+        (c: unknown[]) => (c[0] as string).endsWith('config.yaml')
+      );
+      const content = configCall![1] as string;
+      // The appended agentic-qe entry must run in-memory, not point at a db path.
+      expect(content).toContain('AQE_MEMORY_BACKEND: memory');
+      expect(content).not.toContain('AQE_MEMORY_PATH');
+    });
+
     it('skips YAML merge if agentic-qe already present', async () => {
       mockExistsSync.mockReturnValue(true);
       const existingYaml = `mcpServers:

--- a/tests/unit/init/phases/mcp-phase.test.ts
+++ b/tests/unit/init/phases/mcp-phase.test.ts
@@ -181,4 +181,42 @@ describe('MCPPhase', () => {
       expect(logFn).toHaveBeenCalledWith(expect.stringContaining('agentic-qe'));
     });
   });
+
+  describe('database-free mode (#533)', () => {
+    it("writes AQE_MEMORY_BACKEND=memory and disables learning/workers when memoryBackend is 'memory'", async () => {
+      // Arrange — clear accumulated mock calls so .find() can't match an
+      // earlier test's write to the same path.
+      vi.mocked(writeFileSync).mockClear();
+      const context = createMockContext({ projectRoot: '/my/project', options: { memoryBackend: 'memory' } });
+
+      // Act
+      await phase.execute(context);
+
+      // Assert
+      const rootCall = vi.mocked(writeFileSync).mock.calls.find(
+        (call: any[]) => (call[0] as string) === '/my/project/.mcp.json'
+      );
+      const env = JSON.parse(rootCall![1] as string).mcpServers['agentic-qe'].env;
+      expect(env.AQE_MEMORY_BACKEND).toBe('memory');
+      expect(env.AQE_MEMORY_PATH).toBeUndefined();
+      expect(env.AQE_LEARNING_ENABLED).toBe('false');
+      expect(env.AQE_WORKERS_ENABLED).toBe('false');
+    });
+  });
+
+  describe('--no-claude (#532)', () => {
+    it('does not write .mcp.json and reports not configured', async () => {
+      // Arrange
+      vi.mocked(writeFileSync).mockClear();
+      const context = createMockContext({ options: { noClaude: true } });
+
+      // Act
+      const result = await phase.execute(context);
+
+      // Assert — .mcp.json is part of the suppressed Claude Code surface.
+      expect(writeFileSync).not.toHaveBeenCalled();
+      expect(result.success).toBe(true);
+      expect(result.data!.configured).toBe(false);
+    });
+  });
 });

--- a/tests/unit/init/platform-config-generator.test.ts
+++ b/tests/unit/init/platform-config-generator.test.ts
@@ -91,6 +91,35 @@ describe('PlatformConfigGenerator', () => {
     });
   });
 
+  describe('database-free mode (#533)', () => {
+    const ALL: PlatformId[] = ['copilot', 'cursor', 'cline', 'kilocode', 'roocode', 'codex', 'windsurf', 'continuedev'];
+
+    it('default (persistent) configs keep AQE_MEMORY_PATH and no AQE_MEMORY_BACKEND', () => {
+      for (const id of ALL) {
+        const content = generator.generateMcpConfig(id).content;
+        expect(content).toContain('AQE_MEMORY_PATH');
+        expect(content).not.toContain('AQE_MEMORY_BACKEND');
+      }
+    });
+
+    it("memoryBackend:'memory' emits AQE_MEMORY_BACKEND=memory and drops AQE_MEMORY_PATH for every platform", () => {
+      for (const id of ALL) {
+        const content = generator.generateMcpConfig(id, { memoryBackend: 'memory' }).content;
+        expect(content, `${id} should declare in-memory backend`).toContain('AQE_MEMORY_BACKEND');
+        expect(content.toLowerCase(), `${id} backend value`).toContain('memory');
+        expect(content, `${id} must not point at a db path in db-free mode`).not.toContain('AQE_MEMORY_PATH');
+      }
+    });
+
+    it("non-memory backends (sqlite/hybrid) stay persistent", () => {
+      for (const backend of ['sqlite', 'hybrid', 'agentdb'] as const) {
+        const content = generator.generateMcpConfig('cursor', { memoryBackend: backend }).content;
+        expect(content).toContain('AQE_MEMORY_PATH');
+        expect(content).not.toContain('AQE_MEMORY_BACKEND');
+      }
+    });
+  });
+
   describe('generateBehavioralRules()', () => {
     it('copilot returns markdown rules', () => {
       const rules = generator.generateBehavioralRules('copilot');


### PR DESCRIPTION
## Summary

v3.10.9 — MCP server reliability and database-free completeness, all from community-reported issues (@nagoodman), plus the devil's-advocate follow-up hardening:

- **#528** — `agentic-qe mcp` now runs the server **in-process** instead of double-spawning; piped-stdin MCP clients get `tools/list` instead of a premature shutdown. Failed startup now exits non-zero.
- **#535** — `memory_delete` is no longer masked by a stale session-cache read (mutating tools invalidate their domain's cached reads).
- **#533** — `--no-database` propagates `AQE_MEMORY_BACKEND=memory` to **all** editor MCP configs (Claude `.mcp.json`, Cursor, Cline, Continue.dev incl. merge path, Kilo/Roo Code, Windsurf, Codex, Copilot, Kiro), not just OpenCode.
- **#532** — new opt-in `--no-claude` exclusive install (suppresses `.claude/`, `.mcp.json`, `CLAUDE.md`, governance, hooks).
- **#540** — js-yaml dev dependency → 4.2.0 (lockfile's pruned optional platform binaries restored).

Default install and persistent-backend behavior are unchanged. See [CHANGELOG](CHANGELOG.md).

## Verification

Real output from this branch:

\`\`\`
build         : tsc && build:cli && build:mcp → "CLI/MCP bundle built successfully (v3.10.9)"  ✅
typecheck     : tsc --noEmit → exit 0  ✅
performance   : npm run performance:gate → Total: 15 | Passed: 15 | Failed: 0  ✅
test:ci       : Test Files 2 failed | 68 passed (846); Tests 3 failed | 1481 passed (1490)
                → the failures are PRE-EXISTING (see Failure modes), not introduced here
artifacts     : dist/cli/bundle.js, dist/index.js, dist/mcp/bundle.js all present  ✅
CLI --version : 3.10.9  ✅
init --auto   : exit 0 in a fresh project → creates .agentic-qe/, .claude/, CLAUDE.md, .mcp.json  ✅
isolated pack : npm pack + clean install of agentic-qe-3.10.9.tgz → aqe --version = 3.10.9, exit 0, 0 vulns  ✅
\`\`\`

Targeted regression coverage for the shipped fixes (all green):
- `tests/integration/mcp/mcp-cli-inprocess.test.ts` (#528) — server serves `initialize` + `tools/list` over piped/EOF stdin; CLI/MCP parity.
- `tests/integration/mcp/memory-delete-cache-invalidation.test.ts` (#535) — retrieve-after-delete is `found:false` with the cache enabled.
- `tests/unit/init/platform-config-generator.test.ts` + `mcp-phase.test.ts` + `continuedev-installer.test.ts` (#533/#532/C2).
- Full init unit suite: 407 passing.

## Failure modes

- **Cache invalidation is verb-suffix-scoped (#535 fix).** Mutators whose names don't end in a mutation verb (`agent_spawn`, `fleet_init`, `task_orchestrate`, …) do not invalidate their domain's cached reads, so a stale-read could recur for an unrelated write/read pair. The memory + cross_phase domains in #535 are covered and tested. Tracked in #542 (with a suggested `isConcurrencySafe`-based fix and the test to add).
- **In-process MCP startup (#528).** A startup failure now exits non-zero (entry.ts `main().catch`); normal startup is exercised by the #528 integration test. A runtime (post-startup) failure is intentionally kept alive by the existing `unhandledRejection` handler, unchanged by this PR.
- **`--no-claude` (#532) is opt-in only** and does not by itself imply a lightweight (no-DB) install — the kernel/DB still build unless `--no-database` is also passed. This is documented behavior, not a defect; deeper coupling is out of scope here.
- **Two pre-existing test reds are NOT introduced by this release.** `tests/integration/llm/multi-provider.test.ts > bidirectional mapping for Claude models` and `tests/integration/ruvector/native-hnsw-real-fixture.test.ts > recall@10` (#399) fail **identically on the v3.10.8 base in this same environment** (verified by checking out the v3.10.8 tag and re-running). They live in LLM model-mapping and native-HNSW code that this PR does not touch, and the HNSW one is environment-sensitive (native-binary recall). They are not a regression from this release; the publish workflow's clean-runner `test:ci` is the authoritative gate.

---

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.** "Unlikely" is not an acceptable substitute. If you wrote "I don't think this can happen but...", that sentence is a failure mode and needs a test or an issue link.

### Optional context

- Linked issues: #528, #532, #533, #535, #540, #542 (follow-up)
- Trust tier change (if any): none
- Affects published API or CLI surface: yes (new `--no-claude` flag; `agentic-qe mcp` now in-process; db-free MCP env)
- Touches the init flow / `npm-publish.yml` / `tests/fixtures/init-corpus/`: yes (init flow + the mcp CI workflow)
  - If yes: did you run `./tests/fixtures/init-corpus/run-gate.sh` locally? not applicable — verified via real `aqe init --auto` + per-platform config smokes instead

See [CHANGELOG](CHANGELOG.md) for details.