### PR TITLE
fix(aqe): make generation and execution evidence trustworthy

### DIFF
--- a/docs/implementation/adrs/ADR-074-loki-mode-adversarial-quality-gates.md
+++ b/docs/implementation/adrs/ADR-074-loki-mode-adversarial-quality-gates.md
@@ -3,8 +3,9 @@
 | Field | Value |
 |-------|-------|
 | **Decision ID** | ADR-074 |
-| **Status** | Accepted |
+| **Status** | Accepted — implementation drift repair in progress |
 | **Date** | 2026-03-04 |
+| **Updated** | 2026-07-28 |
 | **Author** | Architecture Team |
 | **Review Cadence** | 6 months |
 | **Relates To** | ADR-026 (Intelligent Model Routing), ADR-064 (Agent Teams Integration) |
@@ -122,6 +123,15 @@ enableComplexityComposition?: boolean; // default: true
 - Full test suite: 17,955 tests passing, 0 failures
 - Build clean (tsc + CLI + MCP bundles)
 - All features verified behind config flags with default-off behavior
+
+### 2026-07-28 implementation correction
+
+The generated-test gate was found to be advisory and regex-only: syntactically invalid JavaScript
+could receive `passed: true` and `score: 100`. This contradicts the accepted decision to prevent
+hollow tests from inflating quality metrics. The repair makes syntax validity, at least one real
+assertion mandatory before generated JavaScript/TypeScript can pass the structural gate. The CLI
+refuses gate-failed output. Real execution remains a downstream Test Execution responsibility until
+the staged execution-and-rollback path is implemented.
 
 ---
 

--- a/docs/implementation/adrs/ADR-077-compilation-validation-loop.md
+++ b/docs/implementation/adrs/ADR-077-compilation-validation-loop.md
@@ -3,8 +3,9 @@
 | Field | Value |
 |-------|-------|
 | **Decision ID** | ADR-077 |
-| **Status** | Accepted & Implemented |
+| **Status** | Accepted — partially implemented; dynamic-language validation repair in progress |
 | **Date** | 2026-03-04 |
+| **Updated** | 2026-07-28 |
 | **Author** | AQE Architecture Team |
 | **Review Cadence** | 6 months |
 
@@ -107,6 +108,7 @@ Use language-specific linters (ESLint, Clippy, golangci-lint) instead of full co
 | Status | Date | Notes |
 |--------|------|-------|
 | Proposed | 2026-03-04 | Initial creation as part of multi-language test generation initiative |
+| Accepted, partially implemented | 2026-07-28 | Reconciled contradictory header/history. Compiled-language checking exists, but the repair loop and JavaScript/TypeScript syntax-and-execution validation were not implemented. Dynamic generated tests now fail closed unless syntax and execution are proven. |
 
 ---
 

--- a/docs/implementation/adrs/ADR-113-evals-are-oracles.md
+++ b/docs/implementation/adrs/ADR-113-evals-are-oracles.md
@@ -3,8 +3,9 @@
 | Field | Value |
 |-------|-------|
 | **Decision ID** | ADR-113 |
-| **Status** | Accepted (2026-06-27) — implemented P0–P5 (38 tests green; durable-first proven to lift mutation score 0%→100% on a worked module). Follow-ups: reconcile 5 pre-existing assets/ drifts; wire live `aqe test generate` into oracle evals (CLI+MCP) |
+| **Status** | Accepted (2026-06-27) — P0–P5 implemented; live `aqe test generate` mechanical validation repair in progress |
 | **Date** | 2026-06-27 |
+| **Updated** | 2026-07-28 |
 | **Author** | AQE Core |
 | **Review Cadence** | 3 months |
 | **Supersedes** | — |
@@ -80,6 +81,14 @@ Oracle outcomes written to `memory.db` are append-only; back up and verify row c
 - **Positive:** evals certify real fault detection; generated suites survive reimplementation; quality verdicts reflect bug-catching power; end users get a regenerability score unique to AQE.
 - **Cost:** durable evals cost more to author; oracle runs are subprocess-heavy (sampled/nightly mitigation).
 - **Reversible:** keyword matching remains as a fallback; the gate is non-blocking until explicitly opted in.
+
+### 2026-07-28 live-generator correction
+
+The unfinished live-generator follow-up allowed invalid JavaScript to receive a passing structural
+score. The live generation boundary now requires syntax validity and real assertions before a
+structural pass, and the CLI refuses gate-failed output. Actual execution remains explicitly
+unproven until the staged Test Execution integration is built; mutation grading remains the deeper
+durability oracle.
 
 ## Status of work (38 tests green)
 

--- a/docs/implementation/adrs/ADR-119-two-gate-quality-verdicts.md
+++ b/docs/implementation/adrs/ADR-119-two-gate-quality-verdicts.md
@@ -3,8 +3,9 @@
 | Field | Value |
 |-------|-------|
 | **Decision ID** | ADR-119 |
-| **Status** | Accepted (2026-07-08) — `quality-verdict.ts` core (8 tests) + frontier `frontier-judge.ts` (preflight→inconclusive, injectable provider seam) + `quality-gate-runner.ts` (CLI/MCP parity) + `aqe quality-gate` CLI + `qe/quality/gate` MCP tool. Unit-tested; MCP protocol-level integration test deferred to CI. |
+| **Status** | Accepted (2026-07-08) — core implemented; live test-generation adoption repair in progress |
 | **Date** | 2026-07-07 |
+| **Updated** | 2026-07-28 |
 | **Author** | AQE Core |
 | **Review Cadence** | 3 months |
 | **Supersedes** | — |
@@ -86,6 +87,10 @@ One local/Haiku judgment, pass/fail.
 
 ### 1. Mechanical gate (reuse ADR-113)
 Tests that do not execute ⇒ `fail`. No judge is consulted until the mechanical gate is satisfied — an artifact whose tests didn't run is never "pass," regardless of judge opinion.
+
+At `aqe test generate`, syntax-invalid or assertion-free output cannot receive a passing structural
+result and the CLI cannot persist it. This is a prerequisite, not a claim that live generation already
+executes the candidate; staged execution remains a follow-up under ADR-113.
 
 ### 2. Spec gate — frontier judge vs pinned checklist
 The judge model is **always frontier-tier** (never the cheap writer lane — ADR-111 §"deterministic verification kernel stays uncheapened," extended here to the LLM-judge case). It scores the artifact against the ADR-117 pinned checklist (constant denominator). `requirement_coverage == 1.0` ⇒ candidate pass for that attempt.

--- a/docs/implementation/ddd/quality-assessment.md
+++ b/docs/implementation/ddd/quality-assessment.md
@@ -1,5 +1,9 @@
 # Quality Assessment Domain
 
+**Status**: Accepted — implementation alignment in progress
+**Date**: 2026-01-18
+**Updated**: 2026-07-28
+
 ## Bounded Context Overview
 
 **Domain**: Quality Assessment
@@ -15,6 +19,7 @@ The Quality Assessment domain evaluates software quality metrics, enforces quali
 | **Quality Gate** | Set of thresholds that must pass for release |
 | **Gate Check** | Individual threshold evaluation |
 | **Quality Score** | Aggregate quality rating (A-E) |
+| **Mechanical Gate** | Fail-closed proof that an artifact parsed and its tests actually executed |
 | **Deployment Advice** | AI recommendation for release decisions |
 | **Complexity Hotspot** | High-complexity code requiring attention |
 | **Technical Debt** | Accumulated quality issues requiring remediation |
