### PR TITLE
Migrate PACT → PACTS framework (add Structured principle)

### DIFF
--- a/.agentic-qe/docs/skills.md
+++ b/.agentic-qe/docs/skills.md
@@ -15,7 +15,7 @@ QE skills are specialized knowledge modules that agents can invoke to enhance th
 #### agentic-quality-engineering
 **Using AI agents as force multipliers in quality work**
 
-Covers autonomous testing systems, PACT principles (Proactive, Autonomous, Collaborative, Targeted), and scaling quality engineering with intelligent agents.
+Covers autonomous testing systems, PACTS principles (Proactive, Autonomous, Collaborative, Targeted, Structured), and scaling quality engineering with intelligent agents.
 
 **Key Topics:**
 - AI-driven test generation
@@ -49,14 +49,14 @@ Skill("context-driven-testing")
 ---
 
 #### holistic-testing-pact
-**Holistic Testing Model evolved with PACT principles**
+**Holistic Testing Model evolved with PACTS principles**
 
-Applies the Holistic Testing Model with Proactive, Autonomous, Collaborative, and Targeted principles for comprehensive quality coverage.
+Applies the Holistic Testing Model with Proactive, Autonomous, Collaborative, Targeted, and Structured principles for comprehensive quality coverage.
 
 **Key Topics:**
 - Quadrant-based testing
 - Whole-team quality
-- PACT evolution
+- PACTS evolution
 - Agile testing strategies
 
 **Usage:**

--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -20,7 +20,7 @@ Then browse and install plugins:
 
 ### `agentic-qe-fleet`
 
-PACT-based agentic quality engineering fleet — slim Claude Code bundle with 11 specialized QE agents, 9 trust-tier-2/3 skills, 9 `/aqe-*` slash commands, and an auto-registered MCP server.
+PACTS-based agentic quality engineering fleet — slim Claude Code bundle with 11 specialized QE agents, 9 trust-tier-2/3 skills, 9 `/aqe-*` slash commands, and an auto-registered MCP server.
 
 **Agents** (model-routed by cognitive load):
 - **Opus tier** (heavy reasoning): `qe-test-architect`, `qe-fleet-commander`, `qe-security-scanner`, `qe-chaos-engineer`, `qe-regression-analyzer`, `qe-requirements-validator`

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "agentic-qe-fleet",
       "source": "./plugins/agentic-qe-fleet",
-      "description": "PACT-based agentic quality engineering fleet — 11 specialized QE agents (model-routed across Opus/Sonnet), 9 trust-tier-2/3 skills, 9 slash commands, and auto-registered MCP server"
+      "description": "PACTS-based agentic quality engineering fleet — 11 specialized QE agents (model-routed across Opus/Sonnet), 9 trust-tier-2/3 skills, 9 slash commands, and auto-registered MCP server"
     }
   ]
 }

--- a/.claude/agents/v3/qe-learning-coordinator.md
+++ b/.claude/agents/v3/qe-learning-coordinator.md
@@ -180,7 +180,7 @@ Core Skills:
 Advanced Skills:
 - reasoningbank-agentdb: Vector-indexed pattern storage
 - quality-metrics: Measure and optimize quality metrics
-- holistic-testing-pact: PACT principles for comprehensive testing
+- holistic-testing-pact: PACTS principles for comprehensive testing
 
 Use via CLI: `aqe skills show reasoningbank-intelligence`
 Use via Claude Code: `Skill("reasoningbank-agentdb")`

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -19,7 +19,7 @@ Version-agnostic quality engineering best practices from the QE community.
 
 - **a11y-ally**: Comprehensive WCAG accessibility auditing with multi-tool testing (axe-core + pa11y + Lighthouse), TRUE PARALLEL execution with Promise.allSettled, graceful degradation, retry with backoff, context-aware remediation, learning integration, and video accessibility. Uses 3-tier browser cascade: Vibium → agent-browser → Playwright+Stealth.
 - **accessibility-testing**: WCAG 2.2 compliance testing, screen reader validation, and inclusive design verification. Use when ensuring legal compliance (ADA, Section 508), testing for disabilities, or building accessible applications for 1 billion disabled users globally.
-- **agentic-quality-engineering**: AI agents as force multipliers for quality work. Core skill for all 19 QE agents using PACT principles.
+- **agentic-quality-engineering**: AI agents as force multipliers for quality work. Core skill for all 19 QE agents using PACTS principles.
 - **api-testing-patterns**: Comprehensive API testing patterns including contract testing, REST/GraphQL testing, and integration testing. Use when testing APIs or designing API test strategies.
 - **browser**: Web browser automation with AI-optimized snapshots for claude-flow agents
 - **brutal-honesty-review**: Unvarnished technical criticism combining Linus Torvalds
@@ -36,7 +36,7 @@ Version-agnostic quality engineering best practices from the QE community.
 - **debug-loop**: Hypothesis-driven autonomous debugging with real command validation
 - **enterprise-integration-testing**: Orchestration skill for enterprise integration testing across SAP, middleware, WMS, and backend systems. Covers E2E enterprise flows, SAP-specific patterns (RFC, BAPI, IDoc, OData, Fiori), cross-system data validation, and enterprise quality gates.
 - **exploratory-testing-advanced**: Advanced exploratory testing techniques with Session-Based Test Management (SBTM), RST heuristics, and test tours. Use when planning exploration sessions, investigating bugs, or discovering unknown quality risks.
-- **holistic-testing-pact**: Apply the Holistic Testing Model evolved with PACT (Proactive, Autonomous, Collaborative, Targeted) principles. Use when designing comprehensive test strategies for Classical, AI-assisted, Agent based, or Agentic Systems building quality into the team, or implementing whole-team quality practices.
+- **holistic-testing-pact**: Apply the Holistic Testing Model evolved with PACTS (Proactive, Autonomous, Collaborative, Targeted, Structured) principles. Use when designing comprehensive test strategies for Classical, AI-assisted, Agent based, or Agentic Systems building quality into the team, or implementing whole-team quality practices.
 - **localization-testing**: Internationalization (i18n) and localization (l10n) testing for global products including translations, locale formats, RTL languages, and cultural appropriateness. Use when launching in new markets or building multi-language products.
 - **middleware-testing-patterns**: Enterprise middleware testing patterns for message routing, transformation, DLQ, protocol mediation, ESB error handling, and EIP patterns. Use when testing middleware layers, message brokers, ESBs, or integration buses.
 - **mobile-testing**: Comprehensive mobile testing for iOS and Android platforms including gestures, sensors, permissions, device fragmentation, and performance. Use when testing native apps, hybrid apps, or mobile web, ensuring quality across 1000+ device variants.

--- a/.claude/skills/agentic-quality-engineering/SKILL.md
+++ b/.claude/skills/agentic-quality-engineering/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentic-quality-engineering
-description: "Use when orchestrating QE agents, understanding PACT principles, configuring the AQE v3 fleet, or leveraging AI agents as force multipliers for quality work."
+description: "Use when orchestrating QE agents, understanding PACTS principles, configuring the AQE v3 fleet, or leveraging AI agents as force multipliers for quality work."
 category: qe-core
 priority: critical
 tokenEstimate: 1400
@@ -10,7 +10,7 @@ optimization_version: 1.0
 last_optimized: 2025-12-02
 dependencies: []
 quick_reference_card: true
-tags: [pact, agents, fleet, coordination, autonomous, foundational]
+tags: [pacts, agents, fleet, coordination, autonomous, structured, foundational]
 trust_tier: 1
 validation:
   schema_path: schemas/output.json
@@ -22,7 +22,7 @@ validation:
 When implementing agentic QE or coordinating agents:
 1. SPAWN appropriate agent(s) for the task using `Task` tool with agent type
 2. CONFIGURE agent coordination (hierarchical/mesh/sequential)
-3. EXECUTE with PACT principles: Proactive analysis, Autonomous operation, Collaborative feedback, Targeted risk focus
+3. EXECUTE with PACTS principles: Proactive analysis, Autonomous operation, Collaborative feedback, Targeted risk focus, Structured governance (observability and explainability of agent behavior)
 4. VALIDATE results through quality gates before deployment
 5. LEARN from outcomes - store patterns in `aqe/learning/*` namespace
 
