### PR TITLE
feat(flywheel): sign receipts with the Cognitum platform witness identity (bridge, qe-harness#7)

### DIFF
--- a/src/learning/qe-flywheel/platform-signer.ts
+++ b/src/learning/qe-flywheel/platform-signer.ts
@@ -1,0 +1,62 @@
+/**
+ * Witness-key bridge (qe-harness issue #7) — sign flywheel receipts with the ONE
+ * Cognitum platform identity instead of a self-generated key, so every QE receipt
+ * (engine campaign · flywheel promotion · coherence verdict) chains to the same
+ * externally-verifiable key (`QE_WITNESS_PUBLIC_KEYS_JSON` allowlist, fingerprint
+ * `f1ac28607da49ec1`).
+ *
+ * `createSigner` already accepts a 32-byte Ed25519 seed → deterministic keypair.
+ * The platform key is delivered as `QE_WITNESS_SIGNING_KEY` — a JSON
+ * `{ publicKey, privateKey }` of PEM strings (same shape qe-harness Stage-B reads
+ * from Secret Manager). We derive the seed from that private key and hand it to
+ * `createSigner`, reproducing the exact platform keypair.
+ *
+ * Graceful: returns null when the env var is absent/malformed, so the flywheel
+ * keeps its self-generated-key behaviour where the platform key isn't provided.
+ * Env-reading lives HERE, not in the dependency-free `receipt.ts` core.
+ */
+
+import { createPrivateKey, createPublicKey } from 'node:crypto';
+import { createSigner, type Signer } from './receipt.js';
+
+/** DER prefix of an Ed25519 PKCS#8 private key (16 bytes) preceding the 32-byte seed. */
+const ED25519_PKCS8_PREFIX = '302e020100300506032b657004220420';
+
+/**
+ * Extract the raw 32-byte Ed25519 seed from a PKCS#8 private-key PEM. Throws if the
+ * key is not an Ed25519 PKCS#8 key (wrong curve / format).
+ */
+export function seedFromPkcs8Pem(privateKeyPem: string): Buffer {
+  const der = createPrivateKey(privateKeyPem).export({ format: 'der', type: 'pkcs8' });
+  if (der.length !== 48 || der.subarray(0, 16).toString('hex') !== ED25519_PKCS8_PREFIX) {
+    throw new Error('not an Ed25519 PKCS#8 private key (cannot derive a 32-byte seed)');
+  }
+  return Buffer.from(der.subarray(16, 48));
+}
+
+/** The shape of the `QE_WITNESS_SIGNING_KEY` secret (JSON of PEM strings). */
+interface PlatformKey { publicKey?: string; privateKey?: string; }
+
+/**
+ * Build a {@link Signer} bound to the Cognitum platform identity from
+ * `QE_WITNESS_SIGNING_KEY`, or null when it is unset/malformed (graceful fallback).
+ * The returned signer's `keyId` equals the platform witness fingerprint, so a
+ * verifier can attribute the receipt to the platform via the same allowlist that
+ * accepts qe-harness evidence bundles.
+ */
+export function platformSigner(env: NodeJS.ProcessEnv = process.env): Signer | null {
+  const raw = env.QE_WITNESS_SIGNING_KEY;
+  if (!raw) return null;
+  let key: PlatformKey;
+  try {
+    key = JSON.parse(raw) as PlatformKey;
+  } catch {
+    return null;
+  }
+  if (!key.privateKey) return null;
+  try {
+    return createSigner(seedFromPkcs8Pem(key.privateKey));
+  } catch {
+    return null; // wrong key type / unparseable — fall back to a self-generated signer
+  }
+}

--- a/src/learning/qe-flywheel/receipt.ts
+++ b/src/learning/qe-flywheel/receipt.ts
@@ -30,9 +30,16 @@ export interface Signer {
   sign(message: string): string;
 }
 
-/** Derive a stable key id from a public key PEM. */
+/**
+ * Derive a stable key id from a public key PEM. The PEM is trimmed first so the id
+ * is invariant to trailing whitespace (PEM exports carry a trailing newline) AND
+ * matches the Cognitum platform witness fingerprint scheme — `sha256(pem.trim())`
+ * truncated to 16 hex (qe-harness `witness.ts` / meta-llm `qe-witness.ts`). This lets
+ * a flywheel receipt signed with the platform key carry the SAME id the platform
+ * allowlist (`QE_WITNESS_PUBLIC_KEYS_JSON`) recognizes. See platform-signer.ts.
+ */
 function keyIdOf(publicKeyPem: string): string {
-  return createHash('sha256').update(publicKeyPem).digest('hex').slice(0, 16);
+  return createHash('sha256').update(publicKeyPem.trim()).digest('hex').slice(0, 16);
 }
 
 /**

--- a/tests/unit/learning/platform-signer.test.ts
+++ b/tests/unit/learning/platform-signer.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { generateKeyPairSync, createHash } from 'node:crypto';
+import { platformSigner, seedFromPkcs8Pem } from '../../../src/learning/qe-flywheel/platform-signer.js';
+import { createSigner, signReceipt, verifyReceiptSignature, type ReceiptBody } from '../../../src/learning/qe-flywheel/receipt.js';
+
+/** Generate a platform-key JSON (the shape of the QE_WITNESS_SIGNING_KEY secret). */
+function platformKeyJson(): { json: string; publicKey: string } {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519', {
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+  return { json: JSON.stringify({ publicKey, privateKey }), publicKey };
+}
+
+const fp = (pem: string) => createHash('sha256').update(pem.trim()).digest('hex').slice(0, 16);
+
+describe('platform witness-key bridge', () => {
+  it('should_extractA32ByteSeed_fromAnEd25519Pkcs8Pem', () => {
+    const { privateKey } = generateKeyPairSync('ed25519', {
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+    const seed = seedFromPkcs8Pem(privateKey);
+    expect(seed).toHaveLength(32);
+    // Reproducing a signer from the seed yields the same key (determinism).
+    expect(createSigner(seed).keyId).toBe(createSigner(seed).keyId);
+  });
+
+  it('should_rejectANonEd25519Key', () => {
+    const { privateKey } = generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+    expect(() => seedFromPkcs8Pem(privateKey)).toThrow(/Ed25519/);
+  });
+
+  it('should_signWithThePlatformIdentity_whenEnvIsSet', () => {
+    const { json, publicKey } = platformKeyJson();
+    const signer = platformSigner({ QE_WITNESS_SIGNING_KEY: json } as NodeJS.ProcessEnv);
+    expect(signer).not.toBeNull();
+    // Same public key as the platform secret, and keyId == the platform fingerprint scheme.
+    expect(signer!.publicKeyPem.trim()).toBe(publicKey.trim());
+    expect(signer!.keyId).toBe(fp(publicKey));
+  });
+
+  it('should_produceAVerifiableReceipt_underThePlatformKey', () => {
+    const { json } = platformKeyJson();
+    const signer = platformSigner({ QE_WITNESS_SIGNING_KEY: json } as NodeJS.ProcessEnv)!;
+    const body: ReceiptBody = {
+      generation: 1, ruleVersion: 'v1', ruleFingerprint: 'rf', sealed: {} as never, sealedHash: 'h',
+      verdict: 'promote', baselinePolicyId: 'b', candidatePolicyId: 'c',
+      signerKeyId: signer.keyId, publicKeyPem: signer.publicKeyPem,
+    };
+    const receipt = signReceipt(body, signer);
+    expect(verifyReceiptSignature(receipt)).toBe(true);
+    // Tamper the verdict → signature must fail.
+    expect(verifyReceiptSignature({ ...receipt, verdict: 'reject' })).toBe(false);
+  });
+
+  it('should_returnNull_whenEnvUnsetOrMalformed', () => {
+    expect(platformSigner({} as NodeJS.ProcessEnv)).toBeNull();
+    expect(platformSigner({ QE_WITNESS_SIGNING_KEY: 'not json' } as NodeJS.ProcessEnv)).toBeNull();
+    expect(platformSigner({ QE_WITNESS_SIGNING_KEY: '{"publicKey":"x"}' } as NodeJS.ProcessEnv)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Wires the **witness-key bridge** (cognitum-one/qe-harness#7): the QE-policy flywheel now signs its evolve receipts with the **Cognitum platform identity** instead of a self-generated key, so all QE evidence — engine campaign, flywheel promotion — chains to the same externally-verifiable key (`f1ac28607da49ec1`).

## Why now
"Signed evidence = trust" only holds if every receipt chains to ONE verifiable identity. qe-harness Stage-B already signs with the platform key from Secret Manager; the flywheel signed with its own local key, so a verifier couldn't attribute its lineage to the platform.

## What changed
- **`platform-signer.ts` (new)** — `platformSigner()` derives the deterministic Ed25519 seed from `QE_WITNESS_SIGNING_KEY` (JSON `{publicKey, privateKey}`) and hands it to the existing `createSigner`, reproducing the exact platform keypair. Returns `null` when the env is unset/malformed (graceful — self-generated-key behaviour is preserved). Env-reading is kept **out** of the dependency-free `receipt.ts` core.
- **`receipt.ts` `keyIdOf`** now trims the PEM before hashing, so the key-id is whitespace-invariant **and matches the platform witness fingerprint scheme** (`sha256(pem.trim())` → 16 hex, per qe-harness `witness.ts` / meta-llm `qe-witness.ts`). No existing flywheel test asserts a literal key-id; determinism tests still pass.

## Verification (against the real secret — no key material logged)
```
flywheelKeyId:            f1ac28607da49ec1
isPlatformKey_f1ac:       true
keyIdInAllowlist:         true   (real QE_WITNESS_PUBLIC_KEYS_JSON)
receiptVerifies:          true
tamperRejected:           true
```
Tests: **+5** (`platform-signer.test.ts`); existing flywheel suite (**34**) green; `tsc --noEmit` clean.

## Not in scope (follow-up on cognitum-one/qe-harness#7)
- meta-llm: accept/verify flywheel receipts on the same allowlist path (they aren't ingested today).
- Wire `platformSigner()` at the flywheel run call-sites (evals adapter / MCP / CLI) — this PR provides the mechanism; the default remains a self-generated key when the env isn't set.

🤖 Generated with Ruflo & AQE