@@ -36,6 +41,15 @@ interface GateResult {
   failedChecks: string[];
 }
 ```
+
+### Assessment invariants
+
+- Quality Assessment consumes measured execution/coverage evidence, never a missing result coerced to
+  zero or success.
+- The CLI gate reports only metrics present in canonical AgentDB evidence. It does not invent zero
+  security, debt, duplication, bug, or smell counts.
+- Non-execution is a failed mechanical gate or an explicit inconclusive result, never a passing score.
+- Structural heuristics may explain quality but cannot override syntax or execution failure.
 
 #### QualityReport (Aggregate Root)
 Comprehensive quality analysis with recommendations.
@@ -278,3 +292,5 @@ thresholds:
 
 - **ADR-051**: LLM-powered quality insights
 - **ADR-010**: Claims-based authorization for gate overrides
+- **ADR-113**: Execution and mutation oracles
+- **ADR-119**: Two-gate, three-valued quality verdicts

--- a/docs/implementation/ddd/test-execution.md
+++ b/docs/implementation/ddd/test-execution.md
@@ -1,5 +1,9 @@
 # Test Execution Domain
 
+**Status**: Accepted — implementation alignment in progress
+**Date**: 2026-01-18
+**Updated**: 2026-07-28
+
 ## Bounded Context Overview
 
 **Domain**: Test Execution
@@ -16,6 +20,7 @@ The Test Execution domain handles the actual running of tests, including paralle
 | **Flaky Test** | Test with inconsistent pass/fail results |
 | **Sharding** | Strategy for distributing tests across workers |
 | **Retry** | Re-execution of failed tests with backoff |
+| **Retry Confidence** | Saturating confidence value in the closed interval `[0, 1]` |
 | **Prioritization** | RL-based ordering of test execution |
 | **E2E Step** | Individual action in an end-to-end test |
 | **User Flow** | Recorded sequence of user interactions |
@@ -248,6 +253,19 @@ const RETRY_CONSTANTS = {
 };
 ```
 
+### Retry invariants
+
+- Vitest and Jest own their internal parallelism, so AQE sends each discovered suite as one runner
+  batch instead of starting one process per file.
+- Batch timeouts scale with the number of discovered files; retry filters use a test name only when
+  the runner reported an actual test name rather than a file-level failure.
+- Test execution does not force coverage flags; coverage collection is a separate measured command
+  so project coverage thresholds cannot turn passing tests into execution failures.
+- Retry confidence is always finite and within `[0, 1]`, regardless of failed-test batch size.
+- The consensus boundary remains strict; producers normalize their evidence instead of weakening
+  validation.
+- Large failure batches return execution results and retry diagnostics rather than crashing the CLI.
+
 ## E2E Step Types
 
 The domain supports rich E2E step definitions:
@@ -266,3 +284,4 @@ The domain supports rich E2E step definitions:
 
 - **ADR-051**: LLM-powered flaky test analysis
 - **ADR-047**: MinCut topology for distributed execution
+- **ADR-103**: Structured, validated confidence handoffs

--- a/docs/implementation/ddd/test-generation.md
+++ b/docs/implementation/ddd/test-generation.md
@@ -1,5 +1,9 @@
 # Test Generation Domain
 
+**Status**: Accepted — implementation alignment in progress
+**Date**: 2026-01-18
+**Updated**: 2026-07-28
+
 ## Bounded Context Overview
 
 **Domain**: Test Generation
@@ -20,6 +24,7 @@ The Test Generation domain is responsible for automatically generating high-qual
 | **Pattern** | Learned testing approach extracted from existing tests |
 | **Code Analysis** | AST-based extraction of functions and classes |
 | **Test Generator** | Strategy implementation for framework-specific test output |
+| **Mechanical Evidence** | Syntax and real-run evidence required before generated code is accepted |
 
 ## Domain Model
 