@@ -48,13 +48,14 @@ When implementing agentic QE or coordinating agents:
 - Implementing multi-agent coordination
 - Building CI/CD quality pipelines
 
-### PACT Principles
+### PACTS Principles
 | Principle | Agent Behavior | Human Role |
 |-----------|---------------|------------|
 | **P**roactive | Analyze pre-merge, predict risk | Set guardrails |
 | **A**utonomous | Execute tests, fix flaky tests | Review critical |
 | **C**ollaborative | Multi-agent coordination | Provide context |
 | **T**argeted | Risk-based prioritization | Define risk areas |
+| **S**tructured | Governance, observability, explainable decisions (measure confidence, not trust) | Audit behavior, set policy |
 
 ### 19-Agent Fleet
 | Category | Agents | Primary Use |
@@ -294,7 +295,7 @@ agent_assignments:
 ---
 
 ## Related Skills
-- `holistic-testing-pact` - PACT principles deep dive
+- `holistic-testing-pact` - PACTS principles deep dive
 - `risk-based-testing` - Prioritize agent focus
 - `quality-metrics` - Measure agent effectiveness
 - `api-testing-patterns`, `security-testing`, `performance-testing` - Specialized testing

--- a/.claude/skills/agentic-quality-engineering/schemas/output.json
+++ b/.claude/skills/agentic-quality-engineering/schemas/output.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://agentic-qe.dev/schemas/agentic-quality-engineering-output.json",
   "title": "Agentic Quality Engineering Skill Output Schema",
-  "description": "Schema for agentic quality engineering output with fleet status, agent coordination, and PACT principles validation.",
+  "description": "Schema for agentic quality engineering output with fleet status, agent coordination, and PACTS principles validation.",
   "type": "object",
   "required": ["skillName", "version", "timestamp", "status", "trustTier", "output"],
   "properties": {
@@ -52,7 +52,7 @@
         },
         "pactPrinciples": {
           "$ref": "#/$defs/pactPrinciples",
-          "description": "PACT principles assessment (Proactive, Autonomous, Collaborative, Targeted)"
+          "description": "PACTS principles assessment (Proactive, Autonomous, Collaborative, Targeted, Structured)"
         },
         "qualityScore": {
           "$ref": "#/$defs/qualityScore",
@@ -272,11 +272,15 @@
           "$ref": "#/$defs/pactDimension",
           "description": "Targeted testing approach"
         },
+        "structured": {
+          "$ref": "#/$defs/pactDimension",
+          "description": "Structured governance, observability, and explainability of agent behavior (measure confidence, not trust)"
+        },
         "overallScore": {
           "type": "number",
           "minimum": 0,
           "maximum": 100,
-          "description": "Overall PACT score"
+          "description": "Overall PACTS score"
         }
       }
     },

--- a/.claude/skills/holistic-testing-pact/SKILL.md
+++ b/.claude/skills/holistic-testing-pact/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: holistic-testing-pact
-description: "Apply the Holistic Testing Model evolved with PACT (Proactive, Autonomous, Collaborative, Targeted) principles. Use when designing comprehensive test strategies for Classical, AI-assisted, Agent based, or Agentic Systems building quality into the team, or implementing whole-team quality practices."
+description: "Apply the Holistic Testing Model evolved with PACTS (Proactive, Autonomous, Collaborative, Targeted, Structured) principles. Use when designing comprehensive test strategies for Classical, AI-assisted, Agent based, or Agentic Systems building quality into the team, or implementing whole-team quality practices."
 category: testing-methodologies
 priority: critical
 tokenEstimate: 1100
@@ -10,26 +10,27 @@ optimization_version: 1.0
 last_optimized: 2025-12-02
 dependencies: []
 quick_reference_card: true
-tags: [holistic, pact, quality, whole-team, proactive, autonomous, collaborative, targeted]
+tags: [holistic, pacts, quality, whole-team, proactive, autonomous, collaborative, targeted, structured]
 trust_tier: 0
 validation:
 ---
 
-# Holistic Testing Model with PACT Principles
+# Holistic Testing Model with PACTS Principles
 
 <default_to_action>
 When designing test strategies or building quality into teams:
-1. APPLY PACT principles: Proactive (test before bugs), Autonomous (teams own quality), Collaborative (whole-team responsibility), Targeted (risk-focused)
+1. APPLY PACTS principles: Proactive (test before bugs), Autonomous (teams own quality), Collaborative (whole-team responsibility), Targeted (risk-focused), Structured (governance, observability, and explainability of agent behavior)
 2. IDENTIFY quadrant focus: Technology-facing (unit, integration, performance) or Business-facing (acceptance, exploratory, usability)
-3. SELECT agents based on PACT dimension and testing quadrant
+3. SELECT agents based on PACTS dimension and testing quadrant
 4. IMPLEMENT feedback loops that catch issues in minutes, not days
-5. MEASURE outcomes (bug escape rate, release confidence) not activities (test count)
+5. MEASURE outcomes (bug escape rate, release confidence, agent confidence) not activities (test count)
 
-**Quick PACT Application:**
+**Quick PACTS Application:**
 - Proactive → Design testability into architecture, risk analysis during refinement
 - Autonomous → Devs run tests locally, CI pipeline with no manual gates
 - Collaborative → Three Amigos, QE pairs with dev, shared test ownership
 - Targeted → Risk-based planning, focus on critical flows, kill valueless tests
+- Structured → Governance, observability, and explainability of agent behavior; measure confidence, not trust
 
 **Critical Success Factors:**
 - Quality is a whole-team responsibility, not a QA phase
@@ -45,13 +46,14 @@ When designing test strategies or building quality into teams:
 - Choosing testing approach for new projects
 - Evolving from sequential QA to concurrent quality
 
-### PACT Principles
+### PACTS Principles
 | Principle | Focus | Anti-Pattern |
 |-----------|-------|--------------|
 | **Proactive** | Test before code, design testability | Waiting for bugs to find you |
 | **Autonomous** | Teams deploy when ready | QA as manual gatekeepers |
 | **Collaborative** | Whole-team quality thinking | QA works in isolation |
 | **Targeted** | Risk-based, high-value tests | Exhaustive checkbox testing |
+| **Structured** | Governance, observability, explainability of agent behavior | Bolting agentic AI onto chaos |
 
 ### Holistic Testing Quadrants
 | Quadrant | Purpose | Examples |
@@ -61,17 +63,18 @@ When designing test strategies or building quality into teams:
 | Business + Support | Shared understanding | BDD, acceptance tests |
 | Business + Critique | Discover unknowns | Exploratory, usability, A/B |
 
-### Agent Selection by PACT + Quadrant
-| PACT Dimension | Agents |
+### Agent Selection by PACTS + Quadrant
+| PACTS Dimension | Agents |
 |----------------|--------|
 | Proactive + Tech | qe-test-generator, qe-requirements-validator |
 | Autonomous + Tech | qe-test-executor, qe-coverage-analyzer |
 | Collaborative | qe-fleet-commander (orchestration) |
 | Targeted | qe-regression-risk-analyzer, qe-quality-gate |
+| Structured | qe-fleet-commander, qe-quality-gate (governance, observability, explainability) |
 
 ---
 
-## PACT in Practice
+## PACTS in Practice
 
 ### Proactive: Test Before Bugs
 ```javascript
@@ -105,11 +108,41 @@ await Task("Risk-Based Planning", {
 }, "qe-regression-risk-analyzer");
 ```
 
+### Structured: Governance, Observability, Explainability
+The 5th principle for agentic systems. As agents take on quality work, you need
+governance (boundaries and guardrails), observability (what agents did and why),
+and explainability (decisions you can audit). Especially important in regulated
+industries.
+
+- We measure **CONFIDENCE, not trust** — trust is a human feeling; confidence can
+  be mathematically explained.
+- Ships with a playbook + readiness-assessment guide.
+- Anti-pattern: bolting agentic AI onto chaos. Structure first, then automate.
+
+```javascript
+// Make agent behavior auditable and explainable, not a black box
+await Task("Agent Governance Review", {
+  guardrails: ['scope-boundaries', 'approval-gates'],
+  observability: ['decision-traces', 'confidence-scores'],
+  explainability: 'every-decision-auditable'
+}, "qe-fleet-commander");
+```
+
+---
+
+## From PACT to PACTS
+
+PACT originated with Reuven Cohen (Agentics Foundation) and was adapted to quality
+engineering by Dragan Spiridonov. PACTS adds a fifth principle — **Structured** —
+inspired by DORA's research on AI-assisted delivery and platform-engineering
+quality measurement. The addition reflects that autonomous, agentic quality work
+needs governance, observability, and explainability to be trustworthy at scale.
+
 ---
 
 ## Evolution from Traditional
 
