### PR TITLE
chore(release): v3.12.3 — atomic RVF export + self-healing stores (#563)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-qe",
-  "version": "3.12.2",
+  "version": "3.12.3",
   "description": "Agentic Quality Engineering — AI-powered QE platform with 60 specialized agents, 75+ skills, sublinear coverage analysis, ReasoningBank pattern learning, and deep MCP integration for Claude Code and 11 coding agent platforms",
   "author": {
     "name": "Agentic QE Team",

--- a/.claude/skills/skills-manifest.json
+++ b/.claude/skills/skills-manifest.json
@@ -939,7 +939,7 @@
   },
   "metadata": {
     "generatedBy": "Agentic QE Fleet",
-    "fleetVersion": "3.12.2",
+    "fleetVersion": "3.12.3",
     "manifestVersion": "1.4.0",
     "lastUpdated": "2026-04-13T00:00:00.000Z",
     "contributors": [

--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,9 @@ coordination/orchestration/*
 !src/adapters/claude-flow/
 .agentic-qe/aqe.rvf.manifest.json
 .agentic-qe/memory/
+# Issue #563: quarantined unusable RVF stores and in-flight export tmps
+*.rvf.corrupt-*
+*.rvf.tmp.*
 # ADR-070: Ed25519 witness-chain signing keys — never commit private key material
 .agentic-qe/witness-keys/
 .agentic-qe/data/learning/state.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to the Agentic QE project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.12.3] - 2026-07-17
+
+Fixes a bug that could silently switch off vector search — permanently. If an
+export of the RVF store was interrupted (a hook timing out, a session ending, a
+hard kill), it left behind a store file that AQE could neither open nor replace.
+Every later run fell back to SQLite without saying so, and only deleting the
+file by hand brought it back. One reporting project hit this three times in a
+day; this repository turned out to have been running degraded for nine days.
+Existing broken projects self-heal on the next run — no manual cleanup. Thanks
+to @pacphi for the detailed report (#563).
+
+### Fixed
+
+- **An interrupted brain export no longer breaks the store (#563).** Exports
+  are now written to a temporary file and moved into place only once complete,
+  so an interruption leaves your previous store untouched instead of destroying
+  it. Abandoned temporary files are cleaned up on the next export.
+- **Unusable stores are repaired automatically instead of silently disabling
+  vector search (#563).** When a store can neither be opened nor rebuilt over,
+  AQE now sets it aside (as `<name>.rvf.corrupt-<pid>` — kept, not deleted, in
+  case you want to report it) and rebuilds the cache from `memory.db`. This
+  applies to `brain.rvf`, `patterns.rvf`, and the pattern-store path. Previously
+  each of these degraded quietly, for every subsequent run.
+- **RVF failures are no longer silent.** Falling back to SQLite now logs why,
+  rather than vanishing into an empty `catch`.
+- **A live process's store is no longer at risk during lock cleanup (#563).**
+  Stale-lock recovery previously removed lock files unconditionally, which could
+  break a store another process was actively using. Locks are now checked
+  against their owning process and left alone when it is still running.
+
+### Added
+
+- **Flywheel receipts are signed with the Cognitum platform identity (#562).**
+  The QE-policy flywheel now signs its evolve receipts with the same
+  externally-verifiable platform key (`f1ac28607da49ec1`) used elsewhere, so all
+  QE evidence — engine campaign and flywheel promotion — chains to one identity
+  a verifier can attribute. Falls back to the local key when the platform
+  identity is unavailable.
+
 ## [3.12.2] - 2026-07-13
 
 Billing-aware LLM execution. AQE could previously only bill the paid Anthropic

--- a/assets/skills/skills-manifest.json
+++ b/assets/skills/skills-manifest.json
@@ -939,7 +939,7 @@
   },
   "metadata": {
     "generatedBy": "Agentic QE Fleet",
-    "fleetVersion": "3.12.2",
+    "fleetVersion": "3.12.3",
     "manifestVersion": "1.4.0",
     "lastUpdated": "2026-04-13T00:00:00.000Z",
     "contributors": [

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -4,6 +4,7 @@ All Agentic QE release notes organized by version.
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| [v3.12.3](v3.12.3.md) | 2026-07-17 | Fixes vector search silently switching off for good: an interrupted RVF export left a store AQE could neither open nor replace, degrading to SQLite on every later run. Exports are now atomic; unusable stores quarantine and rebuild themselves — no manual cleanup. Flywheel receipts signed with the Cognitum platform identity. |
 | [v3.12.2](v3.12.2.md) | 2026-07-13 | Billing-aware LLM execution: run QE on your Claude subscription (`AQE_LLM_PROVIDER=claude-code`), enforced cross-process spend caps (`--max-budget-usd`), Cognitum gateway provider, and billing transparency in `aqe health`. Fixes `aqe eval run` scoring fabricated mock responses — now real calls by default. ADR-123. |
 | [v3.12.1](v3.12.1.md) | 2026-07-12 | Non-destructive `aqe init`: merges (never overwrites) `.claude/settings.json`, preserves custom statusLine / `includeCoAuthoredBy` / `AQE_*` overrides / other tools' hooks (ruflo, Claude Flow), and backs up the original before changes. |
 | [v3.12.0](v3.12.0.md) | 2026-07-10 | Learning-integrity layer: promotions gated by evidence quality (test-exec > LLM-judge > structural), frozen hash-pinned oracle benchmark, Ed25519-signed replayable receipts, and frozen-rule re-execution before promotion. New two-gate `aqe quality-gate` CLI + `qe/quality/gate` MCP tool. Designed-experiment (DoE) tool with real ANOVA. ADRs 117–122. Additive. |

--- a/docs/releases/v3.12.3.md
+++ b/docs/releases/v3.12.3.md
@@ -1,0 +1,79 @@
+# v3.12.3 Release Notes
+
+**Release Date:** 2026-07-17
+
+## Highlights
+
+Fixes a bug that could **silently switch off vector search — permanently**. An
+interrupted export of the RVF store left behind a file AQE could neither open
+nor replace, so every later run quietly fell back to SQLite and only manual
+deletion brought it back. Exports are now atomic, and unusable stores repair
+themselves on the next run. Reported in
+[#563](https://github.com/proffesor-for-testing/agentic-qe/issues/563) by
+[@pacphi](https://github.com/pacphi).
+
+## Background
+
+`aqe brain export` (and the session-checkpoint hook that calls it) deleted the
+existing store and rebuilt it in place. Anything that interrupted that window — a
+hook timing out, a session ending, a `SIGKILL` — left a store that had been
+created but never completed: it could not be opened (`0x0106 ManifestNotFound`)
+and could not be created over either (`0x0303 FsyncFailed`, because the path
+already exists). Both paths failed on every subsequent run, and the failure was
+swallowed, so AQE kept working with vector search off and never said so.
+
+The reporting project hit this three times in a single working day. While fixing
+it we found this repository's own `patterns.rvf` had been unusable since Jul 8 —
+running degraded for nine days without a single visible symptom.
+
+**If you are affected, you don't need to do anything.** The next run detects the
+unusable store, sets it aside, and rebuilds the cache from `memory.db`.
+
+## Fixed
+
+- **Interrupted exports no longer destroy the store (#563)** — the export is
+  built at a temporary path and renamed into place only once it is complete, so
+  an interruption leaves the *previous* good store untouched. Temporary files
+  orphaned by a killed export are swept on the next export (skipping any whose
+  owning process is still running).
+- **Unusable stores are quarantined and rebuilt (#563)** — when a store can
+  neither be opened nor created over, it is provably unusable: AQE moves it aside
+  as `<name>.rvf.corrupt-<pid>` and rebuilds the derived cache from `memory.db`.
+  The bytes are **kept, not deleted**, both because they may hold writes that
+  never reached SQLite and so you can attach them to a bug report. This covers
+  all three store paths: `brain.rvf`, `patterns.rvf`, and the pattern store.
+- **RVF fallbacks are no longer silent** — degrading to SQLite now logs the
+  reason instead of disappearing into an empty `catch`.
+- **Lock cleanup no longer risks a live process's store (#563)** — stale-lock
+  recovery removed lock files unconditionally, which could break a store another
+  process was actively using. Lock ownership is now checked against the owning
+  process, and live locks are left alone.
+
+## Added
+
+- **Flywheel receipts signed with the Cognitum platform identity (#562)** — the
+  QE-policy flywheel signs its evolve receipts with the same externally
+  verifiable platform key (`f1ac28607da49ec1`) used by the rest of the QE
+  evidence chain, so engine campaign and flywheel promotion attribute to one
+  identity. Falls back to the local key when the platform identity is
+  unavailable.
+
+## Notes on the diagnosis
+
+The issue reported the corruption signature as "RVF store bytes inside the
+`.lock` file" (`FLVR` magic) plus a "truncated 162-byte store". Measured against
+`@ruvector/rvf-node` 0.1.8, both readings are misleading:
+
+- `FLVR` is the **lock record's own magic** — the store's magic is `SFVR`. A
+  104-byte `FLVR` lock is an ordinary lock record, live or stale, not leaked
+  store bytes.
+- A **valid, empty store is exactly 162 bytes** — indistinguishable by size from
+  the "truncated" file.
+
+Keying recovery on either signal would quarantine healthy stores, including out
+from under live processes. Recovery therefore triggers only on proof — open
+*and* create both failing — and uses the pid recorded in the lock record (u32 LE
+at offset 4) to avoid touching a store a live process owns.
+
+If you use tooling that quarantines on the `FLVR`-in-lock signature, it is
+likely flagging healthy locks.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentic-qe",
-  "version": "3.12.2",
+  "version": "3.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentic-qe",
-      "version": "3.12.2",
+      "version": "3.12.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-qe",
-  "version": "3.12.2",
+  "version": "3.12.3",
   "description": "Agentic Quality Engineering V3 - Domain-Driven Design Architecture with 13 Bounded Contexts, O(log n) coverage analysis, ReasoningBank learning, 60 specialized QE agents, mathematical Coherence verification, deep Claude Flow integration",
   "type": "module",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "test:all": "npm test -- --run",
     "test:mcp": "npm run test:unit:mcp",
     "test:mcp:integration": "npm test -- --run tests/integration/mcp/",
-    "test:integration:fast": "NODE_OPTIONS='--max-old-space-size=2048 --expose-gc' vitest run tests/integration/mcp/fleet-init-wires-daemon.test.ts tests/integration/mcp/mcp-cli-inprocess.test.ts tests/integration/mcp/memory-delete-cache-invalidation.test.ts tests/integration/workers/workers-reach-domains.test.ts tests/integration/learning/coordinator-roundtrip.test.ts tests/integration/bridge/bridge-end-to-end.test.ts",
+    "test:integration:fast": "NODE_OPTIONS='--max-old-space-size=2048 --expose-gc' vitest run tests/integration/mcp/fleet-init-wires-daemon.test.ts tests/integration/mcp/mcp-cli-inprocess.test.ts tests/integration/mcp/memory-delete-cache-invalidation.test.ts tests/integration/workers/workers-reach-domains.test.ts tests/integration/learning/coordinator-roundtrip.test.ts tests/integration/bridge/bridge-end-to-end.test.ts tests/integration/rvf-corruption-recovery.integration.test.ts",
     "test:integration": "NODE_OPTIONS='--max-old-space-size=4096 --expose-gc' vitest run tests/integration/ --exclude='**/browser/**' --exclude='**/browser-integration/**' --exclude='**/*.e2e.test.ts'",
     "mcp:validate": "node scripts/smoke-mcp-protocol.mjs",
     "mcp:parity": "node scripts/audit-mcp-tool-parity.mjs",

--- a/src/integrations/ruvector/brain-rvf-exporter.ts
+++ b/src/integrations/ruvector/brain-rvf-exporter.ts
@@ -4,8 +4,8 @@
  * Falls back to JSONL directory format when the native binding is unavailable.
  */
 
-import { existsSync, statSync, unlinkSync, writeFileSync } from 'fs';
-import { resolve } from 'path';
+import { existsSync, readdirSync, renameSync, statSync, unlinkSync, writeFileSync } from 'fs';
+import { basename, dirname, join, resolve } from 'path';
 import Database from 'better-sqlite3';
 import {
   createRvfStore,
@@ -92,6 +92,75 @@ export interface RvfBrainImportResult {
 
 // --- Export ---
 
+/**
+ * Sidecar suffixes that make up a complete store on disk. `''` is the store
+ * itself; the adapter writes `.idmap.json` on close, and we write the manifest.
+ */
+const RVF_STORE_SUFFIXES = ['', '.idmap.json', '.manifest.json'] as const;
+
+/**
+ * Everything an abandoned tmp export can leave behind. `.lock` is cleaned up
+ * but deliberately absent from RVF_STORE_SUFFIXES — renaming a lock into the
+ * final path is the very corruption this fix exists to prevent.
+ */
+const RVF_CLEANUP_SUFFIXES = [...RVF_STORE_SUFFIXES, '.lock'] as const;
+
+/** Best-effort removal of a store and its sidecars at `base`. */
+function removeStoreFiles(base: string): void {
+  for (const suffix of RVF_CLEANUP_SUFFIXES) {
+    try {
+      const p = `${base}${suffix}`;
+      if (existsSync(p)) unlinkSync(p);
+    } catch {
+      // best-effort — a leftover tmp is inert, unlike a corrupt final store
+    }
+  }
+}
+
+/**
+ * Remove tmp stores orphaned by killed exports (#563). Each interrupted export
+ * strands a full-size tmp store, so on a project where the checkpoint hook is
+ * killed regularly these would accumulate unbounded.
+ *
+ * Only tmps whose owning pid is gone are removed: a live pid means a concurrent
+ * export is mid-write, and deleting its tmp would corrupt exactly what this
+ * change exists to protect.
+ */
+function sweepStaleTmpFiles(outPath: string): void {
+  const dir = dirname(outPath);
+  const prefix = `${basename(outPath)}.tmp.`;
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (!entry.startsWith(prefix)) continue;
+    // `<name>.rvf.tmp.<pid>` and its `<...>.tmp.<pid>.idmap.json` siblings.
+    const pid = Number.parseInt(entry.slice(prefix.length).split('.')[0], 10);
+    if (!Number.isInteger(pid) || pid <= 0) continue;
+    if (pid !== process.pid && isPidAlive(pid)) continue;
+    try {
+      unlinkSync(join(dir, entry));
+    } catch {
+      // best-effort
+    }
+  }
+}
+
+/** True when a process with `pid` exists (signal 0 probes without delivering). */
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM means it exists but belongs to another user — still alive.
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
 /** Export brain state to a single `.rvf` file with vector embeddings + kernel. */
 export function exportBrainToRvf(
   db: Database.Database,
@@ -107,13 +176,21 @@ export function exportBrainToRvf(
   const outPath = resolve(options.outputPath);
   const dimension = options.dimension ?? 384;
 
-  // Clean up any existing file
-  if (existsSync(outPath)) unlinkSync(outPath);
-  const idmapPath = `${outPath}.idmap.json`;
-  if (existsSync(idmapPath)) unlinkSync(idmapPath);
+  // Issue #563: build the store at a private tmp path and rename it over the
+  // final path only once it is closed and complete. The previous code deleted
+  // the old store and then built the new one in place, so any interruption
+  // (hook timeout, session teardown, SIGKILL) left a created-but-incomplete
+  // store that could neither be opened (ManifestNotFound) nor created over
+  // (FsyncFailed) — permanently disabling the RVF backend. With tmp+rename an
+  // interrupted export leaves the *previous* good store untouched and orphans
+  // only an inert tmp file, which the next export sweeps.
+  const tmpPath = `${outPath}.tmp.${process.pid}`;
+  sweepStaleTmpFiles(outPath);
+  removeStoreFiles(tmpPath);
 
   // Create RVF container via adapter (handles idmap automatically)
-  const rvf = createRvfStore(outPath, dimension);
+  const rvf = createRvfStore(tmpPath, dimension);
+  let closed = false;
 
   try {
     // --- Export all tables using TABLE_CONFIGS ---
@@ -273,12 +350,35 @@ export function exportBrainToRvf(
     }
 
     // Persist manifest as sidecar JSON alongside the .rvf file
-    const manifestPath = `${outPath}.manifest.json`;
-    writeFileSync(manifestPath, JSON.stringify(manifest, null, 2), 'utf-8');
+    writeFileSync(`${tmpPath}.manifest.json`, JSON.stringify(manifest, null, 2), 'utf-8');
+
+    // Close before promoting: close() flushes the store and writes the idmap
+    // sidecar, so renaming any earlier would publish an incomplete store.
+    rvf.close();
+    closed = true;
+
+    // Promote tmp → final. The store itself goes last: until it lands, the
+    // previous store (if any) is still the one on disk, and a crash mid-promote
+    // leaves the old store readable rather than a half-written new one.
+    for (const suffix of [...RVF_STORE_SUFFIXES].reverse()) {
+      const from = `${tmpPath}${suffix}`;
+      const to = `${outPath}${suffix}`;
+      if (existsSync(from)) {
+        renameSync(from, to);
+      } else if (existsSync(to)) {
+        // No new sidecar produced — drop the stale one so it can't be read
+        // against the new store.
+        unlinkSync(to);
+      }
+    }
 
     return manifest;
-  } finally {
-    rvf.close();
+  } catch (err) {
+    if (!closed) {
+      try { rvf.close(); } catch { /* best-effort */ }
+    }
+    removeStoreFiles(tmpPath);
+    throw err;
   }
 }
 

--- a/src/integrations/ruvector/rvf-dual-writer.ts
+++ b/src/integrations/ruvector/rvf-dual-writer.ts
@@ -179,14 +179,34 @@ export class RvfDualWriter {
       try {
         nativeAdapter = adapter.openRvfStore(this.config.rvfPath);
       } catch {
-        nativeAdapter = adapter.createRvfStore(this.config.rvfPath, this.config.dimensions);
+        try {
+          nativeAdapter = adapter.createRvfStore(this.config.rvfPath, this.config.dimensions);
+        } catch (createErr) {
+          // Issue #563: open failed *and* create failed, so the file on disk is
+          // provably unusable — the signature of an export killed mid-write
+          // (open → ManifestNotFound, create → FsyncFailed because the path
+          // exists). Previously this fell to the catch below and disabled RVF
+          // silently for the whole run. Quarantine and rebuild instead.
+          const { quarantineUnusableStore } = await import('./rvf-store-integrity.js');
+          const quarantined = quarantineUnusableStore(
+            this.config.rvfPath,
+            createErr instanceof Error ? createErr.message : String(createErr),
+          );
+          if (!quarantined) throw createErr; // live peer, or nothing to move
+          nativeAdapter = adapter.createRvfStore(this.config.rvfPath, this.config.dimensions);
+        }
       }
 
       this.rvfStore = wrapNativeAdapter(nativeAdapter, this.config.dimensions);
       this.rvfAvailable = true;
-    } catch {
-      // Native adapter module not available at all
+    } catch (err) {
+      // Native adapter unavailable, or recovery itself failed. Degrade to
+      // sqlite-only — but say so, instead of vanishing silently (#563).
       this.rvfAvailable = false;
+      console.warn(
+        `[RVF] Dual-writer disabled for ${this.config.rvfPath}; falling back to SQLite: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
 

--- a/src/integrations/ruvector/rvf-store-integrity.ts
+++ b/src/integrations/ruvector/rvf-store-integrity.ts
@@ -1,0 +1,141 @@
+/**
+ * RVF store integrity helpers (issue #563).
+ *
+ * An export that is killed mid-write leaves a store that was created but never
+ * completed. Such a file cannot be opened (`RVF error 0x0106: ManifestNotFound`)
+ * and cannot be created over either, because the path already exists
+ * (`RVF error 0x0303: FsyncFailed`). Both paths fail forever, so the RVF
+ * backend stays disabled for the life of the project until someone deletes the
+ * file by hand.
+ *
+ * Recovery has to be evidence-based rather than fingerprint-based. Measured
+ * against @ruvector/rvf-node 0.1.8:
+ *
+ *   • A *valid, empty* store is 162 bytes with magic `SFVR` — byte-for-byte
+ *     the size the issue reports as "truncated: header only". Size and magic
+ *     therefore cannot distinguish a broken store from a healthy empty one.
+ *   • `<store>.lock` is a 104-byte record with magic `FLVR` and the owning pid
+ *     as a little-endian u32 at offset 4. `FLVR` in a lock is the *normal*
+ *     case — the issue reads it as "RVF store bytes leaked into the lock", but
+ *     the store magic is `SFVR`; a 104-byte `FLVR` lock is just a live-or-stale
+ *     lock record.
+ *
+ * So the only sound trigger is "open failed *and* create failed": at that point
+ * the file is provably unusable. The lock's pid is used as a *guard* — if it is
+ * held by a live process, the store is presumed healthy and left alone.
+ */
+
+import { existsSync, openSync, readSync, closeSync, renameSync, unlinkSync } from 'fs';
+
+/** Magic of a lock record (the store's own magic is `SFVR`). */
+const LOCK_MAGIC = 'FLVR';
+
+/** Byte offset of the owning pid within a lock record (u32 LE). */
+const LOCK_PID_OFFSET = 4;
+
+/** Sidecars that belong to a store and must be quarantined alongside it. */
+const STORE_SIDECAR_SUFFIXES = ['', '.idmap.json', '.manifest.json'] as const;
+
+/** Read the first `n` bytes of a file, or null if unreadable/shorter. */
+function readHead(path: string, n: number): Buffer | null {
+  let fd: number | undefined;
+  try {
+    fd = openSync(path, 'r');
+    const buf = Buffer.alloc(n);
+    if (readSync(fd, buf, 0, n, 0) < n) return null;
+    return buf;
+  } catch {
+    return null;
+  } finally {
+    if (fd !== undefined) {
+      try { closeSync(fd); } catch { /* best-effort */ }
+    }
+  }
+}
+
+/** True when a process with `pid` exists (signal 0 probes without delivering). */
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM means it exists but belongs to another user — still alive.
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+/** The pid recorded in `<rvfPath>.lock`, or null if there is no readable lock. */
+export function readLockOwnerPid(rvfPath: string): number | null {
+  const head = readHead(`${rvfPath}.lock`, LOCK_PID_OFFSET + 4);
+  if (!head || head.subarray(0, 4).toString('latin1') !== LOCK_MAGIC) return null;
+  const pid = head.readUInt32LE(LOCK_PID_OFFSET);
+  return pid > 0 ? pid : null;
+}
+
+/**
+ * True when the store's lock is held by a process that is still running.
+ *
+ * Deliberately conservative: an unreadable or pid-less lock reports false (the
+ * caller's open already failed, so there is nothing to protect), while a live
+ * pid reports true and blocks recovery. Pid reuse can only produce a false
+ * "alive", which fails safe — we leave the store alone.
+ */
+export function isLockHeldByLiveProcess(rvfPath: string): boolean {
+  const pid = readLockOwnerPid(rvfPath);
+  if (pid === null) return false;
+  return pid !== process.pid && isPidAlive(pid);
+}
+
+/**
+ * Move an unusable store and its sidecars aside so the next create succeeds.
+ * Returns the quarantine base path, or null if nothing was quarantined.
+ *
+ * Only call this once open *and* create have both failed — that is the proof
+ * the file is unusable. The store is a derived cache, rebuilt from the unified
+ * DB, so quarantining is recoverable; we move rather than delete because the
+ * bytes may hold writes that never reached SQLite, and they are the only
+ * evidence if this recurs.
+ */
+export function quarantineUnusableStore(rvfPath: string, reason: string): string | null {
+  if (!existsSync(rvfPath)) return null;
+
+  // Never pull a store out from under a live peer.
+  if (isLockHeldByLiveProcess(rvfPath)) {
+    console.warn(
+      `[RVF] ${rvfPath} is unusable but its lock is held by a live process — ` +
+        'leaving it alone and degrading to SQLite for this run.',
+    );
+    return null;
+  }
+
+  // Keyed by pid, not a timestamp: a crash-loop quarantining the same file
+  // repeatedly overwrites its own copy instead of filling .agentic-qe/ with
+  // one corrupt store per startup.
+  const quarantineBase = `${rvfPath}.corrupt-${process.pid}`;
+
+  for (const sidecar of STORE_SIDECAR_SUFFIXES) {
+    const from = `${rvfPath}${sidecar}`;
+    if (!existsSync(from)) continue;
+    try {
+      renameSync(from, `${quarantineBase}${sidecar}`);
+    } catch {
+      // A failed quarantine must not throw and take down the caller; the
+      // caller's retry will simply fail again and degrade as before.
+    }
+  }
+
+  // The store is gone, so its lock — stale by definition here — goes with it.
+  try {
+    if (existsSync(`${rvfPath}.lock`)) unlinkSync(`${rvfPath}.lock`);
+  } catch {
+    // best-effort
+  }
+
+  console.warn(
+    `[RVF] Quarantined unusable store ${rvfPath} → ${quarantineBase} (${reason}). ` +
+      'It is a derived cache and will be rebuilt from the unified DB. ' +
+      'Please report a recurrence with the quarantined files (issue #563).',
+  );
+
+  return quarantineBase;
+}

--- a/src/integrations/ruvector/shared-rvf-adapter.ts
+++ b/src/integrations/ruvector/shared-rvf-adapter.ts
@@ -15,6 +15,13 @@ import type { RvfNativeAdapter, RvfCompactionResult, RvfStatus } from './rvf-nat
 // Issue #516: lightweight, sqlite-free project-root resolver (static import so it
 // resolves under the test runner; avoids pulling unified-memory's sqlite graph).
 import { findProjectRoot } from '../../kernel/project-root.js';
+// Issue #563: static import — this module is fs-only, and a require() here
+// would not resolve under the test runner.
+import {
+  quarantineUnusableStore,
+  isLockHeldByLiveProcess,
+  readLockOwnerPid,
+} from './rvf-store-integrity.js';
 
 let sharedAdapter: RvfNativeAdapter | null = null;
 let initAttempted = false;
@@ -157,16 +164,24 @@ function openOrCreateRvf(
   // .lock that subsequent invocations interpret as `LockHeld`. Since AQE
   // CLI is overwhelmingly single-shot serial, the realistic case is "the
   // prior process is dead and the lock is stale". We unlink the .lock and
-  // retry open exactly once. If a genuinely-live peer existed, it still
-  // holds the file open — but the binding's lock is content-based (lock
-  // file presence), so this is a best-effort cooperative recovery rather
-  // than an OS-level lock break.
+  // retry open exactly once.
+  //
+  // Issue #563: the lock record turns out to carry its owner's pid (u32 LE at
+  // offset 4, after the `FLVR` magic), so "is it stale?" is now a check rather
+  // than an assumption. This previously unlinked the lock unconditionally,
+  // which breaks a genuinely-live peer — the one case the old comment admitted
+  // it could not distinguish.
   if (!opened && isLockHeld(openErr)) {
     try {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const fs = require('fs');
       const lockPath = `${rvfPath}.lock`;
-      if (fs.existsSync(lockPath)) {
+      if (fs.existsSync(lockPath) && isLockHeldByLiveProcess(rvfPath)) {
+        console.warn(
+          `[RVF] ${rvfPath} is locked by a live process (pid ${readLockOwnerPid(rvfPath)}) — ` +
+            'not breaking the lock; degrading to SQLite for this run.',
+        );
+      } else if (fs.existsSync(lockPath)) {
         fs.unlinkSync(lockPath);
         console.warn(
           `[RVF] Removed stale lock file at ${lockPath} (prior process exited without closing). ` +
@@ -216,6 +231,17 @@ function openOrCreateRvf(
       }
       return reopened;
     } catch {
+      // Pass 4 (#563): open failed, create failed, re-open failed. The file is
+      // provably unusable — the signature of an export killed mid-write, which
+      // used to disable the RVF backend permanently. Quarantine it (unless a
+      // live process holds its lock) and rebuild the derived cache.
+      const quarantined = quarantineUnusableStore(
+        rvfPath,
+        createErr instanceof Error ? createErr.message : String(createErr),
+      );
+      if (quarantined) {
+        return createFn(rvfPath, dimensions);
+      }
       // Fall through with the more informative original error.
       throw createErr instanceof Error ? createErr : new Error(String(createErr));
     }

--- a/src/learning/pattern-store.ts
+++ b/src/learning/pattern-store.ts
@@ -14,7 +14,17 @@ import { findProjectRoot } from '../kernel/project-root.js';
 import type { Result } from '../shared/types/index.js';
 import { ok, err } from '../shared/types/index.js';
 import { RvfPatternStore } from './rvf-pattern-store.js';
-import { createRvfStore as _createRvfStore, isRvfNativeAvailable } from '../integrations/ruvector/rvf-native-adapter.js';
+import {
+  createRvfStore as _createRvfStore,
+  openRvfStore as _openRvfStore,
+  isRvfNativeAvailable,
+} from '../integrations/ruvector/rvf-native-adapter.js';
+// Issue #563: static imports — a require() of a source module resolves in the
+// esbuild bundle but throws under the test runner, which silently changed which
+// code path tests exercised. Neither module loads the native binding at import
+// time, so this costs nothing at startup.
+import { quarantineUnusableStore } from '../integrations/ruvector/rvf-store-integrity.js';
+import { getSharedRvfAdapter } from '../integrations/ruvector/shared-rvf-adapter.js';
 import { toErrorMessage, toError } from '../shared/error-utils.js';
 import {
   QEPattern,
@@ -1916,7 +1926,9 @@ export function createPatternStore(
         // deadlock on the native lock.
         let useSharedAdapter = false;
         try {
-          const { getSharedRvfAdapter } = require('../integrations/ruvector/shared-rvf-adapter.js');
+          // Statically imported (#563): this require() throws "Cannot find
+          // module" under the test runner, so every test silently took the
+          // fallback ladder below instead of this preferred path.
           const shared = getSharedRvfAdapter(rvfDir, mergedConfig.embeddingDimension);
           if (shared) {
             useSharedAdapter = true;
@@ -1940,10 +1952,12 @@ export function createPatternStore(
           // (Jordi #439 / RUFLO P020.)
           const store = new RvfPatternStore(
             (path: string, dim: number) => {
-              // eslint-disable-next-line @typescript-eslint/no-require-imports
-              const { openRvfStore } = require('../integrations/ruvector/rvf-native-adapter.js');
+              // Statically imported (#563): a require() here resolves in the
+              // esbuild bundle but throws "Cannot find module" under the test
+              // runner, so this ladder — including its corruption recovery —
+              // was unreachable from any test.
               const tryOpen = () => {
-                try { return openRvfStore(path); } catch { return null; }
+                try { return _openRvfStore(path); } catch { return null; }
               };
               let adapter = tryOpen();
               if (adapter) {
@@ -1960,6 +1974,14 @@ export function createPatternStore(
               } catch (createErr) {
                 adapter = tryOpen();
                 if (adapter && adapter.dimension() === dim) return adapter;
+                // Issue #563: open failed, create failed, re-open failed — the
+                // store is provably unusable (an export killed mid-write leaves
+                // exactly this). Without recovery, RvfPatternStore.initialize()
+                // logs "vector search is DISABLED" and stays that way for the
+                // life of the process.
+                if (quarantineUnusableStore(path, createErr instanceof Error ? createErr.message : String(createErr))) {
+                  return _createRvfStore(path, dim);
+                }
                 throw createErr;
               }
             },

--- a/tests/integration/rvf-corruption-recovery.integration.test.ts
+++ b/tests/integration/rvf-corruption-recovery.integration.test.ts
@@ -1,0 +1,376 @@
+/**
+ * RVF corruption reproduction + recovery (issue #563)
+ *
+ * Reproduces the reported failure end-to-end with real SQLite DBs, real .rvf
+ * files and a real SIGKILL:
+ *
+ *   The export used to delete the previous store and rebuild in place, so a
+ *   kill mid-export left a store that was created but never completed. It then
+ *   could neither be opened (`0x0106 ManifestNotFound`) nor created over
+ *   (`0x0303 FsyncFailed`, because the path exists) — so the RVF backend was
+ *   silently disabled on every subsequent run, permanently.
+ *
+ * Note on the issue's diagnosis: the `FLVR` bytes it reports inside the `.lock`
+ * are not leaked store bytes. `FLVR` is the *lock record's* own magic (the
+ * store's is `SFVR`), so that file is an ordinary stale lock. Measured against
+ * @ruvector/rvf-node 0.1.8, a valid *empty* store is also exactly 162 bytes —
+ * the size the issue reads as "truncated: header only". Recovery therefore
+ * cannot key on magic or size, and these tests assert the behaviour that
+ * actually matters: after an interrupted export, the store still opens.
+ *
+ * Skips gracefully when @ruvector/rvf-node is not installed.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { spawn } from 'child_process';
+import { existsSync, readFileSync, writeFileSync, statSync, rmSync, mkdtempSync, mkdirSync, readdirSync } from 'fs';
+import { join } from 'path';
+
+import { isRvfNativeAvailable, openRvfStore } from '../../src/integrations/ruvector/rvf-native-adapter.js';
+import { exportBrainToRvf } from '../../src/integrations/ruvector/brain-rvf-exporter.js';
+import {
+  quarantineUnusableStore,
+  isLockHeldByLiveProcess,
+  readLockOwnerPid,
+} from '../../src/integrations/ruvector/rvf-store-integrity.js';
+import { ensureAllBrainTables } from '../../src/integrations/ruvector/brain-table-ddl.js';
+
+const NATIVE_AVAILABLE = isRvfNativeAvailable();
+const describeNative = NATIVE_AVAILABLE ? describe : describe.skip;
+
+const dirs: string[] = [];
+
+/**
+ * Work dirs live under node_modules/.cache (gitignored) rather than os.tmpdir()
+ * because the SIGKILL child below must resolve `better-sqlite3` from the repo's
+ * node_modules — from /tmp it cannot.
+ */
+const CACHE_ROOT = join(process.cwd(), 'node_modules', '.cache');
+
+function workDir(): string {
+  mkdirSync(CACHE_ROOT, { recursive: true });
+  const d = mkdtempSync(join(CACHE_ROOT, 'rvf-563-'));
+  dirs.push(d);
+  return d;
+}
+
+/**
+ * A real memory.db with brain tables, patterns, and their embeddings. The
+ * embeddings matter: without ingested vectors the exporter never writes an
+ * `.idmap.json` sidecar, and the promote path for it would go untested.
+ */
+function seedDb(path: string, patternCount = 25): Database.Database {
+  const db = new Database(path);
+  ensureAllBrainTables(db);
+  const insertEmbedding = db.prepare(
+    `INSERT INTO qe_pattern_embeddings (pattern_id, embedding, dimension) VALUES (?, ?, ?)`,
+  );
+  const insert = db.prepare(
+    `INSERT INTO qe_patterns (id, pattern_type, qe_domain, domain, name, description, confidence)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  );
+  for (let i = 0; i < patternCount; i++) {
+    insert.run(
+      `pat-${i}`,
+      'unit',
+      'test-generation',
+      'test-generation',
+      `pattern ${i}`,
+      `pattern description ${i}`,
+      0.9,
+    );
+    // Deterministic 384-dim float32 vector — content is irrelevant, presence
+    // is what drives ingest → idmap.
+    const vec = Float32Array.from({ length: 384 }, (_, j) => ((i + j) % 17) / 17);
+    insertEmbedding.run(`pat-${i}`, Buffer.from(vec.buffer), 384);
+  }
+  return db;
+}
+
+afterEach(() => {
+  for (const d of dirs.splice(0)) {
+    try { rmSync(d, { recursive: true, force: true }); } catch { /* best-effort */ }
+  }
+});
+
+describeNative('RVF export atomicity under interruption (#563)', () => {
+  it('leaves the previous good store intact when the export is SIGKILLed mid-write', async () => {
+    const dir = workDir();
+    const dbPath = join(dir, 'memory.db');
+    const rvfPath = join(dir, 'brain.rvf');
+
+    // Arrange: a complete, good export we can compare against afterwards. The
+    // row count is load-bearing — it stretches the export to ~150ms so the
+    // kill below lands mid-write. At ~25 rows the export finishes in ~30ms and
+    // the child wins the race, which makes this test prove nothing.
+    const db = seedDb(dbPath, 4000);
+    exportBrainToRvf(db, { outputPath: rvfPath }, 'memory.db');
+    db.close();
+
+    expect(existsSync(rvfPath)).toBe(true);
+    const goodBytes = readFileSync(rvfPath);
+    const goodManifest = readFileSync(`${rvfPath}.manifest.json`, 'utf-8');
+
+    // Act: run a second export in a child and SIGKILL it while it runs. The
+    // child prints READY once the export is underway; we kill on that signal
+    // so the kill lands inside the export rather than before it.
+    // The child is CommonJS (.cts) on purpose: the native binding is loaded
+    // with require(), which resolves under tsx's CJS mode but silently reports
+    // "not available" from an ESM (.mjs/.ts) entry — which would make this
+    // test pass without ever running an export.
+    const script = join(dir, 'export-child.cts');
+    const exporterPath = join(process.cwd(), 'src/integrations/ruvector/brain-rvf-exporter.ts');
+    const adapterPath = join(process.cwd(), 'src/integrations/ruvector/rvf-native-adapter.ts');
+    writeFileSync(
+      script,
+      `
+      const Database = require('better-sqlite3');
+      const { exportBrainToRvf } = require(${JSON.stringify(exporterPath)});
+      const { isRvfNativeAvailable } = require(${JSON.stringify(adapterPath)});
+      const db = new Database(${JSON.stringify(dbPath)});
+      // Load the native binding before signalling: it is lazy, and the kill
+      // would otherwise land during the load, before the export writes at all.
+      isRvfNativeAvailable();
+      // writeSync, not process.stdout.write: stdout to a pipe is async, so a
+      // buffered write would only reach the parent after the *synchronous*
+      // export had already finished — and the kill would arrive too late.
+      require('fs').writeSync(1, 'READY\\n');
+      exportBrainToRvf(db, { outputPath: ${JSON.stringify(rvfPath)} }, 'memory.db');
+      process.stdout.write('DONE\\n');
+      `,
+      'utf-8',
+    );
+
+    // `tsx` re-execs node, so the process doing the export is a *grandchild*:
+    // killing the pid we spawned leaves the real writer running, and the test
+    // then races its own subject. detached:true puts the whole thing in its own
+    // process group so a negative-pid kill reaps the writer too.
+    const tsxBin = join(process.cwd(), 'node_modules', '.bin', 'tsx');
+    const { out, err } = await new Promise<{ out: string; err: string }>((resolve) => {
+      const child = spawn(tsxBin, [script], { cwd: process.cwd(), detached: true });
+      let out = '';
+      let err = '';
+      child.stdout.on('data', (chunk) => {
+        out += String(chunk);
+        if (out.includes('READY')) {
+          // 40ms into a ~150ms export: comfortably inside the write window at
+          // both ends. Too early and nothing has been written yet; too late
+          // and the export has already completed.
+          setTimeout(() => {
+            try { process.kill(-(child.pid as number), 'SIGKILL'); } catch { /* already gone */ }
+          }, 40);
+        }
+      });
+      child.stderr.on('data', (chunk) => { err += String(chunk); });
+      child.on('exit', () => resolve({ out, err }));
+    });
+
+    // Guard: the child must actually have reached the export. Without this a
+    // child that dies on startup would sail through every assertion below.
+    expect(out).toContain('READY');
+    expect(err).not.toContain('rvf-node is not available');
+
+    // Assert: whatever the child managed to do, the store on disk is still a
+    // complete, readable store — either the old one (killed before promote)
+    // or a fully promoted new one (won the race). Never a truncated pair.
+    expect(existsSync(rvfPath)).toBe(true);
+    const after = readFileSync(rvfPath);
+
+    if (!out.includes('DONE')) {
+      // Interrupted: the previous store must be byte-identical and its
+      // manifest untouched. The pre-fix code truncated the store to a
+      // 162-byte header here — exactly the artifact reported in #563.
+      expect(after.equals(goodBytes)).toBe(true);
+      expect(readFileSync(`${rvfPath}.manifest.json`, 'utf-8')).toBe(goodManifest);
+    }
+
+    // The decisive property: the surviving store still opens. Pre-fix, the kill
+    // left a created-but-never-completed store that threw ManifestNotFound here
+    // and could not be created over either — FsyncFailed forever.
+    const reopened = openRvfStore(rvfPath);
+    expect(reopened.dimension()).toBe(384);
+    reopened.close();
+
+    // A killed export strands a full-size tmp store; the next export must
+    // sweep it, or a project whose hook is killed daily leaks disk forever.
+    const debris = () => readdirSync(dir).filter((f) => f.includes('.rvf.tmp.'));
+    const db2 = seedDb(join(dir, 'sweep.db'), 5);
+    exportBrainToRvf(db2, { outputPath: rvfPath }, 'memory.db');
+    db2.close();
+    expect(debris()).toEqual([]);
+  }, 120_000);
+
+  it('cleans up its tmp store and preserves the previous one when the export throws', () => {
+    const dir = workDir();
+    const dbPath = join(dir, 'memory.db');
+    const rvfPath = join(dir, 'brain.rvf');
+
+    // Arrange: a good store, then a DB that fails partway through the export.
+    const db = seedDb(dbPath);
+    exportBrainToRvf(db, { outputPath: rvfPath }, 'memory.db');
+    const goodBytes = readFileSync(rvfPath);
+
+    let callCount = 0;
+    const failingDb = new Proxy(db, {
+      get(target, prop, receiver) {
+        if (prop === 'prepare') {
+          return (...args: unknown[]) => {
+            // Let the export get underway, then fail mid-build.
+            if (++callCount > 3) throw new Error('injected mid-export failure');
+            return (target.prepare as (...a: unknown[]) => unknown)(...args);
+          };
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    }) as Database.Database;
+
+    // Act + Assert: the failure surfaces (fail-loud, not silent).
+    expect(() => exportBrainToRvf(failingDb, { outputPath: rvfPath }, 'memory.db')).toThrow(
+      /injected mid-export failure/,
+    );
+
+    // The previous store survives untouched...
+    expect(readFileSync(rvfPath).equals(goodBytes)).toBe(true);
+    // ...still opens...
+    openRvfStore(rvfPath).close();
+    // ...and no tmp debris is left behind.
+    const tmpBase = `${rvfPath}.tmp.${process.pid}`;
+    for (const suffix of ['', '.idmap.json', '.manifest.json', '.lock']) {
+      expect(existsSync(`${tmpBase}${suffix}`)).toBe(false);
+    }
+
+    db.close();
+  }, 30_000);
+
+  it('produces a store byte-identical in structure to a from-scratch export', () => {
+    const dir = workDir();
+    const rvfPath = join(dir, 'brain.rvf');
+    const db = seedDb(join(dir, 'memory.db'));
+
+    // Exporting over an existing store must still fully replace it (the tmp
+    // path must not leak into the promoted result).
+    exportBrainToRvf(db, { outputPath: rvfPath }, 'memory.db');
+    const second = exportBrainToRvf(db, { outputPath: rvfPath }, 'memory.db');
+
+    expect(second.stats.patternCount).toBe(25);
+    expect(existsSync(`${rvfPath}.idmap.json`)).toBe(true);
+    expect(existsSync(`${rvfPath}.manifest.json`)).toBe(true);
+    // The promoted store is the real one, not a tmp left in place.
+    expect(statSync(rvfPath).size).toBeGreaterThan(1024);
+
+    db.close();
+  }, 30_000);
+});
+
+describeNative('Dual-writer recovery from an unusable store (#563)', () => {
+  it('rebuilds instead of silently disabling RVF for the whole run', async () => {
+    const dir = workDir();
+    const db = seedDb(join(dir, 'memory.db'), 5);
+    const rvfPath = join(dir, 'brain.rvf');
+
+    // Arrange: the reported artifacts — a 162-byte store left by an export that
+    // was killed before it completed (open → ManifestNotFound, create →
+    // FsyncFailed), plus its stale 104-byte lock from the dead process.
+    writeFileSync(rvfPath, Buffer.concat([Buffer.from('SFVR'), Buffer.alloc(158)]));
+    writeFileSync(`${rvfPath}.lock`, lockRecord(0x7ffffffe));
+    // Sanity-check the arrangement really is unusable, so this test cannot
+    // quietly stop reproducing the bug.
+    expect(() => openRvfStore(rvfPath)).toThrow();
+
+    // Act: this is what every `aqe status` / session start does.
+    const { RvfDualWriter } = await import('../../src/integrations/ruvector/rvf-dual-writer.js');
+    const writer = new RvfDualWriter(db, { rvfPath, mode: 'dual-write', dimensions: 384 });
+    await writer.initialize();
+
+    // Assert: RVF is live. Before the fix both opens threw FsyncFailed and the
+    // catch left rvf null — the silent, run-long backend disable in the report.
+    const status = writer.status();
+    expect(status.rvf).not.toBeNull();
+
+    // The unusable store was preserved rather than deleted...
+    expect(existsSync(`${rvfPath}.corrupt-${process.pid}`)).toBe(true);
+    // ...and a healthy, openable store now exists at the live path.
+    expect(existsSync(rvfPath)).toBe(true);
+
+    writer.close();
+    db.close();
+  }, 30_000);
+});
+
+/** Build a lock record: `FLVR` magic + owning pid as u32 LE at offset 4. */
+function lockRecord(pid: number): Buffer {
+  const buf = Buffer.alloc(104);
+  buf.write('FLVR', 0, 'latin1');
+  buf.writeUInt32LE(pid, 4);
+  return buf;
+}
+
+describe('Unusable-store quarantine (#563)', () => {
+  // Pure fs-level checks — no native binding needed.
+  it('quarantines an unusable store and clears its stale lock', () => {
+    const dir = workDir();
+    const rvfPath = join(dir, 'brain.rvf');
+    writeFileSync(rvfPath, Buffer.concat([Buffer.from('SFVR'), Buffer.alloc(158)]));
+    writeFileSync(`${rvfPath}.idmap.json`, '{"nextLabel":1,"entries":[]}');
+    // A stale lock: well-formed, but its owning process is long gone.
+    writeFileSync(`${rvfPath}.lock`, lockRecord(0x7ffffffe));
+
+    const quarantined = quarantineUnusableStore(rvfPath, 'test');
+
+    expect(quarantined).toBe(`${rvfPath}.corrupt-${process.pid}`);
+    // The live paths are clear, so the next create can succeed...
+    expect(existsSync(rvfPath)).toBe(false);
+    expect(existsSync(`${rvfPath}.lock`)).toBe(false);
+    // ...and the bytes are preserved for diagnosis rather than deleted.
+    expect(existsSync(quarantined as string)).toBe(true);
+    expect(existsSync(`${quarantined}.idmap.json`)).toBe(true);
+  });
+
+  it('refuses to quarantine a store whose lock is held by a live process', () => {
+    const dir = workDir();
+    const rvfPath = join(dir, 'brain.rvf');
+    writeFileSync(rvfPath, Buffer.concat([Buffer.from('SFVR'), Buffer.alloc(158)]));
+    // A lock owned by a process that certainly exists: this test runner's
+    // parent. Stealing a live peer's store is the one unrecoverable mistake
+    // this helper can make.
+    writeFileSync(`${rvfPath}.lock`, lockRecord(process.ppid));
+
+    expect(isLockHeldByLiveProcess(rvfPath)).toBe(true);
+    expect(quarantineUnusableStore(rvfPath, 'test')).toBeNull();
+    expect(existsSync(rvfPath)).toBe(true);
+    expect(existsSync(`${rvfPath}.lock`)).toBe(true);
+  });
+
+  it('reads the owning pid out of a lock record', () => {
+    const dir = workDir();
+    const rvfPath = join(dir, 'brain.rvf');
+    writeFileSync(`${rvfPath}.lock`, lockRecord(4242));
+
+    expect(readLockOwnerPid(rvfPath)).toBe(4242);
+  });
+
+  it('treats a file that is not a lock record as no lock at all', () => {
+    const dir = workDir();
+    const rvfPath = join(dir, 'brain.rvf');
+    writeFileSync(`${rvfPath}.lock`, Buffer.from('not a lock record'));
+
+    expect(readLockOwnerPid(rvfPath)).toBeNull();
+    expect(isLockHeldByLiveProcess(rvfPath)).toBe(false);
+  });
+
+  it('does nothing when there is no store to quarantine', () => {
+    const dir = workDir();
+    expect(quarantineUnusableStore(join(dir, 'absent.rvf'), 'test')).toBeNull();
+  });
+
+  it('treats the current process as not-a-peer so a self-owned lock is recoverable', () => {
+    const dir = workDir();
+    const rvfPath = join(dir, 'brain.rvf');
+    // Our own pid is alive by definition, but a lock we ourselves left behind
+    // must not block our own recovery.
+    writeFileSync(`${rvfPath}.lock`, lockRecord(process.pid));
+
+    expect(isLockHeldByLiveProcess(rvfPath)).toBe(false);
+  });
+});

--- a/tests/unit/kernel/kernel-llm-router.test.ts
+++ b/tests/unit/kernel/kernel-llm-router.test.ts
@@ -77,6 +77,10 @@ describe('Kernel ↔ LLM router wiring (ADR-043)', () => {
   it('does not build a router in auto mode when no provider is available', async () => {
     // Save and clear any provider keys from the host env so this test
     // is hermetic (the dev shell may have keys exported from .env).
+    // Keep this list in sync with the providers ProviderManager can detect —
+    // it silently went stale when ADR-123 added cognitum and claude-code, so
+    // the test failed for any developer holding a COGNITUM_API_KEY while
+    // still passing in CI, where none of these are set.
     const saved = {
       ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
       OPENAI_API_KEY: process.env.OPENAI_API_KEY,
@@ -84,6 +88,9 @@ describe('Kernel ↔ LLM router wiring (ADR-043)', () => {
       GEMINI_API_KEY: process.env.GEMINI_API_KEY,
       GOOGLE_AI_API_KEY: process.env.GOOGLE_AI_API_KEY,
       GOOGLE_API_KEY: process.env.GOOGLE_API_KEY,
+      COGNITUM_API_KEY: process.env.COGNITUM_API_KEY,
+      CLAUDE_API_KEY: process.env.CLAUDE_API_KEY,
+      ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
     };
     for (const k of Object.keys(saved)) delete process.env[k];
 
@@ -267,7 +274,8 @@ describe('Kernel ↔ LLM router wiring (ADR-043)', () => {
 
   describe('Init failure observability (Fix #7)', () => {
     it('publishes kernel.llm-router.init-no-provider event when enabled=true but no provider available', async () => {
-      // Hermetic: clear all provider keys
+      // Hermetic: clear all provider keys (see the note above — keep in sync
+      // with the providers ProviderManager can detect).
       const saved: Record<string, string | undefined> = {
         ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
         OPENAI_API_KEY: process.env.OPENAI_API_KEY,
@@ -275,6 +283,9 @@ describe('Kernel ↔ LLM router wiring (ADR-043)', () => {
         GEMINI_API_KEY: process.env.GEMINI_API_KEY,
         GOOGLE_AI_API_KEY: process.env.GOOGLE_AI_API_KEY,
         GOOGLE_API_KEY: process.env.GOOGLE_API_KEY,
+        COGNITUM_API_KEY: process.env.COGNITUM_API_KEY,
+        CLAUDE_API_KEY: process.env.CLAUDE_API_KEY,
+        ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
       };
       for (const k of Object.keys(saved)) delete process.env[k];
 

--- a/tests/unit/learning/pattern-store-rvf-recovery.test.ts
+++ b/tests/unit/learning/pattern-store-rvf-recovery.test.ts
@@ -1,0 +1,81 @@
+/**
+ * PatternStore RVF recovery from an unusable store (issue #563).
+ *
+ * `createPatternStore()` has its own open-or-create ladder, used when the
+ * shared adapter is unavailable. An export killed mid-write leaves a store that
+ * can neither be opened (0x0106 ManifestNotFound) nor created over (0x0303
+ * FsyncFailed); without recovery this ladder throws into a catch that logs
+ * "RVF store unavailable, using in-memory HNSW" and silently degrades — every
+ * run, forever.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { existsSync, writeFileSync, mkdirSync, mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+
+import { isRvfNativeAvailable } from '../../../src/integrations/ruvector/rvf-native-adapter.js';
+
+// Force the fallback ladder: the factory prefers the shared adapter singleton
+// and only reaches its own ladder when that yields nothing. This mock is
+// load-bearing — without it the factory takes the shared-adapter path, which
+// has its own separate recovery and would leave this ladder untested.
+vi.mock('../../../src/integrations/ruvector/shared-rvf-adapter.js', () => ({
+  getSharedRvfAdapter: () => null,
+  __setSharedRvfAdapterForTests: () => {},
+}));
+
+const describeNative = isRvfNativeAvailable() ? describe : describe.skip;
+
+const dirs: string[] = [];
+const CACHE_ROOT = join(process.cwd(), 'node_modules', '.cache');
+let originalRoot: string | undefined;
+
+beforeEach(() => {
+  originalRoot = process.env.AQE_PROJECT_ROOT;
+});
+
+afterEach(() => {
+  if (originalRoot === undefined) delete process.env.AQE_PROJECT_ROOT;
+  else process.env.AQE_PROJECT_ROOT = originalRoot;
+  for (const d of dirs.splice(0)) {
+    try { rmSync(d, { recursive: true, force: true }); } catch { /* best-effort */ }
+  }
+});
+
+function projectWithUnusableStore(): { root: string; rvfPath: string } {
+  mkdirSync(CACHE_ROOT, { recursive: true });
+  const root = mkdtempSync(join(CACHE_ROOT, 'ps-563-'));
+  dirs.push(root);
+  mkdirSync(join(root, '.agentic-qe'), { recursive: true });
+  const rvfPath = join(root, '.agentic-qe', 'patterns.rvf');
+  // A store created but never completed — the #563 artifact.
+  writeFileSync(rvfPath, Buffer.concat([Buffer.from('SFVR'), Buffer.alloc(158)]));
+  return { root, rvfPath };
+}
+
+describeNative('createPatternStore RVF recovery (#563)', () => {
+  it('quarantines an unusable patterns.rvf and rebuilds instead of degrading', async () => {
+    const { root, rvfPath } = projectWithUnusableStore();
+    process.env.AQE_PROJECT_ROOT = root;
+
+    const { createPatternStore } = await import('../../../src/learning/pattern-store.js');
+    const memory = { store: async () => {}, retrieve: async () => null } as never;
+
+    const store = createPatternStore(memory);
+    // The ladder is lazy — it only runs on initialize(), which is where the
+    // open/create/reopen against the unusable file actually happens.
+    await store.initialize();
+
+    // The unusable bytes are preserved, not deleted...
+    expect(existsSync(`${rvfPath}.corrupt-${process.pid}`)).toBe(true);
+    // ...a fresh store took its place...
+    expect(existsSync(rvfPath)).toBe(true);
+    // ...and vector search is live. Pre-fix, the ladder threw and left
+    // nativeAvailable false with vector search disabled for the process.
+    const stats = (await store.getStats()) as unknown as {
+      hnswStats: { nativeAvailable: boolean; rvfInitError?: string };
+    };
+    expect(stats.hnswStats.nativeAvailable).toBe(true);
+    expect(stats.hnswStats.rvfInitError).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a bug that could **silently switch off vector search — permanently** (#563). `aqe brain export` deleted the existing RVF store and rebuilt it in place, so any interruption (hook timeout, session teardown, SIGKILL) left a store created but never completed: it could neither be opened (`0x0106 ManifestNotFound`) nor created over (`0x0303 FsyncFailed`, path exists). Both paths failed on every later run and the failure was swallowed, so AQE kept running on SQLite without saying so. Only manual deletion recovered it.

Exports are now atomic (tmp + rename), and unusable stores are quarantined and rebuilt automatically — existing broken projects self-heal on the next run. Also ships #562 (flywheel receipts signed with the Cognitum platform identity), already merged to main.

Reported by @pacphi with an unusually good writeup. **His diagnosis was wrong in a way that matters** — see below.

## The reported signature is a red herring

The issue identifies corruption as "RVF store bytes inside the `.lock`" (`FLVR` magic) plus a "truncated 162-byte store", and proposes self-healing on that signature. Measured against `@ruvector/rvf-node` 0.1.8:

- **`FLVR` is the lock record's own magic** — the store's magic is `SFVR`. A 104-byte `FLVR` lock is an ordinary lock record, live or stale. Not leaked store bytes.
- **A valid, empty store is exactly 162 bytes** — identical to the "truncated" file.

Healing on either signal would quarantine healthy stores, including out from under live processes. Recovery therefore triggers only on proof — open **and** create both failing. The lock record does carry its owner pid (u32 LE at offset 4), which now guards recovery and also fixes a **pre-existing hazard**: stale-lock cleanup previously unlinked locks unconditionally, which could break a store a live peer was using.

## This repo was itself affected

The quarantine fired on this repository's real `.agentic-qe/patterns.rvf` during a test run: 32MB, unusable with `ManifestNotFound`, dated Jul 8 — **degraded for nine days with no visible symptom**. It was preserved and a working store rebuilt (66 vectors). Independent confirmation of the "silent disable" on a second machine.

## Verification

Publish gate (`npm-publish.yml`) — all five steps:

```
npm audit --audit-level=high --omit=dev  →  found 0 vulnerabilities (exit 0)
npm run typecheck                        →  exit 0
npm run build                            →  MCP bundle built successfully (v3.12.3)
npm run test:unit:fast                   →  Test Files 323 passed | 1 skipped (324)
                                            Tests 8298 passed | 6 skipped (8304)
npm run test:integration:fast            →  Test Files 7 passed (7)
                                            Tests 25 passed (25)
npm run test:regression                  →  Tests 8298 passed | 6 skipped (8304)
```

Artifact + fresh-project verification:

```
dist/cli/bundle.js 12595 | dist/index.js 5245 | dist/mcp/bundle.js 3810778
aqe init --auto        →  exit 0; creates .agentic-qe/ .claude/ CLAUDE.md .mcp.json
aqe --version          →  3.12.3
aqe status/health/learning stats/agent list  →  all initialize cleanly
isolated tarball install → aqe --version = 3.12.3, exit 0, 0 vulnerabilities
```

The fix is visible live in `aqe health` on a fresh project:
```
[RVF] Removed stale lock file at .../patterns.rvf.lock (prior process exited without closing). Retrying open.
```

Regression tests (all fail without the fix, verified by reverting each):
- Real SIGKILL mid-export: pre-fix truncates the store to **exactly 162 bytes + stale lock** — bit-for-bit the reported artifact. Post-fix the previous store is byte-identical and still opens.
- Fault-injected export failure: previous store preserved, no tmp debris.
- Recovery through each of the three open paths (dual-writer/`brain.rvf`, shared adapter/`patterns.rvf`, pattern-store ladder). The dual-writer test fails pre-fix with `expected null not to be null` — the exact reported symptom.

## Failure modes

- **The new test never ran in CI.** It was referenced by no script or workflow (`test:unit:fast` excludes `tests/integration/`; `test:integration:fast` is a hardcoded list). Now added to `test:integration:fast`, verified running in the gate. Without this the fix had zero regression protection.
- **Windows rename-over-open-file.** `renameSync` over a destination another process holds open can fail with `EPERM`/`EBUSY` on Windows. Not exercised — reporter and CI are POSIX. The failure mode is a failed export that surfaces loudly, not corruption: the previous store survives. Tracked in #563 if a Windows user reports it.
- **Pid reuse.** A recycled pid can make a dead owner's lock look alive, in which case we decline to recover and degrade to SQLite — the pre-fix behaviour, and the safe direction. The unsafe direction (stealing a live peer's store) is what the guard prevents.
- **Quarantined stores are kept, not deleted** (`<name>.rvf.corrupt-<pid>`), so a crash-loop leaves one file per pid. Keyed by pid rather than timestamp so a loop overwrites its own copy. Gitignored via `*.rvf.corrupt-*`.
- **`brain.rvf` is a dual-write target, not a pure cache.** "Rebuild from `memory.db`" loses any write that reached RVF but not SQLite. Quarantining rather than deleting is what makes that recoverable — the bytes are kept.
- **Not covered:** `@ruvector/rvf-node` 0.2.0 (repo pins `^0.1.7`) — the reporter suggests the lock behaviour may differ there. Out of scope; our export was unsafe regardless of the binding.

## Incidental fixes found while testing

- **Tests exercised a different code path than production.** Three `require()` calls of source modules resolve in the esbuild bundle but throw under the test runner, so `createPatternStore` silently took its fallback ladder in every test while production took the shared-adapter path. Converted to static imports; tests now run what users run.
- **`kernel-llm-router` hermeticity was stale.** Its "no provider available" tests clear six provider keys, a list that never grew when ADR-123 (v3.12.2) added cognitum/claude-code — so it failed for any developer holding `COGNITUM_API_KEY` while passing in CI. Fixed; 17/17 now pass with the key exported.

---

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.** "Unlikely" is not an acceptable substitute. If you wrote "I don't think this can happen but...", that sentence is a failure mode and needs a test or an issue link.

### Optional context

- Linked issues: #563, #562
- Trust tier change (if any): none
- Affects published API or CLI surface: no (internal storage behaviour only)
- Touches the init flow / `npm-publish.yml` / `tests/fixtures/init-corpus/`: no
  - If yes: did you run `./tests/fixtures/init-corpus/run-gate.sh` locally? not applicable

See [CHANGELOG](CHANGELOG.md) for details.