@@ -51,8 +56,19 @@ interface IGeneratedTest {
   type: TestType;               // unit | integration | e2e
   assertions: number;           // Number of assertions
   llmEnhanced?: boolean;        // Whether LLM improved the test
+  qualityGateResult?: TestQualityGateResult; // Present when the configured gate evaluated output
 }
 ```
+
+### Aggregate invariants
+
+- JavaScript/TypeScript generated code must parse before it can pass.
+- A generated test with zero assertions cannot pass.
+- Syntax-invalid or assertion-free output cannot pass the configured quality gate.
+- The CLI must not persist output whose configured quality gate failed.
+- Real execution remains the downstream Test Execution responsibility; until staged execution is
+  wired into live generation, the generator must not claim execution evidence.
+- Estimated coverage never substitutes for measured syntax, execution, or mutation evidence.
 
 ### Value Objects
 
@@ -201,3 +217,6 @@ const TEST_GENERATION_DEFAULTS = {
 
 - **ADR-051**: LLM-powered test enhancement
 - **ADR-001**: Integration with agentic-flow patterns
+- **ADR-074**: Adversarial generated-test quality gates
+- **ADR-113**: Evals are execution and mutation oracles
+- **ADR-119**: Mechanical evidence precedes quality verdicts

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "pg": "^8.17.2",
         "prime-radiant-advanced-wasm": "^0.1.3",
         "secure-json-parse": "^4.1.0",
+        "typescript": "^5.9.3",
         "uuid": "^14.0.0",
         "vibium": "^0.1.2",
         "web-tree-sitter": "~0.26.8",
@@ -59,7 +60,6 @@
         "glob": "^13.0.0",
         "msw": "^2.12.7",
         "tsx": "^4.21.0",
-        "typescript": "^5.9.3",
         "vitest": "^4.0.16"
       },
       "engines": {
@@ -11248,7 +11248,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -182,6 +182,7 @@
     "pg": "^8.17.2",
     "prime-radiant-advanced-wasm": "^0.1.3",
     "secure-json-parse": "^4.1.0",
+    "typescript": "^5.9.3",
     "uuid": "^14.0.0",
     "vibium": "^0.1.2",
     "web-tree-sitter": "~0.26.8",
@@ -258,7 +259,6 @@
     "glob": "^13.0.0",
     "msw": "^2.12.7",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3",
     "vitest": "^4.0.16"
   },
   "engines": {

--- a/src/cli/commands/quality.ts
+++ b/src/cli/commands/quality.ts
@@ -7,8 +7,61 @@
 
 import { Command } from 'commander';
 import chalk from 'chalk';
+import type { MemoryBackend } from '../../kernel/interfaces.js';
 import type { CLIContext } from '../handlers/interfaces.js';
 import { type OutputFormat, type QualityGateResult, writeOutput, toJSON, qualityGateToMarkdown } from '../utils/ci-output.js';
+
+export async function loadQualityEvidence(memory: MemoryBackend): Promise<{
+  coverage: number;
+  testsPassing: number;
+}> {
+  const coverage = await memory.get<{ line?: number }>('coverage:latest');
+  const tests = await memory.get<{ passed?: number; failed?: number; skipped?: number }>(
+    'test-run:latest',
+    { namespace: 'test-execution' }
+  );
+  if (!coverage || !tests) {
+    throw new Error(
+      'No measured quality evidence found in AgentDB. Run coverage and `aqe test execute` before `aqe quality --gate`.'
+    );
+  }
+  const total = (tests.passed ?? 0) + (tests.failed ?? 0) + (tests.skipped ?? 0);
+  if (!Number.isFinite(coverage.line) || total <= 0 || !Number.isFinite(tests.passed)) {
+    throw new Error('Measured quality evidence is malformed or incomplete.');
+  }
+  return {
+    coverage: coverage.line!,
+    testsPassing: ((tests.passed ?? 0) / total) * 100,
+  };
+}
+
+export function evaluateMeasuredQualityEvidence(measured: {
+  coverage: number;
+  testsPassing: number;
+}): QualityGateResult {
+  const checks = [
+    {
+      name: 'coverage',
+      passed: measured.coverage >= 80,
+      value: measured.coverage,
+      threshold: 80,
+    },
+    {
+      name: 'testsPassing',
+      passed: measured.testsPassing >= 95,
+      value: measured.testsPassing,
+      threshold: 95,
+    },
+  ];
+  return {
+    passed: checks.every(check => check.passed),
+    score: 'N/A',
+    checks,
+    recommendations: checks
+      .filter(check => !check.passed)
+      .map(check => `${check.name} is below its measured threshold.`),
+  };
+}
 
 export function createQualityCommand(
   context: CLIContext,
@@ -33,101 +86,32 @@ export function createQualityCommand(
             console.log(chalk.blue(`\n Running quality gate evaluation...\n`));
           }
 
-          const qualityAPI = await context.kernel!.getDomainAPIAsync!<{
-            evaluateGate(request: { gateName?: string; metrics?: Record<string, number>; thresholds?: Record<string, { min?: number; max?: number }> }): Promise<{ success: boolean; value?: unknown; error?: Error }>;
-          }>('quality-assessment');
+          const measured = await loadQualityEvidence(context.kernel!.memory);
+          const gateResult = evaluateMeasuredQualityEvidence(measured);
 
-          if (!qualityAPI) {
-            console.log(chalk.red('Quality assessment domain not available'));
-            await cleanupAndExit(1);
-          }
-
-          // Provide default metrics when user doesn't supply explicit values.
-          // The gate service requires metrics + thresholds to evaluate.
-          const defaultMetrics = {
-            coverage: 0,
-            testsPassing: 0,
-            criticalBugs: 0,
-            codeSmells: 0,
-            securityVulnerabilities: 0,
-            technicalDebt: 0,
-            duplications: 0,
-          };
-          const defaultThresholds = {
-            coverage: { min: 80 },
-            testsPassing: { min: 95 },
-            criticalBugs: { max: 0 },
-            codeSmells: { max: 20 },
-            securityVulnerabilities: { max: 0 },
-            technicalDebt: { max: 5 },
-            duplications: { max: 5 },
-          };
-          const result = await qualityAPI!.evaluateGate({
-            gateName: 'standard',
-            metrics: defaultMetrics,
-            thresholds: defaultThresholds,
-          });
-
-          if (result.success && result.value) {
-            const assessment = result.value as {
-              passed?: boolean;
-              score?: string;
-              grade?: string;
-              checks?: Array<{ name: string; passed: boolean; value: number | string; threshold: number | string }>;
-              recommendations?: string[];
-              meetsThreshold?: boolean;
-              summary?: { line: number; branch: number; function: number; statement: number };
-            };
-
-            const gateResult: QualityGateResult = {
-              passed: assessment.passed ?? assessment.meetsThreshold ?? true,
-              score: assessment.score ?? assessment.grade ?? 'N/A',
-              checks: assessment.checks || [],
-              recommendations: assessment.recommendations || [],
-            };
-
-            if (format === 'json') {
-              writeOutput(toJSON(gateResult), options.output);
-            } else if (format === 'markdown') {
-              writeOutput(qualityGateToMarkdown(gateResult), options.output);
-            } else {
-              // Text output
-              const statusIcon = gateResult.passed ? chalk.green('✓ PASSED') : chalk.red('✗ FAILED');
-              console.log(`  Quality Gate: ${statusIcon}`);
-              console.log(`  Score: ${chalk.cyan(gateResult.score)}\n`);
-
-              if (gateResult.checks.length > 0) {
-                console.log(chalk.cyan('  Checks:'));
-                for (const check of gateResult.checks) {
-                  const icon = check.passed ? chalk.green('✓') : chalk.red('✗');
-                  console.log(`    ${icon} ${check.name}: ${check.value} (threshold: ${check.threshold})`);
-                }
-              }
-
-              if (gateResult.recommendations && gateResult.recommendations.length > 0) {
-                console.log(chalk.cyan('\n  Recommendations:'));
-                for (const rec of gateResult.recommendations) {
-                  console.log(chalk.gray(`    - ${rec}`));
-                }
-              }
-              console.log('');
-            }
-
-            // Exit codes: 1 = gate failed, 2 = warning (score within 5% of threshold), 0 = passed
-            if (!gateResult.passed) {
-              await cleanupAndExit(1);
-            }
-            const scoreNum = parseFloat(String(gateResult.score));
-            if (!isNaN(scoreNum) && scoreNum < 100 && scoreNum >= 95) {
-              // Score is within 5% of perfect — warn
-              await cleanupAndExit(2);
-            }
-            await cleanupAndExit(0);
+          if (format === 'json') {
+            writeOutput(toJSON(gateResult), options.output);
+          } else if (format === 'markdown') {
+            writeOutput(qualityGateToMarkdown(gateResult), options.output);
           } else {
-            console.log(chalk.red(`Quality gate failed: ${result.error?.message || 'Unknown error'}`));
-            await cleanupAndExit(1);
+            const statusIcon = gateResult.passed ? chalk.green('✓ PASSED') : chalk.red('✗ FAILED');
+            console.log(`  Quality Gate: ${statusIcon}`);
+            console.log(`  Score: ${chalk.cyan(gateResult.score)}\n`);
+            console.log(chalk.cyan('  Checks:'));
+            for (const check of gateResult.checks) {
+              const icon = check.passed ? chalk.green('✓') : chalk.red('✗');
+              console.log(`    ${icon} ${check.name}: ${check.value} (threshold: ${check.threshold})`);
+            }
+            if (gateResult.recommendations && gateResult.recommendations.length > 0) {
+              console.log(chalk.cyan('\n  Recommendations:'));
+              for (const rec of gateResult.recommendations) {
+                console.log(chalk.gray(`    - ${rec}`));
+              }
+            }
+            console.log('');
           }
 
+          await cleanupAndExit(gateResult.passed ? 0 : 1);
         }
 
       } catch (error) {

--- a/src/cli/commands/test.ts
+++ b/src/cli/commands/test.ts
@@ -67,8 +67,23 @@ export function createTestCommand(
           });
 
           if (result.success && result.value) {
-            const generated = result.value as { tests: Array<{ name: string; sourceFile: string; testFile: string; testCode?: string; assertions: number }>; coverageEstimate: number; patternsUsed: string[] };
+            const generated = result.value as { tests: Array<{ name: string; sourceFile: string; testFile: string; testCode?: string; assertions: number; qualityGateResult?: { passed: boolean; score: number; issues?: Array<{ description?: string }> } }>; coverageEstimate: number; patternsUsed: string[] };
             const format = options.format as OutputFormat;
+            const rejected = generated.tests.filter(
+              test => test.qualityGateResult?.passed !== true
+            );
+            if (rejected.length > 0) {
+              const details = rejected.map(test => {
+                const issues = test.qualityGateResult?.issues
+                  ?.map(issue => issue.description)
+                  .filter(Boolean)
+                  .join('; ') || 'missing passing quality evidence';
+                return `${test.sourceFile}: ${issues}`;
+              });
+              console.error(chalk.red(`Generation rejected ${rejected.length} invalid or unvalidated test artifact(s):`));
+              for (const detail of details) console.error(chalk.red(`  - ${detail}`));
+              await cleanupAndExit(1);
+            }
 
             if (format === 'json') {
               writeOutput(toJSON(generated), options.output);
@@ -145,6 +160,14 @@ export function createTestCommand(
           if (result.success && result.value) {
             const run = result.value as TestRunSummary;
             const format = options.format as OutputFormat;
+            const total = run.passed + run.failed + run.skipped;
+            await context.kernel!.memory.set('test-run:latest', {
+              passed: run.passed,
+              failed: run.failed,
+              skipped: run.skipped,
+              duration: run.duration,
+              measuredAt: new Date().toISOString(),
+            }, { namespace: 'test-execution', persist: true });
 
             if (format === 'json') {
               writeOutput(toJSON(run), options.output);
@@ -154,7 +177,6 @@ export function createTestCommand(
               writeOutput(testRunToMarkdown(run), options.output);
             } else {
               // Default text output
-              const total = run.passed + run.failed + run.skipped;
               console.log(chalk.green(`Test run complete`));
               console.log(`\n  Results:`);
               console.log(`    Total: ${chalk.white(total)}`);
@@ -168,7 +190,6 @@ export function createTestCommand(
             if (run.failed > 0) {
               await cleanupAndExit(1);
             }
-            const total = run.passed + run.failed + run.skipped;
             if (total > 0 && run.skipped / total > 0.2) {
               await cleanupAndExit(2);
             }

--- a/src/domains/test-execution/coordinator.ts
+++ b/src/domains/test-execution/coordinator.ts
@@ -323,7 +323,9 @@ export class TestExecutionCoordinator
 
     const framework = this.detectFramework(testsToRun);
     const workers = request.workers ?? Math.min(4, Math.max(1, testsToRun.length));
-    const timeout = request.timeout ?? 60000;
+    // Batched runners own internal parallelism, so the timeout applies to the
+    // whole discovered suite rather than one file.
+    const timeout = request.timeout ?? Math.max(60000, testsToRun.length * 2000);
 
     // Use parallel execution by default (unless explicitly disabled)
     if (request.parallel !== false && testsToRun.length > 1) {
@@ -767,7 +769,7 @@ export class TestExecutionCoordinator
           maxRetries: request.maxRetries,
           backoffType: request.backoff ?? 'exponential',
         },
-        0.7 + (testsToRetry.length / 100) // Higher confidence for larger batches
+        Math.min(1, 0.7 + (testsToRetry.length / 100)) // Higher confidence for larger batches
       );
 
       if (!isStrategyVerified) {

--- a/src/domains/test-execution/services/retry-handler.ts
+++ b/src/domains/test-execution/services/retry-handler.ts
@@ -538,7 +538,7 @@ export class RetryHandlerService implements IRetryHandler {
       case 'vitest':
         // vitest run --reporter=json testFile -t "testName"
         { const vitestArgs = ['vitest', 'run', '--reporter=json', testFile];
-        if (testName) {
+        if (testName && testName !== testFile) {
           vitestArgs.push('-t', testName);
         }
         return { command: npx, args: vitestArgs }; }
@@ -546,7 +546,7 @@ export class RetryHandlerService implements IRetryHandler {
       case 'jest':
         // jest --json testFile -t "testName"
         { const jestArgs = ['jest', '--json', '--testPathPattern', testFile];
-        if (testName) {
+        if (testName && testName !== testFile) {
           jestArgs.push('-t', testName);
         }
         return { command: npx, args: jestArgs }; }
@@ -554,7 +554,7 @@ export class RetryHandlerService implements IRetryHandler {
       case 'mocha':
         // mocha --reporter json testFile --grep "testName"
         { const mochaArgs = ['mocha', '--reporter', 'json', testFile];
-        if (testName) {
+        if (testName && testName !== testFile) {
           mochaArgs.push('--grep', testName);
         }
         return { command: npx, args: mochaArgs }; }

--- a/src/domains/test-execution/services/test-executor.ts
+++ b/src/domains/test-execution/services/test-executor.ts
@@ -191,9 +191,11 @@ export class TestExecutorService implements ITestExecutionService {
       }
 
       const { workers, sharding = 'file', isolation = 'process' } = request;
+      const runnerOwnsParallelism = ['vitest', 'jest'].includes(request.framework.toLowerCase());
+      const processWorkers = runnerOwnsParallelism ? 1 : workers;
 
       // Shard tests across workers
-      const shards = this.shardTests(request.testFiles, workers, sharding);
+      const shards = this.shardTests(request.testFiles, processWorkers, sharding);
 
       // Execute shards in parallel
       const shardResults = await Promise.all(
@@ -232,7 +234,7 @@ export class TestExecutorService implements ITestExecutionService {
         endTime,
         duration,
         testsPerSecond: aggregated.total / (duration / 1000),
-        workers,
+        workers: processWorkers,
         memoryUsage: process.memoryUsage?.().heapUsed ?? 0,
       };
       this.runStats.set(runId, stats);
@@ -455,27 +457,35 @@ Provide:
     framework: string,
     timeout: number
   ): Promise<TestExecutionResult> {
+    return this.executeTestFiles([file], framework, timeout);
+  }
+
+  private async executeTestFiles(
+    files: string[],
+    framework: string,
+    timeout: number
+  ): Promise<TestExecutionResult> {
     // In simulation mode (for unit testing), use random behavior
     if (this.config.simulateForTesting) {
-      return this.simulateTestExecution(file);
+      return this.aggregateResults(files.map(file => this.simulateTestExecution(file)));
     }
 
     // Production mode: spawn actual test runner process
-    const result = await this.spawnTestRunner(file, framework, timeout);
+    const result = await this.spawnTestRunner(files, framework, timeout);
     if (result.success === false) {
       // Return as a failed test rather than throwing — allows other files to still run
       return {
-        total: 1,
+        total: files.length,
         passed: 0,
-        failed: 1,
+        failed: files.length,
         skipped: 0,
-        failedTests: [{
+        failedTests: files.map(file => ({
           testId: file,
           testName: file,
           file,
           error: result.error.message,
           duration: 0,
-        }],
+        })),
         coverage: this.aggregateCoverage([]),
       };
     }
@@ -486,17 +496,19 @@ Provide:
    * Spawn actual test runner process (vitest, jest, mocha)
    */
   private async spawnTestRunner(
-    file: string,
+    files: string[],
     framework: string,
     timeout: number
   ): Promise<Result<TestExecutionResult, Error>> {
     // Verify test file exists
-    if (!existsSync(file)) {
-      return err(new Error(`Test file not found: ${file}`));
+    const missingFile = files.find(file => !existsSync(file));
+    if (missingFile) {
+      return err(new Error(`Test file not found: ${missingFile}`));
     }
 
     // Build command based on framework
-    const { command, args } = this.buildTestCommand(file, framework);
+    const { command, args } = this.buildTestCommand(files, framework);
+    const fileLabel = files.join(', ');
 
     return new Promise((resolve) => {
       let stdout = '';
@@ -519,7 +531,7 @@ Provide:
       const timeoutId = setTimeout(() => {
         killed = true;
         proc.kill('SIGTERM');
-        resolve(err(new Error(`Test execution timed out after ${timeout}ms for file: ${file}`)));
+        resolve(err(new Error(`Test execution timed out after ${timeout}ms for files: ${fileLabel}`)));
       }, timeout);
 
       proc.stdout?.on('data', (data: Buffer) => {
@@ -538,7 +550,7 @@ Provide:
         }
 
         // Parse results based on framework
-        const parseResult = this.parseTestOutput(stdout, stderr, file, framework, code);
+        const parseResult = this.parseTestOutput(stdout, stderr, fileLabel, framework, code);
 
         // If no coverage in stdout JSON, try reading from disk
         // (vitest/jest write coverage to coverage/coverage-summary.json)
@@ -565,33 +577,34 @@ Provide:
   /**
    * Build test command based on framework
    */
-  private buildTestCommand(file: string, framework: string): { command: string; args: string[] } {
+  private buildTestCommand(
+    fileOrFiles: string | string[],
+    framework: string
+  ): { command: string; args: string[] } {
+    const files = Array.isArray(fileOrFiles) ? fileOrFiles : [fileOrFiles];
     switch (framework.toLowerCase()) {
       case 'vitest':
         return {
           command: 'npx',
-          args: ['vitest', 'run', file, '--reporter=json', '--no-color',
-            '--coverage', '--coverage.reporter=json'],
+          args: ['vitest', 'run', ...files, '--reporter=json', '--no-color'],
         };
       case 'jest':
         return {
           command: 'npx',
-          args: ['jest', file, '--json', '--no-colors', '--testLocationInResults',
-            '--coverage', '--coverageReporters=json'],
+          args: ['jest', ...files, '--json', '--no-colors', '--testLocationInResults'],
         };
       case 'mocha':
         // Note: mocha has no built-in coverage — requires external nyc/c8 wrapper.
         // Coverage data will be unavailable for mocha-based test runs.
         return {
           command: 'npx',
-          args: ['mocha', file, '--reporter=json'],
+          args: ['mocha', ...files, '--reporter=json'],
         };
       default:
         // Default to vitest
         return {
           command: 'npx',
-          args: ['vitest', 'run', file, '--reporter=json', '--no-color',
-            '--coverage', '--coverage.reporter=json'],
+          args: ['vitest', 'run', ...files, '--reporter=json', '--no-color'],
         };
     }
   }
@@ -981,13 +994,7 @@ Provide:
     _isolation: 'process' | 'worker' | 'none',
     request: ParallelExecutionRequest
   ): Promise<TestExecutionResult> {
-    const results = await Promise.all(
-      files.map(file =>
-        this.executeTestFile(file, request.framework, request.timeout ?? 30000)
-      )
-    );
-
-    return this.aggregateResults(results);
+    return this.executeTestFiles(files, request.framework, request.timeout ?? 30000);
   }
 
   private aggregateResults(results: TestExecutionResult[]): TestExecutionResult {

--- a/src/domains/test-generation/gates/test-quality-gate.ts
+++ b/src/domains/test-generation/gates/test-quality-gate.ts
@@ -8,14 +8,18 @@
  * 3. Empty test bodies - it('...', () => {}) with no assertions
  * 4. Mirrored assertions - expected values copy-pasted from source literals
  *
- * All detection is regex-based, no LLM calls.
+ * Detection is deterministic (TypeScript parser plus structural checks), with no LLM calls.
  */
+
+import ts from 'typescript';
 
 // ============================================================================
 // Types
 // ============================================================================
 
 export type TestQualityIssueType =
+  | 'syntax-error'
+  | 'no-assertions'
   | 'no-source-import'
   | 'tautological-assertion'
   | 'empty-test-body'
@@ -46,6 +50,92 @@ export interface TestQualityGateConfig {
   checkMirroredAssertions: boolean;
   /** Minimum score to pass (default: 60) */
   minPassScore: number;
+}
+
+function scriptKindFor(filePath: string): ts.ScriptKind {
+  if (/\.(?:jsx)$/i.test(filePath)) return ts.ScriptKind.JSX;
+  if (/\.(?:tsx)$/i.test(filePath)) return ts.ScriptKind.TSX;
+  if (/\.(?:js|mjs|cjs)$/i.test(filePath)) return ts.ScriptKind.JS;
+  return ts.ScriptKind.TS;
+}
+
+function isJavaScriptFamily(filePath: string): boolean {
+  return /\.(?:tsx?|jsx?|mjs|cjs|mts|cts)$/i.test(filePath);
+}
+
+function parseGeneratedTest(testCode: string, sourceFilePath: string): ts.SourceFile {
+  const extension = sourceFilePath.match(/\.(?:tsx?|jsx?|mjs|cjs|mts|cts)$/i)?.[0] ?? '.ts';
+  return ts.createSourceFile(
+    `generated.test${extension}`,
+    testCode,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKindFor(sourceFilePath),
+  );
+}
+
+/**
+ * Return parser errors for generated JavaScript/TypeScript.
+ * This is deliberately exported so generation can reject malformed LLM output
+ * before replacing a valid deterministic template.
+ */
+export function getGeneratedTestSyntaxIssues(
+  testCode: string,
+  sourceFilePath: string,
+): TestQualityIssue[] {
+  if (!isJavaScriptFamily(sourceFilePath)) return [];
+
+  const sourceFile = parseGeneratedTest(testCode, sourceFilePath);
+  const diagnostics = (
+    sourceFile as ts.SourceFile & { parseDiagnostics?: readonly ts.Diagnostic[] }
+  ).parseDiagnostics ?? [];
+
+  return diagnostics.map((diagnostic) => {
+    const position = sourceFile.getLineAndCharacterOfPosition(diagnostic.start ?? 0);
+    return {
+      type: 'syntax-error' as const,
+      severity: 'error' as const,
+      line: position.line + 1,
+      description: `Generated test has invalid syntax: ${ts.flattenDiagnosticMessageText(diagnostic.messageText, ' ')}`,
+      suggestion: 'Repair the generated test syntax before accepting or executing it.',
+    };
+  });
+}
+
+function hasExecutableAssertion(testCode: string, sourceFilePath: string): boolean {
+  if (!isJavaScriptFamily(sourceFilePath)) {
+    return /\b(?:assert\w*|expect)\s*(?:[.(])/i.test(testCode);
+  }
+
+  const sourceFile = parseGeneratedTest(testCode, sourceFilePath);
+  let found = false;
+
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (ts.isCallExpression(node)) {
+      const expression = node.expression;
+      if (ts.isIdentifier(expression)) {
+        found = expression.text === 'expect' || expression.text === 'assert';
+      } else if (ts.isPropertyAccessExpression(expression)) {
+        let root: ts.Expression = expression.expression;
+        while (ts.isPropertyAccessExpression(root)) root = root.expression;
+        if (ts.isIdentifier(root) && root.text === 'assert') {
+          found = true;
+        } else if (
+          ts.isIdentifier(root)
+          && root.text === 'expect'
+          && expression.name.text !== 'assertions'
+          && expression.name.text !== 'hasAssertions'
+        ) {
+          found = true;
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return found;
 }
 
 const DEFAULT_CONFIG: TestQualityGateConfig = {
@@ -80,7 +170,16 @@ export class TestQualityGate {
     sourceFilePath: string,
     sourceCode?: string
   ): TestQualityGateResult {
-    const issues: TestQualityIssue[] = [];
+    const issues: TestQualityIssue[] = getGeneratedTestSyntaxIssues(testCode, sourceFilePath);
+
+    if (!hasExecutableAssertion(testCode, sourceFilePath)) {
+      issues.push({
+        type: 'no-assertions',
+        severity: 'error',
+        description: 'Generated test contains no executable assertions.',
+        suggestion: 'Add at least one assertion that observes behavior from the source under test.',
+      });
+    }
 
     if (this.config.checkSourceImports) {
       issues.push(...this.detectMissingSourceImports(testCode, sourceFilePath));
@@ -98,8 +197,12 @@ export class TestQualityGate {
       issues.push(...this.detectMirroredAssertions(testCode, sourceCode));
     }
 
-    const score = this.calculateScore(issues);
-    const passed = score >= this.config.minPassScore;
+    const mechanicallyInvalid = issues.some(
+      issue => issue.type === 'syntax-error' || issue.type === 'no-assertions',
+    );
+    const hasError = issues.some(issue => issue.severity === 'error');
+    const score = mechanicallyInvalid ? 0 : this.calculateScore(issues);
+    const passed = !hasError && score >= this.config.minPassScore;
 
     return { passed, issues, score };
   }

--- a/src/domains/test-generation/generators/base-test-generator.ts
+++ b/src/domains/test-generation/generators/base-test-generator.ts
@@ -182,20 +182,6 @@ export abstract class BaseTestGenerator implements ITestGenerator {
               : `const action = () => ${fn.name}(${paramsWithUndefined});`,
             assertion: 'expect(action).toThrow();',
           });
-        } else {
-          // Function has no explicit throw — but may still crash on property access.
-          // Use try-catch pattern that accepts either behavior.
-          const undefinedCall = fn.isAsync
-            ? `await ${fn.name}(${paramsWithUndefined})`
-            : `${fn.name}(${paramsWithUndefined})`;
-          testCases.push({
-            description: `should handle undefined ${param.name}`,
-            type: 'edge-case',
-            action: fn.isAsync
-              ? `let threw = false;\n    try {\n      await ${fn.name}(${paramsWithUndefined});\n    } catch (e) {\n      threw = true;\n      expect(e).toBeInstanceOf(Error);\n    }`
-              : `let threw = false;\n    try {\n      ${fn.name}(${paramsWithUndefined});\n    } catch (e) {\n      threw = true;\n      expect(e).toBeInstanceOf(Error);\n    }`,
-            assertion: `expect(true).toBe(true); // function either handles undefined or throws TypeError`,
-          });
         }
       }
 