-| Old Way (Sequential) | Holistic + PACT (Concurrent) |
+| Old Way (Sequential) | Holistic + PACTS (Concurrent) |
 |---------------------|------------------------------|
 | Dev writes → QA tests → bugs found → fixes | Team discusses what to build and how to test |
 | Slow feedback, finger-pointing | Fast feedback, shared ownership |
@@ -133,7 +166,7 @@ await Task("Risk-Based Planning", {
 ### Memory Namespace
 ```
 aqe/holistic-testing/
-├── pact-assessment/*     - PACT maturity analysis
+├── pacts-assessment/*    - PACTS maturity analysis
 ├── quadrant-coverage/*   - Coverage per quadrant
 ├── team-metrics/*        - Quality ownership metrics
 └── feedback-loops/*      - Cycle time data
@@ -143,7 +176,7 @@ aqe/holistic-testing/
 ```typescript
 const holisticFleet = await FleetManager.coordinate({
   strategy: 'holistic-testing',
-  pact: { proactive: true, autonomous: true, collaborative: true, targeted: true },
+  pacts: { proactive: true, autonomous: true, collaborative: true, targeted: true, structured: true },
   agents: [
     'qe-fleet-commander',       // Orchestration
     'qe-test-generator',        // Tech quadrant
@@ -166,8 +199,8 @@ const holisticFleet = await FleetManager.coordinate({
 
 ## Remember
 
-**PACT = Proactive + Autonomous + Collaborative + Targeted**
+**PACTS = Proactive + Autonomous + Collaborative + Targeted + Structured**
 
-Quality is built in, not tested in. Teams own quality. QA enables, doesn't gate. Test what matters, skip what doesn't. Measure outcomes, not activities.
+Quality is built in, not tested in. Teams own quality. QA enables, doesn't gate. Test what matters, skip what doesn't. Govern agent behavior with observability and explainability — measure confidence, not trust. Measure outcomes, not activities.
 
-**With Agents:** Agents analyze PACT maturity, recommend quadrant coverage, and coordinate whole-team quality. Use agents to scale holistic thinking while maintaining human judgment.
+**With Agents:** Agents analyze PACTS maturity, recommend quadrant coverage, and coordinate whole-team quality. Use agents to scale holistic thinking while maintaining human judgment.

--- a/.claude/skills/skills-manifest.json
+++ b/.claude/skills/skills-manifest.json
@@ -308,7 +308,7 @@
     "agentic-quality-engineering": {
       "id": "agentic-quality-engineering",
       "name": "Agentic Quality Engineering",
-      "description": "Core foundational skill for all 19 QE agents with PACT principles (Proactive, Autonomous, Collaborative, Targeted).",
+      "description": "Core foundational skill for all 19 QE agents with PACTS principles (Proactive, Autonomous, Collaborative, Targeted, Structured).",
       "category": "qe-core",
       "priority": "critical",
       "file": "agentic-quality-engineering/SKILL.md",
@@ -317,19 +317,19 @@
       "optimizationStatus": "optimized",
       "optimizationVersion": "1.0",
       "lastOptimized": "2025-12-02",
-      "tags": ["agents", "pact", "core", "foundation", "autonomous-testing"],
+      "tags": ["agents", "pacts", "core", "foundation", "autonomous-testing"],
       "dependencies": [],
       "agents": ["qe-test-generator", "qe-test-executor", "qe-coverage-analyzer", "qe-quality-gate", "qe-quality-analyzer", "qe-performance-tester", "qe-security-scanner", "qe-requirements-validator", "qe-production-intelligence", "qe-fleet-commander", "qe-deployment-readiness", "qe-regression-risk-analyzer", "qe-test-data-architect", "qe-api-contract-validator", "qe-flaky-test-hunter", "qe-visual-tester", "qe-chaos-engineer", "qe-code-complexity", "qx-partner"]
     },
     "holistic-testing-pact": {
       "id": "holistic-testing-pact",
-      "name": "Holistic Testing with PACT Principles",
-      "description": "Holistic Testing Model evolved with PACT for whole-team quality in agentic systems.",
+      "name": "Holistic Testing with PACTS Principles",
+      "description": "Holistic Testing Model evolved with PACTS for whole-team quality in agentic systems.",
       "category": "qe-core",
       "priority": "critical",
       "file": "holistic-testing-pact/SKILL.md",
       "tokenEstimate": 1500,
-      "tags": ["pact", "holistic", "whole-team", "testing-quadrants"],
+      "tags": ["pacts", "holistic", "whole-team", "testing-quadrants"],
       "dependencies": ["agentic-quality-engineering"],
       "agents": ["qe-coverage-analyzer", "qe-quality-gate", "qe-fleet-commander"]
     },

--- a/.kiro/skills/qcsd-ideation-swarm/SKILL.md
+++ b/.kiro/skills/qcsd-ideation-swarm/SKILL.md
@@ -1249,7 +1249,7 @@ Task({
 
 ## METHODOLOGY
 
-Apply holistic-testing-pact methodology (PACT principles).
+Apply holistic-testing-pact methodology (PACTS principles).
 
 ## EPIC CONTENT
 
@@ -1259,7 +1259,7 @@ Apply holistic-testing-pact methodology (PACT principles).
 
 ## REQUIRED ANALYSIS (ALL SECTIONS MANDATORY)
 
-### 1. PACT Analysis
+### 1. Quality Experience Analysis (People, Activities, Contexts, Technologies)
 
 | Dimension | Analysis |
 |-----------|----------|
@@ -1477,7 +1477,7 @@ fi
 if [ "$HAS_UX" = "TRUE" ]; then
   npx @claude-flow/cli@latest agent spawn \
     --type qe-qx-partner \
-    --task "PACT quality experience analysis" &
+    --task "Quality experience analysis" &
 fi
 
 # Wait for conditional agents
@@ -1491,7 +1491,7 @@ I've launched [N] conditional agent(s) in parallel:
 
 [IF HAS_UI] ♿ qe-accessibility-auditor [Domain: visual-accessibility] - WCAG 2.1 AA assessment
 [IF HAS_SECURITY] 🔒 qe-security-auditor [Domain: security-compliance] - STRIDE threat modeling
-[IF HAS_UX] 💫 qe-qx-partner [Domain: cross-domain] - PACT quality experience analysis
+[IF HAS_UX] 💫 qe-qx-partner [Domain: cross-domain] - Quality experience analysis
 
 ⏳ WAITING for conditional agents to complete...
 ```
@@ -1894,7 +1894,7 @@ npx @claude-flow/cli@latest memory list --namespace qcsd-ideation
 1. `testability-scoring` - 10 testability principles
 2. `risk-based-testing` - Risk prioritization
 3. `context-driven-testing` - Context-appropriate strategy
-4. `holistic-testing-pact` - PACT methodology (People, Activities, Contexts, Technologies)
+4. `holistic-testing-pact` - PACTS methodology (Proactive, Autonomous, Collaborative, Targeted, Structured)
 
 ---
 

--- a/.kiro/skills/qe-agentic-quality-engineering/SKILL.md
+++ b/.kiro/skills/qe-agentic-quality-engineering/SKILL.md
@@ -1,8 +1,8 @@
 ---
 inclusion: auto
 name: qe-agentic-quality-engineering
-description: "AI agents as force multipliers for quality work. Core skill for all 19 QE agents using PACT principles."
-tags: [pact, agents, fleet, coordination, autonomous, foundational]
+description: "AI agents as force multipliers for quality work. Core skill for all 19 QE agents using PACTS principles."
+tags: [pacts, agents, fleet, coordination, autonomous, structured, foundational]
 ---
 
 # Agentic Quality Engineering
@@ -11,7 +11,7 @@ tags: [pact, agents, fleet, coordination, autonomous, foundational]
 When implementing agentic QE or coordinating agents:
 1. SPAWN appropriate agent(s) for the task using `Task` tool with agent type
 2. CONFIGURE agent coordination (hierarchical/mesh/sequential)
-3. EXECUTE with PACT principles: Proactive analysis, Autonomous operation, Collaborative feedback, Targeted risk focus
+3. EXECUTE with PACTS principles: Proactive analysis, Autonomous operation, Collaborative feedback, Targeted risk focus, Structured governance (observability and explainability of agent behavior)
 4. VALIDATE results through quality gates before deployment
 5. LEARN from outcomes - store patterns in `aqe/learning/*` namespace
 
@@ -37,13 +37,14 @@ When implementing agentic QE or coordinating agents:
 - Implementing multi-agent coordination
 - Building CI/CD quality pipelines
 
-### PACT Principles
+### PACTS Principles
 | Principle | Agent Behavior | Human Role |
 |-----------|---------------|------------|
 | **P**roactive | Analyze pre-merge, predict risk | Set guardrails |
 | **A**utonomous | Execute tests, fix flaky tests | Review critical |
 | **C**ollaborative | Multi-agent coordination | Provide context |
 | **T**argeted | Risk-based prioritization | Define risk areas |
+| **S**tructured | Governance, observability, explainable decisions (measure confidence, not trust) | Audit behavior, set policy |
 
 ### 19-Agent Fleet
 | Category | Agents | Primary Use |
@@ -283,7 +284,7 @@ agent_assignments:
 ---
 
 ## Related Skills
-- `holistic-testing-pact` - PACT principles deep dive
+- `holistic-testing-pact` - PACTS principles deep dive
 - `risk-based-testing` - Prioritize agent focus
 - `quality-metrics` - Measure agent effectiveness
 - `api-testing-patterns`, `security-testing`, `performance-testing` - Specialized testing

--- a/.kiro/skills/qe-holistic-testing-pact/SKILL.md
+++ b/.kiro/skills/qe-holistic-testing-pact/SKILL.md
@@ -1,25 +1,26 @@
 ---
 inclusion: auto
 name: qe-holistic-testing-pact
-description: "Apply the Holistic Testing Model evolved with PACT (Proactive, Autonomous, Collaborative, Targeted) principles. Use when designing comprehensive test strategies for Classical, AI-assisted, Agent based, or Agentic Systems building quality into the team, or implementing whole-team quality practices."
-tags: [holistic, pact, quality, whole-team, proactive, autonomous, collaborative, targeted]
+description: "Apply the Holistic Testing Model evolved with PACTS (Proactive, Autonomous, Collaborative, Targeted, Structured) principles. Use when designing comprehensive test strategies for Classical, AI-assisted, Agent based, or Agentic Systems building quality into the team, or implementing whole-team quality practices."
+tags: [holistic, pacts, quality, whole-team, proactive, autonomous, collaborative, targeted, structured]
 ---
 
-# Holistic Testing Model with PACT Principles
+# Holistic Testing Model with PACTS Principles
 
 <default_to_action>
 When designing test strategies or building quality into teams:
-1. APPLY PACT principles: Proactive (test before bugs), Autonomous (teams own quality), Collaborative (whole-team responsibility), Targeted (risk-focused)
+1. APPLY PACTS principles: Proactive (test before bugs), Autonomous (teams own quality), Collaborative (whole-team responsibility), Targeted (risk-focused), Structured (governance, observability, and explainability of agent behavior)
 2. IDENTIFY quadrant focus: Technology-facing (unit, integration, performance) or Business-facing (acceptance, exploratory, usability)
-3. SELECT agents based on PACT dimension and testing quadrant
+3. SELECT agents based on PACTS dimension and testing quadrant
 4. IMPLEMENT feedback loops that catch issues in minutes, not days
-5. MEASURE outcomes (bug escape rate, release confidence) not activities (test count)
+5. MEASURE outcomes (bug escape rate, release confidence, agent confidence) not activities (test count)
 
-**Quick PACT Application:**
+**Quick PACTS Application:**
 - Proactive → Design testability into architecture, risk analysis during refinement
 - Autonomous → Devs run tests locally, CI pipeline with no manual gates
 - Collaborative → Three Amigos, QE pairs with dev, shared test ownership
 - Targeted → Risk-based planning, focus on critical flows, kill valueless tests
+- Structured → Governance, observability, and explainability of agent behavior; measure confidence, not trust
 
 **Critical Success Factors:**
 - Quality is a whole-team responsibility, not a QA phase
@@ -35,13 +36,14 @@ When designing test strategies or building quality into teams:
 - Choosing testing approach for new projects
 - Evolving from sequential QA to concurrent quality
 
-### PACT Principles
+### PACTS Principles
 | Principle | Focus | Anti-Pattern |
 |-----------|-------|--------------|
 | **Proactive** | Test before code, design testability | Waiting for bugs to find you |
 | **Autonomous** | Teams deploy when ready | QA as manual gatekeepers |
 | **Collaborative** | Whole-team quality thinking | QA works in isolation |
 | **Targeted** | Risk-based, high-value tests | Exhaustive checkbox testing |
+| **Structured** | Governance, observability, explainability of agent behavior | Bolting agentic AI onto chaos |
 
 ### Holistic Testing Quadrants
 | Quadrant | Purpose | Examples |
@@ -51,17 +53,18 @@ When designing test strategies or building quality into teams:
 | Business + Support | Shared understanding | BDD, acceptance tests |
 | Business + Critique | Discover unknowns | Exploratory, usability, A/B |
 
-### Agent Selection by PACT + Quadrant
-| PACT Dimension | Agents |
+### Agent Selection by PACTS + Quadrant
+| PACTS Dimension | Agents |
 |----------------|--------|
 | Proactive + Tech | qe-test-generator, qe-requirements-validator |
 | Autonomous + Tech | qe-test-executor, qe-coverage-analyzer |
 | Collaborative | qe-fleet-commander (orchestration) |
 | Targeted | qe-regression-risk-analyzer, qe-quality-gate |
+| Structured | qe-fleet-commander, qe-quality-gate (governance, observability, explainability) |
 
 ---
 
-## PACT in Practice
+## PACTS in Practice
 
 ### Proactive: Test Before Bugs
 ```javascript
@@ -95,11 +98,41 @@ await Task("Risk-Based Planning", {
 }, "qe-regression-risk-analyzer");
 ```
 
+### Structured: Governance, Observability, Explainability
+The 5th principle for agentic systems. As agents take on quality work, you need
+governance (boundaries and guardrails), observability (what agents did and why),
+and explainability (decisions you can audit). Especially important in regulated
+industries.
+
+- We measure **CONFIDENCE, not trust** — trust is a human feeling; confidence can
+  be mathematically explained.
+- Ships with a playbook + readiness-assessment guide.
+- Anti-pattern: bolting agentic AI onto chaos. Structure first, then automate.
+
+```javascript
+// Make agent behavior auditable and explainable, not a black box
+await Task("Agent Governance Review", {
+  guardrails: ['scope-boundaries', 'approval-gates'],
+  observability: ['decision-traces', 'confidence-scores'],
+  explainability: 'every-decision-auditable'
+}, "qe-fleet-commander");
+```
+
+---
+
+## From PACT to PACTS
+
+PACT originated with Reuven Cohen (Agentics Foundation) and was adapted to quality
+engineering by Dragan Spiridonov. PACTS adds a fifth principle — **Structured** —
+inspired by DORA's research on AI-assisted delivery and platform-engineering
+quality measurement. The addition reflects that autonomous, agentic quality work
+needs governance, observability, and explainability to be trustworthy at scale.
+
 ---
 
 ## Evolution from Traditional
 
-| Old Way (Sequential) | Holistic + PACT (Concurrent) |
+| Old Way (Sequential) | Holistic + PACTS (Concurrent) |
 |---------------------|------------------------------|
 | Dev writes → QA tests → bugs found → fixes | Team discusses what to build and how to test |
 | Slow feedback, finger-pointing | Fast feedback, shared ownership |
@@ -123,7 +156,7 @@ await Task("Risk-Based Planning", {
 ### Memory Namespace
 ```
 aqe/holistic-testing/
-├── pact-assessment/*     - PACT maturity analysis
+├── pacts-assessment/*    - PACTS maturity analysis
 ├── quadrant-coverage/*   - Coverage per quadrant
 ├── team-metrics/*        - Quality ownership metrics
 └── feedback-loops/*      - Cycle time data
@@ -133,7 +166,7 @@ aqe/holistic-testing/
 ```typescript
 const holisticFleet = await FleetManager.coordinate({
   strategy: 'holistic-testing',
-  pact: { proactive: true, autonomous: true, collaborative: true, targeted: true },
+  pacts: { proactive: true, autonomous: true, collaborative: true, targeted: true, structured: true },
   agents: [
     'qe-fleet-commander',       // Orchestration
     'qe-test-generator',        // Tech quadrant
@@ -156,8 +189,8 @@ const holisticFleet = await FleetManager.coordinate({
 
 ## Remember
 
-**PACT = Proactive + Autonomous + Collaborative + Targeted**
+**PACTS = Proactive + Autonomous + Collaborative + Targeted + Structured**
 
-Quality is built in, not tested in. Teams own quality. QA enables, doesn't gate. Test what matters, skip what doesn't. Measure outcomes, not activities.
+Quality is built in, not tested in. Teams own quality. QA enables, doesn't gate. Test what matters, skip what doesn't. Govern agent behavior with observability and explainability — measure confidence, not trust. Measure outcomes, not activities.
 
-**With Agents:** Agents analyze PACT maturity, recommend quadrant coverage, and coordinate whole-team quality. Use agents to scale holistic thinking while maintaining human judgment.
+**With Agents:** Agents analyze PACTS maturity, recommend quadrant coverage, and coordinate whole-team quality. Use agents to scale holistic thinking while maintaining human judgment.

--- a/.opencode/skills/qe-agentic-quality-engineering.yaml
+++ b/.opencode/skills/qe-agentic-quality-engineering.yaml
@@ -1,13 +1,13 @@
 name: qe-agentic-quality-engineering
-description: "AI agents as force multipliers for quality work. Core skill for all 19 QE agents using PACT principles."
+description: "Use when orchestrating QE agents, understanding PACTS principles, configuring the AQE v3 fleet, or leveraging AI agents as force multipliers for quality work."
 minModelTier: tier1-any
-tags: ["pact", "agents", "fleet", "coordination", "autonomous", "foundational", "qe", "quality-engineering", "qe-core"]
+tags: ["pacts", "agents", "fleet", "coordination", "autonomous", "structured", "foundational", "qe", "quality-engineering", "qe-core"]
 steps:
-  - name: pact-principles
-    description: "PACT Principles"
+  - name: pacts-principles
+    description: "PACTS Principles"
     tools: ["bash", "read", "edit"]
     prompt: |
-      PACT Principles
+      PACTS Principles
   - name: 19-agent-fleet
     description: "19-Agent Fleet"
     tools: ["bash", "read"]

--- a/.opencode/skills/qe-holistic-testing-pact.yaml
+++ b/.opencode/skills/qe-holistic-testing-pact.yaml
@@ -1,28 +1,28 @@
 name: qe-holistic-testing-pact
-description: "Apply the Holistic Testing Model evolved with PACT (Proactive, Autonomous, Collaborative, Targeted) principles. Use when designing comprehensive test strategies for Classical, AI-assisted, Agent based, or Agentic Systems building quality into the team, or implementing whole-team quality practices."
+description: "Apply the Holistic Testing Model evolved with PACTS (Proactive, Autonomous, Collaborative, Targeted, Structured) principles. Use when designing comprehensive test strategies for Classical, AI-assisted, Agent based, or Agentic Systems building quality into the team, or implementing whole-team quality"
 minModelTier: tier1-any
-tags: ["holistic", "pact", "quality", "whole-team", "proactive", "autonomous", "collaborative", "targeted", "qe", "quality-engineering", "testing-methodologies"]
+tags: ["holistic", "pacts", "quality", "whole-team", "proactive", "autonomous", "collaborative", "targeted", "structured", "qe", "quality-engineering", "testing-methodologies"]
 steps:
-  - name: pact-principles
-    description: "PACT Principles"
+  - name: pacts-principles
+    description: "PACTS Principles"
     tools: ["bash", "read", "grep"]
     prompt: |
-      PACT Principles
+      PACTS Principles
   - name: holistic-testing-quadrants
     description: "Holistic Testing Quadrants"
     tools: ["bash", "read", "grep"]
     prompt: |
       Holistic Testing Quadrants
-  - name: agent-selection-by-pact-quadrant
-    description: "Agent Selection by PACT + Quadrant"
+  - name: agent-selection-by-pacts-quadrant
+    description: "Agent Selection by PACTS + Quadrant"
     tools: ["bash", "read"]
     prompt: |
-      Agent Selection by PACT + Quadrant
-  - name: pact-in-practice
-    description: "PACT in Practice"
+      Agent Selection by PACTS + Quadrant
+  - name: pacts-in-practice
+    description: "PACTS in Practice"
     tools: ["bash", "read"]
     prompt: |
-      PACT in Practice
+      PACTS in Practice
   - name: proactive-test-before-bugs
     description: "Proactive: Test Before Bugs"
     tools: ["bash", "read"]

--- a/assets/agents/v3/qe-learning-coordinator.md
+++ b/assets/agents/v3/qe-learning-coordinator.md
@@ -180,7 +180,7 @@ Core Skills:
 Advanced Skills:
 - reasoningbank-agentdb: Vector-indexed pattern storage
 - quality-metrics: Measure and optimize quality metrics
-- holistic-testing-pact: PACT principles for comprehensive testing
+- holistic-testing-pact: PACTS principles for comprehensive testing
 
 Use via CLI: `aqe skills show reasoningbank-intelligence`
 Use via Claude Code: `Skill("reasoningbank-agentdb")`

--- a/assets/skills/README.md
+++ b/assets/skills/README.md
@@ -19,7 +19,7 @@ Version-agnostic quality engineering best practices from the QE community.
 
 - **a11y-ally**: Comprehensive WCAG accessibility auditing with multi-tool testing (axe-core + pa11y + Lighthouse), TRUE PARALLEL execution with Promise.allSettled, graceful degradation, retry with backoff, context-aware remediation, learning integration, and video accessibility. Uses 3-tier browser cascade: Vibium → agent-browser → Playwright+Stealth.
 - **accessibility-testing**: WCAG 2.2 compliance testing, screen reader validation, and inclusive design verification. Use when ensuring legal compliance (ADA, Section 508), testing for disabilities, or building accessible applications for 1 billion disabled users globally.
-- **agentic-quality-engineering**: AI agents as force multipliers for quality work. Core skill for all 19 QE agents using PACT principles.
+- **agentic-quality-engineering**: AI agents as force multipliers for quality work. Core skill for all 19 QE agents using PACTS principles.
 - **api-testing-patterns**: Comprehensive API testing patterns including contract testing, REST/GraphQL testing, and integration testing. Use when testing APIs or designing API test strategies.
 - **browser**: Web browser automation with AI-optimized snapshots for claude-flow agents
 - **brutal-honesty-review**: Unvarnished technical criticism combining Linus Torvalds
@@ -36,7 +36,7 @@ Version-agnostic quality engineering best practices from the QE community.
 - **debug-loop**: Hypothesis-driven autonomous debugging with real command validation
 - **enterprise-integration-testing**: Orchestration skill for enterprise integration testing across SAP, middleware, WMS, and backend systems. Covers E2E enterprise flows, SAP-specific patterns (RFC, BAPI, IDoc, OData, Fiori), cross-system data validation, and enterprise quality gates.
 - **exploratory-testing-advanced**: Advanced exploratory testing techniques with Session-Based Test Management (SBTM), RST heuristics, and test tours. Use when planning exploration sessions, investigating bugs, or discovering unknown quality risks.
-- **holistic-testing-pact**: Apply the Holistic Testing Model evolved with PACT (Proactive, Autonomous, Collaborative, Targeted) principles. Use when designing comprehensive test strategies for Classical, AI-assisted, Agent based, or Agentic Systems building quality into the team, or implementing whole-team quality practices.
+- **holistic-testing-pact**: Apply the Holistic Testing Model evolved with PACTS (Proactive, Autonomous, Collaborative, Targeted, Structured) principles. Use when designing comprehensive test strategies for Classical, AI-assisted, Agent based, or Agentic Systems building quality into the team, or implementing whole-team quality practices.
 - **localization-testing**: Internationalization (i18n) and localization (l10n) testing for global products including translations, locale formats, RTL languages, and cultural appropriateness. Use when launching in new markets or building multi-language products.
 - **middleware-testing-patterns**: Enterprise middleware testing patterns for message routing, transformation, DLQ, protocol mediation, ESB error handling, and EIP patterns. Use when testing middleware layers, message brokers, ESBs, or integration buses.
 - **mobile-testing**: Comprehensive mobile testing for iOS and Android platforms including gestures, sensors, permissions, device fragmentation, and performance. Use when testing native apps, hybrid apps, or mobile web, ensuring quality across 1000+ device variants.

--- a/assets/skills/agentic-quality-engineering/SKILL.md
+++ b/assets/skills/agentic-quality-engineering/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentic-quality-engineering
-description: "Use when orchestrating QE agents, understanding PACT principles, configuring the AQE v3 fleet, or leveraging AI agents as force multipliers for quality work."
+description: "Use when orchestrating QE agents, understanding PACTS principles, configuring the AQE v3 fleet, or leveraging AI agents as force multipliers for quality work."
 category: qe-core
 priority: critical
 tokenEstimate: 1400
@@ -10,7 +10,7 @@ optimization_version: 1.0
 last_optimized: 2025-12-02
 dependencies: []
 quick_reference_card: true
-tags: [pact, agents, fleet, coordination, autonomous, foundational]
+tags: [pacts, agents, fleet, coordination, autonomous, structured, foundational]
 trust_tier: 1
 validation:
   schema_path: schemas/output.json
@@ -22,7 +22,7 @@ validation:
 When implementing agentic QE or coordinating agents:
 1. SPAWN appropriate agent(s) for the task using `Task` tool with agent type
 2. CONFIGURE agent coordination (hierarchical/mesh/sequential)
-3. EXECUTE with PACT principles: Proactive analysis, Autonomous operation, Collaborative feedback, Targeted risk focus
+3. EXECUTE with PACTS principles: Proactive analysis, Autonomous operation, Collaborative feedback, Targeted risk focus, Structured governance (observability and explainability of agent behavior)
 4. VALIDATE results through quality gates before deployment
 5. LEARN from outcomes - store patterns in `aqe/learning/*` namespace
 
@@ -48,13 +48,14 @@ When implementing agentic QE or coordinating agents:
 - Implementing multi-agent coordination
 - Building CI/CD quality pipelines
 
-### PACT Principles
+### PACTS Principles
 | Principle | Agent Behavior | Human Role |
 |-----------|---------------|------------|
 | **P**roactive | Analyze pre-merge, predict risk | Set guardrails |
 | **A**utonomous | Execute tests, fix flaky tests | Review critical |
 | **C**ollaborative | Multi-agent coordination | Provide context |
 | **T**argeted | Risk-based prioritization | Define risk areas |
+| **S**tructured | Governance, observability, explainable decisions (measure confidence, not trust) | Audit behavior, set policy |
 
 ### 19-Agent Fleet
 | Category | Agents | Primary Use |
@@ -294,7 +295,7 @@ agent_assignments:
 ---
 
 ## Related Skills
-- `holistic-testing-pact` - PACT principles deep dive
+- `holistic-testing-pact` - PACTS principles deep dive
 - `risk-based-testing` - Prioritize agent focus
 - `quality-metrics` - Measure agent effectiveness
 - `api-testing-patterns`, `security-testing`, `performance-testing` - Specialized testing

--- a/assets/skills/agentic-quality-engineering/schemas/output.json
+++ b/assets/skills/agentic-quality-engineering/schemas/output.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://agentic-qe.dev/schemas/agentic-quality-engineering-output.json",
   "title": "Agentic Quality Engineering Skill Output Schema",
-  "description": "Schema for agentic quality engineering output with fleet status, agent coordination, and PACT principles validation.",
+  "description": "Schema for agentic quality engineering output with fleet status, agent coordination, and PACTS principles validation.",
   "type": "object",
   "required": ["skillName", "version", "timestamp", "status", "trustTier", "output"],
   "properties": {
@@ -52,7 +52,7 @@
         },
         "pactPrinciples": {
           "$ref": "#/$defs/pactPrinciples",
-          "description": "PACT principles assessment (Proactive, Autonomous, Collaborative, Targeted)"
+          "description": "PACTS principles assessment (Proactive, Autonomous, Collaborative, Targeted, Structured)"
         },
         "qualityScore": {
           "$ref": "#/$defs/qualityScore",
@@ -272,11 +272,15 @@
           "$ref": "#/$defs/pactDimension",
           "description": "Targeted testing approach"
         },
+        "structured": {
+          "$ref": "#/$defs/pactDimension",
+          "description": "Structured governance, observability, and explainability of agent behavior (measure confidence, not trust)"
+        },
         "overallScore": {
           "type": "number",
           "minimum": 0,
           "maximum": 100,
-          "description": "Overall PACT score"
+          "description": "Overall PACTS score"
         }
       }
     },

--- a/assets/skills/holistic-testing-pact/SKILL.md
+++ b/assets/skills/holistic-testing-pact/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: holistic-testing-pact
-description: "Apply the Holistic Testing Model evolved with PACT (Proactive, Autonomous, Collaborative, Targeted) principles. Use when designing comprehensive test strategies for Classical, AI-assisted, Agent based, or Agentic Systems building quality into the team, or implementing whole-team quality practices."
+description: "Apply the Holistic Testing Model evolved with PACTS (Proactive, Autonomous, Collaborative, Targeted, Structured) principles. Use when designing comprehensive test strategies for Classical, AI-assisted, Agent based, or Agentic Systems building quality into the team, or implementing whole-team quality practices."
 category: testing-methodologies
 priority: critical
 tokenEstimate: 1100
@@ -10,26 +10,27 @@ optimization_version: 1.0
 last_optimized: 2025-12-02
 dependencies: []
 quick_reference_card: true
-tags: [holistic, pact, quality, whole-team, proactive, autonomous, collaborative, targeted]
+tags: [holistic, pacts, quality, whole-team, proactive, autonomous, collaborative, targeted, structured]
 trust_tier: 0
 validation:
 ---
 
-# Holistic Testing Model with PACT Principles
+# Holistic Testing Model with PACTS Principles
 
 <default_to_action>
 When designing test strategies or building quality into teams:
-1. APPLY PACT principles: Proactive (test before bugs), Autonomous (teams own quality), Collaborative (whole-team responsibility), Targeted (risk-focused)
+1. APPLY PACTS principles: Proactive (test before bugs), Autonomous (teams own quality), Collaborative (whole-team responsibility), Targeted (risk-focused), Structured (governance, observability, and explainability of agent behavior)
 2. IDENTIFY quadrant focus: Technology-facing (unit, integration, performance) or Business-facing (acceptance, exploratory, usability)
-3. SELECT agents based on PACT dimension and testing quadrant
+3. SELECT agents based on PACTS dimension and testing quadrant
 4. IMPLEMENT feedback loops that catch issues in minutes, not days
-5. MEASURE outcomes (bug escape rate, release confidence) not activities (test count)
+5. MEASURE outcomes (bug escape rate, release confidence, agent confidence) not activities (test count)
 
-**Quick PACT Application:**
+**Quick PACTS Application:**
 - Proactive → Design testability into architecture, risk analysis during refinement
 - Autonomous → Devs run tests locally, CI pipeline with no manual gates
 - Collaborative → Three Amigos, QE pairs with dev, shared test ownership
 - Targeted → Risk-based planning, focus on critical flows, kill valueless tests
+- Structured → Governance, observability, and explainability of agent behavior; measure confidence, not trust
 
 **Critical Success Factors:**
 - Quality is a whole-team responsibility, not a QA phase
@@ -45,13 +46,14 @@ When designing test strategies or building quality into teams:
 - Choosing testing approach for new projects
 - Evolving from sequential QA to concurrent quality
 
-### PACT Principles
+### PACTS Principles
 | Principle | Focus | Anti-Pattern |
 |-----------|-------|--------------|
 | **Proactive** | Test before code, design testability | Waiting for bugs to find you |
 | **Autonomous** | Teams deploy when ready | QA as manual gatekeepers |
 | **Collaborative** | Whole-team quality thinking | QA works in isolation |
 | **Targeted** | Risk-based, high-value tests | Exhaustive checkbox testing |
+| **Structured** | Governance, observability, explainability of agent behavior | Bolting agentic AI onto chaos |
 
 ### Holistic Testing Quadrants
 | Quadrant | Purpose | Examples |
@@ -61,17 +63,18 @@ When designing test strategies or building quality into teams:
 | Business + Support | Shared understanding | BDD, acceptance tests |
 | Business + Critique | Discover unknowns | Exploratory, usability, A/B |
 
-### Agent Selection by PACT + Quadrant
-| PACT Dimension | Agents |
+### Agent Selection by PACTS + Quadrant
+| PACTS Dimension | Agents |
 |----------------|--------|
 | Proactive + Tech | qe-test-generator, qe-requirements-validator |
 | Autonomous + Tech | qe-test-executor, qe-coverage-analyzer |
 | Collaborative | qe-fleet-commander (orchestration) |
 | Targeted | qe-regression-risk-analyzer, qe-quality-gate |
+| Structured | qe-fleet-commander, qe-quality-gate (governance, observability, explainability) |
 
 ---
 
-## PACT in Practice
+## PACTS in Practice
 
 ### Proactive: Test Before Bugs
 ```javascript
@@ -105,11 +108,41 @@ await Task("Risk-Based Planning", {
 }, "qe-regression-risk-analyzer");
 ```
 
+### Structured: Governance, Observability, Explainability
+The 5th principle for agentic systems. As agents take on quality work, you need
+governance (boundaries and guardrails), observability (what agents did and why),
+and explainability (decisions you can audit). Especially important in regulated
+industries.
+
+- We measure **CONFIDENCE, not trust** — trust is a human feeling; confidence can
+  be mathematically explained.
+- Ships with a playbook + readiness-assessment guide.
+- Anti-pattern: bolting agentic AI onto chaos. Structure first, then automate.
+
+```javascript
+// Make agent behavior auditable and explainable, not a black box
+await Task("Agent Governance Review", {
+  guardrails: ['scope-boundaries', 'approval-gates'],
+  observability: ['decision-traces', 'confidence-scores'],
+  explainability: 'every-decision-auditable'
+}, "qe-fleet-commander");
+```
+
+---
+
+## From PACT to PACTS
+
+PACT originated with Reuven Cohen (Agentics Foundation) and was adapted to quality
+engineering by Dragan Spiridonov. PACTS adds a fifth principle — **Structured** —
+inspired by DORA's research on AI-assisted delivery and platform-engineering
+quality measurement. The addition reflects that autonomous, agentic quality work
+needs governance, observability, and explainability to be trustworthy at scale.
+
 ---
 
 ## Evolution from Traditional
 
-| Old Way (Sequential) | Holistic + PACT (Concurrent) |
+| Old Way (Sequential) | Holistic + PACTS (Concurrent) |
 |---------------------|------------------------------|
 | Dev writes → QA tests → bugs found → fixes | Team discusses what to build and how to test |
 | Slow feedback, finger-pointing | Fast feedback, shared ownership |
@@ -133,7 +166,7 @@ await Task("Risk-Based Planning", {
 ### Memory Namespace
 ```
 aqe/holistic-testing/
-├── pact-assessment/*     - PACT maturity analysis
+├── pacts-assessment/*    - PACTS maturity analysis
 ├── quadrant-coverage/*   - Coverage per quadrant
 ├── team-metrics/*        - Quality ownership metrics
 └── feedback-loops/*      - Cycle time data
@@ -143,7 +176,7 @@ aqe/holistic-testing/
 ```typescript
 const holisticFleet = await FleetManager.coordinate({
   strategy: 'holistic-testing',
-  pact: { proactive: true, autonomous: true, collaborative: true, targeted: true },
+  pacts: { proactive: true, autonomous: true, collaborative: true, targeted: true, structured: true },
   agents: [
     'qe-fleet-commander',       // Orchestration
     'qe-test-generator',        // Tech quadrant
@@ -166,8 +199,8 @@ const holisticFleet = await FleetManager.coordinate({
 
 ## Remember
 
-**PACT = Proactive + Autonomous + Collaborative + Targeted**
+**PACTS = Proactive + Autonomous + Collaborative + Targeted + Structured**
 
-Quality is built in, not tested in. Teams own quality. QA enables, doesn't gate. Test what matters, skip what doesn't. Measure outcomes, not activities.
+Quality is built in, not tested in. Teams own quality. QA enables, doesn't gate. Test what matters, skip what doesn't. Govern agent behavior with observability and explainability — measure confidence, not trust. Measure outcomes, not activities.
 
-**With Agents:** Agents analyze PACT maturity, recommend quadrant coverage, and coordinate whole-team quality. Use agents to scale holistic thinking while maintaining human judgment.
+**With Agents:** Agents analyze PACTS maturity, recommend quadrant coverage, and coordinate whole-team quality. Use agents to scale holistic thinking while maintaining human judgment.

--- a/assets/skills/skills-manifest.json
+++ b/assets/skills/skills-manifest.json
@@ -308,7 +308,7 @@
     "agentic-quality-engineering": {
       "id": "agentic-quality-engineering",
       "name": "Agentic Quality Engineering",
-      "description": "Core foundational skill for all 19 QE agents with PACT principles (Proactive, Autonomous, Collaborative, Targeted).",
+      "description": "Core foundational skill for all 19 QE agents with PACTS principles (Proactive, Autonomous, Collaborative, Targeted, Structured).",
       "category": "qe-core",
       "priority": "critical",
       "file": "agentic-quality-engineering/SKILL.md",
@@ -317,19 +317,19 @@
       "optimizationStatus": "optimized",
       "optimizationVersion": "1.0",
       "lastOptimized": "2025-12-02",
-      "tags": ["agents", "pact", "core", "foundation", "autonomous-testing"],
+      "tags": ["agents", "pacts", "core", "foundation", "autonomous-testing"],
       "dependencies": [],
       "agents": ["qe-test-generator", "qe-test-executor", "qe-coverage-analyzer", "qe-quality-gate", "qe-quality-analyzer", "qe-performance-tester", "qe-security-scanner", "qe-requirements-validator", "qe-production-intelligence", "qe-fleet-commander", "qe-deployment-readiness", "qe-regression-risk-analyzer", "qe-test-data-architect", "qe-api-contract-validator", "qe-flaky-test-hunter", "qe-visual-tester", "qe-chaos-engineer", "qe-code-complexity", "qx-partner"]
     },
     "holistic-testing-pact": {
       "id": "holistic-testing-pact",
-      "name": "Holistic Testing with PACT Principles",
-      "description": "Holistic Testing Model evolved with PACT for whole-team quality in agentic systems.",
+      "name": "Holistic Testing with PACTS Principles",
+      "description": "Holistic Testing Model evolved with PACTS for whole-team quality in agentic systems.",
       "category": "qe-core",
       "priority": "critical",
       "file": "holistic-testing-pact/SKILL.md",
       "tokenEstimate": 1500,
-      "tags": ["pact", "holistic", "whole-team", "testing-quadrants"],
+      "tags": ["pacts", "holistic", "whole-team", "testing-quadrants"],
       "dependencies": ["agentic-quality-engineering"],
       "agents": ["qe-coverage-analyzer", "qe-quality-gate", "qe-fleet-commander"]
     },

--- a/docs/agentic-qe-intro.md
+++ b/docs/agentic-qe-intro.md
@@ -485,7 +485,7 @@ claude mcp add agentic-qe -- npx agentic-qe mcp
 #    /tdd-london-chicago           — London/Chicago school TDD
 #    /security-testing             — OWASP vulnerability testing
 #    /six-thinking-hats            — multi-perspective quality analysis
-#    /holistic-testing-pact        — PACT-based test strategy
+#    /holistic-testing-pact        — PACTS-based test strategy
 
 # 5. Or use CLI directly
 aqe test generate src/

--- a/docs/catalogs/AGENTIC-QE-AGENT-CATALOG.md
+++ b/docs/catalogs/AGENTIC-QE-AGENT-CATALOG.md
@@ -33,19 +33,20 @@
 
 ## Overview
 
-The Agentic QE system provides AI-powered quality engineering through a fleet of specialized agents organized into 12 DDD (Domain-Driven Design) domains. These agents follow **PACT principles**:
+The Agentic QE system provides AI-powered quality engineering through a fleet of specialized agents organized into 12 DDD (Domain-Driven Design) domains. These agents follow **PACTS principles**:
 
 - **P**roactive: Analyze pre-merge, predict risk
 - **A**utonomous: Execute tests, fix flaky tests
 - **C**ollaborative: Multi-agent coordination
 - **T**argeted: Risk-based prioritization
+- **S**tructured: Governance, observability, and explainability of agent behavior (measure confidence, not trust)
 
 ### Key Frameworks
 
 | Framework | Purpose |
 |-----------|---------|
 | **SFDIPOT** | Test idea generation (Structure, Function, Data, Interfaces, Platform, Operations, Time) |
-| **PACT** | Agent behavior principles |
+| **PACTS** | Agent behavior principles |
 | **Holistic Testing Model** | Tech/Business x Support/Critique quadrants |
 | **QCSD Phases** | Ideation, Refinement, Development, CI/CD, Production Telemetry |
 
@@ -544,8 +545,8 @@ See `docs/architecture/CROSS-PHASE-MEMORY-IMPLEMENTATION.md` for full details.
 
 | Skill | Purpose |
 |-------|---------|
-| agentic-quality-engineering | Core PACT principles, 19-agent coordination |
-| holistic-testing-pact | PACT principles deep dive, quadrant model |
+| agentic-quality-engineering | Core PACTS principles, 19-agent coordination |
+| holistic-testing-pact | PACTS principles deep dive, quadrant model |
 | cicd-pipeline-qe-orchestrator | 5-phase CI/CD orchestration |
 | qe-iterative-loop | Autonomous iteration loops (Ralph Wiggum technique) |
 

--- a/docs/v3-technical-architecture-glossary.md
+++ b/docs/v3-technical-architecture-glossary.md
@@ -10,7 +10,7 @@
 
 **SPARC (Specification, Pseudocode, Architecture, Refinement, Completion)** — A methodology for structured agent work. Breaks complex tasks into 5 phases so agents don't skip steps. The `sparc-orchestrator` agent coordinates this cycle.
 
-**PACT (Proactive, Autonomous, Collaborative, Targeted)** — The foundational principles of Agentic QE. Agents are proactive (find problems before asked), autonomous (self-coordinate), collaborative (share knowledge), and targeted (focus on highest-risk areas).
+**PACTS (Proactive, Autonomous, Collaborative, Targeted, Structured)** — The foundational principles of Agentic QE. Agents are proactive (find problems before asked), autonomous (self-coordinate), collaborative (share knowledge), targeted (focus on highest-risk areas), and structured (governance, observability, and explainability of agent behavior — measure confidence, not trust). PACTS extends the original PACT (Reuven Cohen, Agentics Foundation; adapted to QE by Dragan Spiridonov) with the Structured principle.
 
 ---
 

--- a/plugins/agentic-qe-fleet/.claude-plugin/plugin.json
+++ b/plugins/agentic-qe-fleet/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-qe-fleet",
-  "description": "PACT-based agentic quality engineering fleet — 11 specialized QE agents, sublinear coverage analysis, chaos/resilience testing, and TDD skills for Claude Code",
+  "description": "PACTS-based agentic quality engineering fleet — 11 specialized QE agents, sublinear coverage analysis, chaos/resilience testing, and TDD skills for Claude Code",
   "version": "0.1.0",
   "author": {
     "name": "Agentic QE",

--- a/plugins/agentic-qe-fleet/README.md
+++ b/plugins/agentic-qe-fleet/README.md
@@ -1,6 +1,6 @@
 # agentic-qe-fleet
 
-PACT-based agentic quality engineering fleet for Claude Code — a slim starter bundle of the AQE platform with 11 specialized QE agents, 9 core skills, 9 slash commands, and the `agentic-qe` MCP server.
+PACTS-based agentic quality engineering fleet for Claude Code — a slim starter bundle of the AQE platform with 11 specialized QE agents, 9 core skills, 9 slash commands, and the `agentic-qe` MCP server.
 
 ## What's bundled
 


### PR DESCRIPTION
## Summary

Evolves the QE framework from **PACT** (Proactive, Autonomous, Collaborative, Targeted) to **PACTS** by adding a fifth principle:

- **Structured** — Governance, observability, and explainability of agent behavior. We measure **CONFIDENCE, not trust** (trust is a human feeling; confidence can be mathematically explained). Inspired by DORA's research on AI-assisted delivery and platform-engineering quality measurement. Especially important in regulated industries. Ships with a playbook + readiness-assessment guide. Anti-pattern: bolting agentic AI onto chaos.

**Attribution:** PACT originated with Reuven Cohen (Agentics Foundation); adapted to QE by Dragan Spiridonov. PACTS adds Structured.

## Skill id kept stable (intentional)

The skill id/dir `holistic-testing-pact` (and `.kiro`'s `qe-holistic-testing-pact`) is **unchanged** — it is referenced across many other repos, so renaming would break them. Only the human-readable **title, description, and content** changed to PACTS; the directory, id, slug, schema property keys (`pactPrinciples`, `pactDimension`), and `file:` paths in manifests are preserved.

## Source-vs-generated

- **Source** = `.claude/skills/` (edited by hand).
- **`assets/skills/`** is generated by `scripts/prepare-assets.cjs` (copies `.claude/skills/`). The two affected SKILL.md, the schema, the README, and `qe-learning-coordinator.md` were byte-identical at HEAD and were updated in lockstep; `assets/skills/skills-manifest.json` is a curated subset (differs from `.claude`) and its 3 PACT lines were edited directly.
- **`.opencode/*.yaml`** is generated by `scripts/generate-opencode-skills.ts`. Only the two affected files were regenerated and committed. (Note: that generator has a pre-existing `__dirname is not defined` bug under the repo's `"type": "module"` ESM config and is not wired to any npm script; I regenerated the two files with a `__dirname` shim and committed only those two to avoid pulling in ~65 unrelated stale-drift files.)
- **`.kiro/`** is separate/hand-maintained — same edits applied consistently.
- `npm run skills:update-manifest` regenerates `trust-tier-manifest.json`, which contains **no PACT content** and showed large pre-existing drift (113→118 skills) unrelated to this change; reverted to keep the PR focused.

## Schema change (additive, non-breaking)

`agentic-quality-engineering/schemas/output.json` adds an **optional** `structured` dimension (not added to `required`) so existing valid outputs continue to validate. Slug keys kept.

## Verification

- `npm run sync:agents:check` → pass (exit 0)
- `npm run verify:counts` → pass (`src 1295, tests 873, agents 53, skills 188`)
- All edited JSON re-validated with `JSON.parse`.
- `npm install` was required (fresh worktree had no node_modules).

## Remaining intentional `PACT` references (verified)

`grep -rnE "\bPACT\b" --include=*.md --include=*.json --include=*.yaml --include=*.ts` (excl. node_modules) leaves only:

1. `holistic-testing-pact/SKILL.md` (+ assets + .kiro copies) — the **"From PACT to PACTS"** evolution note and the Reuven Cohen attribution.
2. `docs/v3-technical-architecture-glossary.md` — the attribution sentence ("PACTS extends the original PACT (Reuven Cohen …)").
3. `scripts/judge-benchmark-phase1-results.md` — historical benchmark result, left untouched per instructions.

All lowercase `pact` references that remain are the **Pact contract-testing tool** (pact-foundation), a different thing, correctly unchanged.

## Files changed: 25

Generated with Nagual