--- a/src/domains/test-generation/generators/jest-vitest-generator.ts
+++ b/src/domains/test-generation/generators/jest-vitest-generator.ts
@@ -242,15 +242,6 @@ ${importStatement}
           code += `\n    it('should handle invalid ${param.name}', ${asyncPrefix}() => {\n`;
           code += `      expect(() => instance.${method.name}(${paramsWithUndefined})).toThrow();\n`;
           code += `    });\n`;
-        } else {
-          // Use try-catch to handle both throwing (TypeError from property access) and non-throwing
-          code += `\n    it('should handle undefined ${param.name}', ${asyncPrefix}() => {\n`;
-          code += `      try {\n`;
-          code += `        ${method.isAsync ? 'await ' : ''}instance.${method.name}(${paramsWithUndefined});\n`;
-          code += `      } catch (e) {\n`;
-          code += `        expect(e).toBeInstanceOf(Error);\n`;
-          code += `      }\n`;
-          code += `    });\n`;
         }
       }
     }
@@ -265,10 +256,11 @@ ${importStatement}
   generateStubTests(context: TestGenerationContext): string {
     const { moduleName, importPath, testType, patterns, dependencies, similarCode } = context;
     const patternComment = this.generatePatternComment(patterns);
+    const moduleIdentifier = 'moduleUnderTest';
 
-    const basicOpsTest = this.generateBasicOpsTest(moduleName, patterns);
-    const edgeCaseTest = this.generateEdgeCaseTest(moduleName, patterns);
-    const errorHandlingTest = this.generateErrorHandlingTest(moduleName, patterns);
+    const basicOpsTest = this.generateBasicOpsTest(moduleIdentifier, patterns);
+    const edgeCaseTest = this.generateEdgeCaseTest(moduleIdentifier, patterns);
+    const errorHandlingTest = this.generateErrorHandlingTest(moduleIdentifier, patterns);
 
     // KG: Generate mock declarations for external (non-relative) dependencies only
     let mockDeclarations = '';
@@ -298,9 +290,9 @@ ${importStatement}
     if (dependencies && dependencies.imports.length > 0) {
       depTest += `\n    it('should interact with dependencies correctly', () => {\n`;
       depTest += `      // KG-informed: module depends on ${dependencies.imports.length} imports\n`;
-      depTest += `      const instance = typeof ${moduleName} === 'function'\n`;
-      depTest += `        ? new ${moduleName}()\n`;
-      depTest += `        : ${moduleName};\n`;
+      depTest += `      const instance = typeof ${moduleIdentifier} === 'function'\n`;
+      depTest += `        ? new ${moduleIdentifier}()\n`;
+      depTest += `        : ${moduleIdentifier};\n`;
       depTest += `      expect(instance).toBeDefined();\n`;
       depTest += `    });\n`;
     }
@@ -310,9 +302,9 @@ ${importStatement}
     if (dependencies && dependencies.importedBy.length > 0) {
       callerTest += `\n    it('should expose stable API for ${dependencies.importedBy.length} consumers', () => {\n`;
       callerTest += `      // KG-informed: used by ${dependencies.importedBy.slice(0, 3).join(', ')}\n`;
-      callerTest += `      const publicKeys = Object.keys(typeof ${moduleName} === 'function'\n`;
-      callerTest += `        ? ${moduleName}.prototype || {}\n`;
-      callerTest += `        : ${moduleName});\n`;
+      callerTest += `      const publicKeys = Object.keys(typeof ${moduleIdentifier} === 'function'\n`;
+      callerTest += `        ? ${moduleIdentifier}.prototype || {}\n`;
+      callerTest += `        : ${moduleIdentifier});\n`;
       callerTest += `      expect(publicKeys.length).toBeGreaterThan(0);\n`;
       callerTest += `    });\n`;
     }
@@ -321,12 +313,12 @@ ${importStatement}
     const stubMockImport = this.framework === 'vitest' ? ', vi' : ', jest';
 
     return `${patternComment}import { describe, it, expect, beforeEach${stubMockImport} } from '${stubImportSource}';
-import { ${moduleName} } from '${importPath}';
+import * as ${moduleIdentifier} from '${importPath}';
 ${mockDeclarations}
 describe('${moduleName}', () => {
 ${similarityComment}  describe('${testType} tests', () => {
     it('should be defined', () => {
-      expect(${moduleName}).toBeDefined();
+      expect(${moduleIdentifier}).toBeDefined();
     });
 
 ${basicOpsTest}

--- a/src/domains/test-generation/services/test-generator.ts
+++ b/src/domains/test-generation/services/test-generator.ts
@@ -51,6 +51,7 @@ import type { HybridRouter, ChatResponse } from '../../../shared/llm';
 import { toError } from '../../../shared/error-utils.js';
 import { safeJsonParse } from '../../../shared/safe-json.js';
 import { TestQualityGate } from '../gates/index.js';
+import { getGeneratedTestSyntaxIssues } from '../gates/test-quality-gate.js';
 import { EdgeCaseInjector } from '../pattern-injection/index.js';
 import { treeSitterRegistry } from '../../../shared/parsers/multi-language-parser.js';
 import { getLanguageFromExtension } from '../../../shared/types/test-frameworks.js';
@@ -227,6 +228,7 @@ export class TestGeneratorService implements ITestGenerationService {
     testCode: string,
     sourceCode: string,
     analysis: CodeAnalysis | null,
+    sourceFilePath: string,
     context?: TestGenerationContext
   ): Promise<{ code: string; enhanced: boolean }> {
     if (!this.llmRouter) return { code: testCode, enhanced: false };
@@ -305,6 +307,10 @@ Return ONLY the enhanced test code, no explanations.`,
         const codeMatch = enhancedCode.match(/```(?:typescript|javascript|ts|js)?\n?([\s\S]*?)```/);
         if (codeMatch) {
           enhancedCode = codeMatch[1].trim();
+        }
+        if (getGeneratedTestSyntaxIssues(enhancedCode, sourceFilePath).length > 0) {
+          logger.warn('LLM enhancement produced invalid syntax, using deterministic template');
+          return { code: testCode, enhanced: false };
         }
         // #567: only claim enhancement when the model actually returned code.
         // An empty/unusable response falls back to the template, and the caller
@@ -626,7 +632,13 @@ Return a JSON array of test suggestions, each with: { "name": "test name", "desc
     // report AI-enhanced output it did not produce.
     let llmEnhanced = false;
     if (this.isLLMEnhancementAvailable() && sourceContent) {
-      const result = await this.enhanceTestWithLLM(testCode, sourceContent, codeAnalysis, context);
+      const result = await this.enhanceTestWithLLM(
+        testCode,
+        sourceContent,
+        codeAnalysis,
+        sourceFile,
+        context,
+      );
       testCode = result.code;
       llmEnhanced = result.enhanced;
     }

--- a/tests/domains/test-generation/gates/test-quality-gate.test.ts
+++ b/tests/domains/test-generation/gates/test-quality-gate.test.ts
@@ -428,16 +428,15 @@ describe('TestQualityGate - configuration', () => {
     expect(mirroredIssues).toHaveLength(0);
   });
 
-  it('should use custom minPassScore', () => {
+  it('should never pass error-level issues even when minPassScore is lower', () => {
     const gate = new TestQualityGate({ minPassScore: 50, checkSourceImports: false });
-    // Two errors: score = 60 >= 50 => pass
     const testCode = `
       expect(true).toBe(true);
       expect(false).toBe(false);
     `;
     const result = gate.validate(testCode, 'source.ts');
-    // 2 errors = score 60, which is >= 50
-    expect(result.passed).toBe(true);
+    expect(result.score).toBe(60);
+    expect(result.passed).toBe(false);
   });
 });
 
@@ -462,9 +461,36 @@ describe('TestQualityGate - edge cases', () => {
       const y = 2;
     `;
     const result = gate.validate(testCode, 'source.ts');
-    // No assertions means no tautological or empty body issues
-    // (no it/test blocks to be empty)
-    expect(result.score).toBe(100);
+    expect(result.passed).toBe(false);
+    expect(result.score).toBe(0);
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({
+        type: 'no-assertions',
+        severity: 'error',
+      }),
+    );
+  });
+
+  it('should fail closed for syntax-invalid generated JavaScript', () => {
+    const gate = new TestQualityGate({ checkSourceImports: false });
+    const testCode = `
+      import { describe, it, expect } from 'vitest';
+      import { policy } from './policy.default.mjs';
+      describe('policy defaults', () => {
+        it('denies by default', () => {
+          expect(policy.defaultDeny).toBe(true);
+    `;
+
+    const result = gate.validate(testCode, 'src/policy.default.mjs');
+
+    expect(result.passed).toBe(false);
+    expect(result.score).toBe(0);
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({
+        type: 'syntax-error',
+        severity: 'error',
+      }),
+    );
   });
 
   it('should handle source code with no extractable literals', () => {

--- a/tests/unit/cli/quality-evidence.test.ts
+++ b/tests/unit/cli/quality-evidence.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+  evaluateMeasuredQualityEvidence,
+  loadQualityEvidence,
+} from '../../../src/cli/commands/quality.js';
+
+describe('quality command evidence loading', () => {
+  it('refuses to invent zero metrics when AgentDB has no measured evidence', async () => {
+    const memory = { get: async () => undefined };
+    await expect(loadQualityEvidence(memory as never)).rejects.toThrow(/no measured quality evidence/i);
+  });
+
+  it('loads measured coverage and test pass rate from canonical AgentDB keys', async () => {
+    const memory = {
+      get: async (key: string) => key === 'coverage:latest'
+        ? { line: 81.25 }
+        : { passed: 38, failed: 2, skipped: 0 },
+    };
+    const evidence = await loadQualityEvidence(memory as never);
+    expect(evidence.coverage).toBe(81.25);
+    expect(evidence.testsPassing).toBe(95);
+  });
+
+  it('reports only measured checks and does not invent security or debt zeros', () => {
+    const result = evaluateMeasuredQualityEvidence({
+      coverage: 81.25,
+      testsPassing: 95,
+    });
+
+    expect(result.passed).toBe(true);
+    expect(result.checks.map(check => check.name)).toEqual(['coverage', 'testsPassing']);
+    expect(result.checks).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'securityVulnerabilities' }),
+        expect.objectContaining({ name: 'technicalDebt' }),
+      ]),
+    );
+  });
+});

--- a/tests/unit/domains/test-execution/coordinator.test.ts
+++ b/tests/unit/domains/test-execution/coordinator.test.ts
@@ -239,6 +239,29 @@ describe('TestExecutionCoordinator', () => {
         expect(result.success).toBe(true);
       });
 
+      it('should scale the default batch timeout with discovered files', async () => {
+        const files = Array.from({ length: 31 }, (_, index) => `test-${index}.test.ts`);
+        const executeParallel = vi.spyOn(coordinator, 'executeParallel').mockResolvedValue({
+          success: true,
+          value: {
+            runId: 'scaled-timeout',
+            status: 'passed',
+            total: 31,
+            passed: 31,
+            failed: 0,
+            skipped: 0,
+            duration: 1,
+            failedTests: [],
+          },
+        });
+
+        await coordinator.runTests({ testFiles: files });
+
+        expect(executeParallel).toHaveBeenCalledWith(
+          expect.objectContaining({ timeout: 62000 }),
+        );
+      });
+
       it('should use sequential execution when parallel is false', async () => {
         const result = await coordinator.runTests({
           testFiles: ['test1.test.ts', 'test2.test.ts'],
@@ -348,6 +371,60 @@ describe('TestExecutionCoordinator', () => {
       if (!result.success) {
         expect(result.error.message).toContain('not found');
       }
+    });
+
+    it('should keep consensus confidence valid when retrying more than 30 failed tests', async () => {
+      const failedTests = Array.from({ length: 31 }, (_, index) => ({
+        testId: `test-${index}`,
+        testName: `failed test ${index}`,
+        file: 'large-suite.test.ts',
+        error: 'failed',
+        duration: 1,
+      }));
+
+      coordinator = new TestExecutionCoordinator(ctx.eventBus, ctx.memory, {
+        ...defaultConfig,
+        enableConsensus: true,
+      });
+      await coordinator.initialize();
+
+      vi.spyOn(coordinator['executor'], 'getResults').mockResolvedValue({
+        success: true,
+        value: {
+          runId: 'large-run',
+          status: 'failed',
+          total: failedTests.length,
+          passed: 0,
+          failed: failedTests.length,
+          skipped: 0,
+          duration: 1,
+          failedTests,
+        },
+      });
+      const requiresConsensus = vi
+        .spyOn(coordinator['consensusMixin'], 'requiresConsensus')
+        .mockReturnValue(false);
+      vi.spyOn(coordinator['retryHandler'], 'executeWithRetry').mockResolvedValue({
+        success: true,
+        value: {
+          originalFailed: failedTests.length,
+          retried: failedTests.length,
+          nowPassing: failedTests.length,
+          stillFailing: 0,
+          flakyDetected: [],
+        },
+      });
+
+      const result = await coordinator.retry({
+        runId: 'large-run',
+        failedTests: failedTests.map(test => test.testId),
+        maxRetries: 2,
+      });
+
+      expect(result.success).toBe(true);
+      expect(requiresConsensus).toHaveBeenCalledWith(
+        expect.objectContaining({ confidence: 1 })
+      );
     });
   });
 

--- a/tests/unit/domains/test-execution/test-executor-command.test.ts
+++ b/tests/unit/domains/test-execution/test-executor-command.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import { TestExecutorService } from '../../../../src/domains/test-execution/services/test-executor.js';
+import { RetryHandlerService } from '../../../../src/domains/test-execution/services/retry-handler.js';
+
+describe('TestExecutorService runner command', () => {
+  it('runs Vitest without per-file coverage thresholds contaminating test results', () => {
+    const executor = new TestExecutorService({ memory: {} as never });
+    const command = (
+      executor as unknown as {
+        buildTestCommand(file: string, framework: string): { command: string; args: string[] };
+      }
+    ).buildTestCommand('tests/unit/example.test.ts', 'vitest');
+
+    expect(command).toEqual({
+      command: 'npx',
+      args: [
+        'vitest',
+        'run',
+        'tests/unit/example.test.ts',
+        '--reporter=json',
+        '--no-color',
+      ],
+    });
+    expect(command.args).not.toContain('--coverage');
+  });
+
+  it('runs each worker shard as one bounded runner batch', async () => {
+    const executor = new TestExecutorService({ memory: {} as never });
+    const internals = executor as unknown as {
+      executeTestFiles(files: string[]): Promise<{
+        total: number;
+        passed: number;
+        failed: number;
+        skipped: number;
+        failedTests: [];
+      }>;
+      executeWorker(
+        files: string[],
+        workerIndex: number,
+        isolation: 'process',
+        request: { framework: string; timeout: number },
+      ): Promise<unknown>;
+    };
+    const batches: string[][] = [];
+    internals.executeTestFiles = async files => {
+      batches.push(files);
+      return { total: 3, passed: 3, failed: 0, skipped: 0, failedTests: [] };
+    };
+
+    await internals.executeWorker(
+      ['one.test.ts', 'two.test.ts', 'three.test.ts'],
+      0,
+      'process',
+      { framework: 'vitest', timeout: 1000 },
+    );
+
+    expect(batches).toEqual([['one.test.ts', 'two.test.ts', 'three.test.ts']]);
+  });
+
+  it('uses one outer process for Vitest because Vitest owns internal parallelism', async () => {
+    const executor = new TestExecutorService({
+      memory: { set: async () => undefined } as never,
+    });
+    const internals = executor as unknown as {
+      executeWorker(files: string[]): Promise<{
+        total: number;
+        passed: number;
+        failed: number;
+        skipped: number;
+        failedTests: [];
+      }>;
+    };
+    const batches: string[][] = [];
+    internals.executeWorker = async files => {
+      batches.push(files);
+      return { total: files.length, passed: files.length, failed: 0, skipped: 0, failedTests: [] };
+    };
+
+    await executor.executeParallel({
+      testFiles: ['one.test.ts', 'two.test.ts', 'three.test.ts'],
+      framework: 'vitest',
+      workers: 3,
+    });
+
+    expect(batches).toEqual([['one.test.ts', 'two.test.ts', 'three.test.ts']]);
+  });
+});
+
+describe('RetryHandlerService runner command', () => {
+  it('does not treat a file-level failure path as a Vitest test-name filter', () => {
+    const retryHandler = new RetryHandlerService({} as never);
+    const command = (
+      retryHandler as unknown as {
+        buildTestCommand(
+          runner: 'vitest',
+          file: string,
+          testName?: string,
+        ): { command: string; args: string[] };
+      }
+    ).buildTestCommand(
+      'vitest',
+      'tests/unit/example.test.ts',
+      'tests/unit/example.test.ts',
+    );
+
+    expect(command.args).toEqual([
+      'vitest',
+      'run',
+      '--reporter=json',
+      'tests/unit/example.test.ts',
+    ]);
+  });
+});

--- a/tests/unit/domains/test-generation/generators/framework-imports.test.ts
+++ b/tests/unit/domains/test-generation/generators/framework-imports.test.ts
@@ -90,4 +90,25 @@ describe('Framework-aware import generation (bug #2)', () => {
     expect(mainImport).toBe('@jest/globals');
     expect(stubImport).toBe('@jest/globals');
   });
+
+  it('uses a valid namespace identifier for dotted JavaScript module filenames', () => {
+    const code = new JestVitestGenerator('vitest').generateTests({
+      moduleName: 'policy.default.mjs',
+      importPath: './policy.default.mjs',
+      testType: 'unit',
+      patterns: [],
+      analysis: { functions: [], classes: [] },
+    });
+
+    expect(code).toContain("import * as moduleUnderTest from './policy.default.mjs';");
+    expect(code).not.toContain('import { policy.default.mjs }');
+    expect(code).toContain('expect(moduleUnderTest).toBeDefined()');
+  });
+
+  it('does not invent an undefined-input contract when the function has no validation', () => {
+    const code = new JestVitestGenerator('vitest').generateTests(makeContext());
+
+    expect(code).not.toContain('expect(true).toBe(true)');
+    expect(code).not.toContain('should handle undefined');
+  });
 });

--- a/tests/unit/domains/test-generation/test-generator-di.test.ts
+++ b/tests/unit/domains/test-generation/test-generator-di.test.ts
@@ -4,6 +4,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   TestGeneratorService,
   createTestGeneratorService,
@@ -260,6 +263,72 @@ describe('TestGeneratorService - Dependency Injection', () => {
 
       expect(result.success).toBe(true);
       expect(alternativeTDDGenerator.generateTDDTests).toHaveBeenCalled();
+    });
+  });
+
+  describe('LLM output validation', () => {
+    it('rejects syntax-invalid JavaScript enhancement and keeps the valid template', async () => {
+      const fixtureDir = mkdtempSync(join(tmpdir(), 'aqe-policy-default-'));
+      const sourceFile = join(fixtureDir, 'policy.default.mjs');
+      writeFileSync(sourceFile, 'export const policy = { defaultDeny: true };');
+
+      const template = `
+        import { describe, it, expect } from 'vitest';
+        import { policy } from './policy.default.mjs';
+        describe('policy defaults', () => {
+          it('denies by default', () => {
+            expect(policy.defaultDeny).toBe(true);
+          });
+        });
+      `;
+      vi.mocked(mockGeneratorFactory.create).mockReturnValue({
+        framework: 'vitest',
+        generateTests: vi.fn().mockReturnValue(template),
+        generateFunctionTests: vi.fn(),
+        generateClassTests: vi.fn(),
+        generateStubTests: vi.fn(),
+        generateCoverageTests: vi.fn(),
+      });
+
+      const llmRouter = {
+        chat: vi.fn().mockResolvedValue({
+          content: `
+            import { describe, it, expect } from 'vitest';
+            import { policy } from './policy.default.mjs';
+            describe('policy defaults', () => {
+              it('denies by default', () => {
+                expect(policy.defaultDeny).toBe(true);
+          `,
+        }),
+      };
+      const service = createTestGeneratorServiceWithDependencies(
+        {
+          memory: mockMemory,
+          generatorFactory: mockGeneratorFactory,
+          llmRouter: llmRouter as never,
+        },
+        {
+          enableLLMEnhancement: true,
+          enableEdgeCaseInjection: false,
+        },
+      );
+
+      try {
+        const result = await service.generateTests({
+          sourceFiles: [sourceFile],
+          testType: 'unit',
+          framework: 'vitest',
+          language: 'javascript',
+        });
+
+        expect(result.success).toBe(true);
+        if (!result.success) return;
+        expect(result.value.tests[0].llmEnhanced).toBe(false);
+        expect(result.value.tests[0].testCode).toBe(template);
+        expect(result.value.tests[0].qualityGateResult?.passed).toBe(true);
+      } finally {
+        rmSync(fixtureDir, { recursive: true, force: true });
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

Makes AQE test generation, execution, retries, and quality evidence fail closed and report only measured results. Batches framework execution under the runner, clamps retry confidence, validates generated syntax/assertions, and persists test-run evidence in AgentDB.

## Verification

- `npm run test:unit:fast`: 330 files passed, 8,383 tests passed, 6 skipped, 0 failed.
- `npm run test:unit:heavy`: 243 files passed, 7,118 tests passed, 2 skipped, 0 failed.
- `npm run test:unit:mcp`: 45 files passed, 1,362 tests passed, 2 skipped, 0 failed.
- Focused repair suite: 114/114 passed.
- `npm run typecheck`: passed.
- `npm run build`: passed.
- Clean packed-package consumer install: passed.
- Real RuvNet Brain execution: 151 test files, 2,381 tests total, 2,371 passed, 10 skipped, 0 failed in 77.167s.
- Full-repo `npm run lint` remains red on the upstream baseline with 385 errors. Scoped comparison confirmed all 7 lint errors in touched source files already exist identically in HEAD; this change introduces no new lint findings.

## Failure modes

- Invalid or assertion-free LLM output falls back to the deterministic template; covered by generator and quality-gate tests.
- Missing or malformed coverage/test evidence now fails closed; covered by quality-evidence tests.
- Large suites execute as one runner-owned batch with a scaled outer timeout; covered by executor command tests and the real 151-file run.
- Retry confidence is clamped to the valid range; covered by the 31-failure coordinator regression.

---

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.**

### Optional context

- Linked issues: none
- Trust tier change: none
- Affects published API or CLI surface: yes, test and quality CLI behavior
- Touches the init flow / npm-publish workflow / init corpus: no