### PR TITLE
chore(release): v3.13.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-qe",
-  "version": "3.13.1",
+  "version": "3.13.3",
   "description": "Agentic Quality Engineering — AI-powered QE platform with 60 specialized agents, 75+ skills, sublinear coverage analysis, ReasoningBank pattern learning, and deep MCP integration for Claude Code and 11 coding agent platforms",
   "author": {
     "name": "Agentic QE Team",

--- a/.claude/hooks/aqe-hook.cjs
+++ b/.claude/hooks/aqe-hook.cjs
@@ -137,11 +137,32 @@ try {
     // Suggesting `npm rebuild` there sends people down the wrong path (verified
     // 2026-07-08: better-sqlite3 loaded fine while this marker still fired).
     const nativeMismatch = /invalid ELF header|ERR_DLOPEN_FAILED|different Node\.js version/.test(hit);
+    // Only claim lock contention when the child ACTUALLY reported a lock error.
+    // "Failed to initialize UnifiedMemoryManager" also covers corruption, EACCES,
+    // ENOSPC and schema faults; asserting "a process is holding the DB" for those
+    // is the same over-confident guidance that cost six days, just pointing a new
+    // wrong way (codex review r2 #2).
+    const lockContention = /SQLITE_BUSY|SQLITE_LOCKED|database is locked/i.test(stderr);
     const fix = nativeMismatch
       ? '`npm rebuild better-sqlite3` (host/container native-binary mismatch).'
-      : 'lock contention — check for concurrent AQE processes holding memory.db '
-        + '(MCP server / daemon / other hooks) and WAL safety on bind mounts '
-        + '(AQE_DISABLE_WAL); NOT a native-binary rebuild.';
+      : !lockContention
+      ? 'persistence init failed for a reason that is NOT lock contention. Do not guess — '
+        + 'read the actual error above, then check: disk space (`df -h`), permissions on '
+        + '.agentic-qe/, and DB health (`sqlite3 .agentic-qe/memory.db "PRAGMA integrity_check;"` '
+        + '— note quick_check does NOT verify indexes).'
+      // 2026-07-23..29: this hint used to say "check for concurrent AQE processes
+      // (MCP server / daemon / other hooks)". Operators checked exactly those,
+      // found nothing, and capture stayed dead for SIX DAYS — because the holder
+      // was `npm exec agentic-qe@latest mcp` from the npx cache, which matches
+      // neither "aqe" nor the servers in .mcp.json. Never name a guessed culprit:
+      // give the command that finds the ACTUAL holder, whatever it is.
+      : 'a process is holding memory.db open (this blocks the journal_mode switch '
+        + 'that AQE_DISABLE_WAL requires). Do NOT guess which process — list them:\n'
+        + '  for p in /proc/[0-9]*; do for f in $p/fd/*; do readlink "$f" 2>/dev/null '
+        + '| grep -q memory.db && echo "$(basename $p) $(tr \'\\0\' \' \' < $p/cmdline)"; '
+        + 'done; done | sort -u\n'
+        + '  (stale `npm exec agentic-qe mcp` from the npx cache is a known culprit '
+        + 'and does NOT match a search for "aqe"). NOT a native-binary rebuild.';
     recordHookHealth(`[${ts()}] FATAL hook persistence failure `
       + `(cmd=${subcmd}): "${hit}". Learning is NOT being captured. `
       + `Fix: ${fix}\n`);

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -290,7 +290,7 @@
   "statusLine": {
     "type": "command",
     "command": "sh -c 'node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/statusline-v3.cjs\" 2>/dev/null || echo \"▊ Agentic QE v3\"'",
-    "refreshMs": 5000,
+    "refreshMs": 60000,
     "enabled": true
   },
   "permissions": {

--- a/.claude/skills/qe-court/SKILL.md
+++ b/.claude/skills/qe-court/SKILL.md
@@ -62,7 +62,7 @@ budget caps and cost receipts apply automatically.
 
 | Step | Default provider / tier | Why |
 |------|------------------------|-----|
-| **Defense** | `cognitum-low` or `claude-code` (may equal writer) | Cheap; states the case, never grades |
+| **Defense** | `claude-code` (default) or `cognitum-low` (may equal writer) | Cheap; states the case, never grades. Must differ in vendor from the jury |
 | Prosecutor — devils-advocate | `cognitum-mid` | Gap/assumption hunting |
 | Prosecutor — brutal-honesty | `claude-code` (Opus/Sonnet) | Rigor lens, different family from jury |
 | Prosecutor — sherlock | `cognitum-high` | Deductive/root-cause needs a strong model |
@@ -83,7 +83,14 @@ when you explicitly want to name several different models.
 **Enforced invariants** (defaults; do not weaken without reason):
 1. **≥2 distinct vendors** across the panel — Claude / Cognitum / GPT-via-Codex — not just tiers.
 2. **Jury provider ∉ {writer, defense}** — no model grades its own or its writer's output.
+   Vendor is compared **coarsely**: `cognitum-low` and `cognitum-high` are the same
+   vendor, so pairing them across defense and jury is a violation, not a diverse panel.
 3. All calls routed through `ProviderManager` → ADR-123 budget cap + receipts.
+
+Invariants 1–2 are machine-checked by `validateCourtConfig()` in `referee.ts`, which
+the court MUST call before seating a panel (see *How to run it*). The `options` block
+below binds directly to that check — `minDistinctVendors` and `writerIsNeverJuror` are
+read, not decorative.
 
 ## The protocol
 
@@ -150,7 +157,20 @@ composing existing agents/skills — there is no monolithic binary yet (a thin
 `aqe court` CLI wrapper is planned as ADR-124 Phase 1; the hosted `/v1/qe/verdict`
 is Phase 2). To run a court now:
 
-1. Read `config.json` for the panel + `routing` + `overturnDepth`.
+1. Read `config.json` for the panel + `routing` + `overturnDepth`, then **validate
+   the panel before seating it** — this step is not optional:
+
+   ```ts
+   import { validateCourtConfig } from 'src/skills/qe-court/referee';
+   const violations = validateCourtConfig(config);   // [] == valid
+   if (violations.length) throw new Error(`Cannot convene: ${violations.join(', ')}`);
+   ```
+
+   A non-empty result means the panel cannot render a trustworthy verdict
+   (colluding jury, too few vendors, no jury at all). **ABORT the court and tell
+   the user which invariant failed** — do not proceed with a degraded panel and
+   do not silently re-route around it. A court that convenes an invalid panel
+   produces exactly the false SHIP it exists to catch.
 2. Spawn the prosecutors **in one message, in parallel** (`Task`/`Agent`,
    `run_in_background: true`), each with its routed provider; run
    `codex exec review` for the cross-vendor lens via Bash.
@@ -172,7 +192,9 @@ Durable, attestable evidence — the "jury waiting for everything you ship."
 (`src/skills/qe-court/referee.ts`) and covered by an oracle suite
 (`tests/unit/skills/qe-court/referee.test.ts`) that the acceptance eval
 (`evals/qe-court.yaml`, command-eval mode) runs through the `aqe eval` CLI —
-6/6 green as of 2026-07-18. The keystone oracle: a seeded mutant a shallow panel
+15/15 green as of 2026-07-29. That suite now validates the **shipped `config.json`
+itself**, so a routing edit that seats a colluding panel fails in CI rather than in
+a user's court (issue #576). The keystone oracle: a seeded mutant a shallow panel
 rated SHIP is overturned to BLOCK when the overturn round is active, and MUST
 regress to SHIP at `overturnDepth: 0` — proving the mechanic carries its weight.
 Run it yourself: `aqe eval run --skill qe-court --model cognitum-low`.

--- a/.claude/skills/qe-court/config.json
+++ b/.claude/skills/qe-court/config.json
@@ -6,7 +6,7 @@
   "emitScore": false,
   "routing": {
     "_note": "provider ids: claude-code | cognitum-{low,mid,high} | openrouter | codex | claude | openai | gemini | ollama. Cognitum resolves multiple models behind its tiers; use openrouter when you want to name several distinct models for breadth.",
-    "defense": { "provider": "cognitum-low" },
+    "defense": { "provider": "claude-code" },
     "prosecutor.devils-advocate": { "provider": "cognitum-mid" },
     "prosecutor.brutal-honesty": { "provider": "claude-code", "model": "sonnet" },
     "prosecutor.sherlock": { "provider": "cognitum-high" },

--- a/.claude/skills/skills-manifest.json
+++ b/.claude/skills/skills-manifest.json
@@ -940,7 +940,7 @@
   },
   "metadata": {
     "generatedBy": "Agentic QE Fleet",
-    "fleetVersion": "3.13.2",
+    "fleetVersion": "3.13.3",
     "manifestVersion": "1.4.0",
     "lastUpdated": "2026-04-13T00:00:00.000Z",
     "contributors": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to the Agentic QE project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.13.3] - 2026-07-29
+
+Two independent quality-of-evidence fixes: learning capture could stop silently
+for days on a filesystem where WAL is disabled, and QE-Court shipped a default
+review panel that violated its own anti-collusion rule.
+
+### Fixed
+
+- **Learning capture no longer stops silently when `AQE_DISABLE_WAL` is set.**
+  With that flag on, AQE tried to switch the database journal mode on *every*
+  writable connection. That switch needs exclusive access, so any other process
+  holding the database open — a stray MCP server, for example — made the attempt
+  fail and take the whole persistence layer down with it. Hooks kept reporting
+  success while nothing was being recorded, which hid the outage for days.
+
+  AQE now only changes the journal mode when it is actually wrong (so normal
+  operation never needs the exclusive lock), refuses to write in a mode you have
+  declared unsafe rather than risking corruption, and — when something really is
+  holding the database — tells you the exact command that finds it instead of
+  guessing which process to blame.
+
+- **QE-Court's shipped default panel violated `writerIsNeverJuror`** ([#576]).
+  The bundled `config.json` seated the defense and the jury on two tiers of the
+  same vendor, which is exactly what the court's core anti-collusion rule
+  forbids — so a brand-new project got an invalid panel with no user action.
+  Worse, the rule could never have caught it: nothing turned the configured
+  routing into a panel, so validation never ran outside its own unit test, and
+  the config's `options` block was not wired to anything.
+
+  The default panel is now genuinely cross-vendor (and keeps the deeper-review
+  round on a different vendor from the jury, so escalation stays independent),
+  validation is a required step before a court convenes, the `options` block
+  actually takes effect, and the shipped config files are checked in CI so this
+  cannot regress unnoticed. Reported by @pacphi.
+
+### Changed
+
+- The bundled statusline refreshes every 60 seconds instead of every 5. It
+  reopened the learning database on every tick, adding constant pressure to the
+  same lock the fix above depends on.
+
+[#576]: https://github.com/proffesor-for-testing/agentic-qe/issues/576
+
 ## [3.13.2] - 2026-07-24
 
 Stops short-lived learning hooks from repeatedly producing

--- a/assets/skills/qe-court/SKILL.md
+++ b/assets/skills/qe-court/SKILL.md
@@ -62,7 +62,7 @@ budget caps and cost receipts apply automatically.
 
 | Step | Default provider / tier | Why |
 |------|------------------------|-----|
-| **Defense** | `cognitum-low` or `claude-code` (may equal writer) | Cheap; states the case, never grades |
+| **Defense** | `claude-code` (default) or `cognitum-low` (may equal writer) | Cheap; states the case, never grades. Must differ in vendor from the jury |
 | Prosecutor — devils-advocate | `cognitum-mid` | Gap/assumption hunting |
 | Prosecutor — brutal-honesty | `claude-code` (Opus/Sonnet) | Rigor lens, different family from jury |
 | Prosecutor — sherlock | `cognitum-high` | Deductive/root-cause needs a strong model |
@@ -83,7 +83,14 @@ when you explicitly want to name several different models.
 **Enforced invariants** (defaults; do not weaken without reason):
 1. **≥2 distinct vendors** across the panel — Claude / Cognitum / GPT-via-Codex — not just tiers.
 2. **Jury provider ∉ {writer, defense}** — no model grades its own or its writer's output.
+   Vendor is compared **coarsely**: `cognitum-low` and `cognitum-high` are the same
+   vendor, so pairing them across defense and jury is a violation, not a diverse panel.
 3. All calls routed through `ProviderManager` → ADR-123 budget cap + receipts.
+
+Invariants 1–2 are machine-checked by `validateCourtConfig()` in `referee.ts`, which
+the court MUST call before seating a panel (see *How to run it*). The `options` block
+below binds directly to that check — `minDistinctVendors` and `writerIsNeverJuror` are
+read, not decorative.
 
 ## The protocol
 
@@ -150,7 +157,20 @@ composing existing agents/skills — there is no monolithic binary yet (a thin
 `aqe court` CLI wrapper is planned as ADR-124 Phase 1; the hosted `/v1/qe/verdict`
 is Phase 2). To run a court now:
 
-1. Read `config.json` for the panel + `routing` + `overturnDepth`.
+1. Read `config.json` for the panel + `routing` + `overturnDepth`, then **validate
+   the panel before seating it** — this step is not optional:
+
+   ```ts
+   import { validateCourtConfig } from 'src/skills/qe-court/referee';
+   const violations = validateCourtConfig(config);   // [] == valid
+   if (violations.length) throw new Error(`Cannot convene: ${violations.join(', ')}`);
+   ```
+
+   A non-empty result means the panel cannot render a trustworthy verdict
+   (colluding jury, too few vendors, no jury at all). **ABORT the court and tell
+   the user which invariant failed** — do not proceed with a degraded panel and
+   do not silently re-route around it. A court that convenes an invalid panel
+   produces exactly the false SHIP it exists to catch.
 2. Spawn the prosecutors **in one message, in parallel** (`Task`/`Agent`,
    `run_in_background: true`), each with its routed provider; run
    `codex exec review` for the cross-vendor lens via Bash.
@@ -172,7 +192,9 @@ Durable, attestable evidence — the "jury waiting for everything you ship."
 (`src/skills/qe-court/referee.ts`) and covered by an oracle suite
 (`tests/unit/skills/qe-court/referee.test.ts`) that the acceptance eval
 (`evals/qe-court.yaml`, command-eval mode) runs through the `aqe eval` CLI —
-6/6 green as of 2026-07-18. The keystone oracle: a seeded mutant a shallow panel
+15/15 green as of 2026-07-29. That suite now validates the **shipped `config.json`
+itself**, so a routing edit that seats a colluding panel fails in CI rather than in
+a user's court (issue #576). The keystone oracle: a seeded mutant a shallow panel
 rated SHIP is overturned to BLOCK when the overturn round is active, and MUST
 regress to SHIP at `overturnDepth: 0` — proving the mechanic carries its weight.
 Run it yourself: `aqe eval run --skill qe-court --model cognitum-low`.

--- a/assets/skills/qe-court/config.json
+++ b/assets/skills/qe-court/config.json
@@ -6,7 +6,7 @@
   "emitScore": false,
   "routing": {
     "_note": "provider ids: claude-code | cognitum-{low,mid,high} | openrouter | codex | claude | openai | gemini | ollama. Cognitum resolves multiple models behind its tiers; use openrouter when you want to name several distinct models for breadth.",
-    "defense": { "provider": "cognitum-low" },
+    "defense": { "provider": "claude-code" },
     "prosecutor.devils-advocate": { "provider": "cognitum-mid" },
     "prosecutor.brutal-honesty": { "provider": "claude-code", "model": "sonnet" },
     "prosecutor.sherlock": { "provider": "cognitum-high" },

--- a/assets/skills/skills-manifest.json
+++ b/assets/skills/skills-manifest.json
@@ -940,7 +940,7 @@
   },
   "metadata": {
     "generatedBy": "Agentic QE Fleet",
-    "fleetVersion": "3.13.2",
+    "fleetVersion": "3.13.3",
     "manifestVersion": "1.4.0",
     "lastUpdated": "2026-04-13T00:00:00.000Z",
     "contributors": [

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -4,6 +4,7 @@ All Agentic QE release notes organized by version.
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| [v3.13.3](v3.13.3.md) | 2026-07-29 | Learning capture no longer stops silently under `AQE_DISABLE_WAL` (it now refuses to write in an unsafe journal mode and names what is holding the DB), and QE-Court's shipped panel no longer violates its own `writerIsNeverJuror` rule (#576). |
 | [v3.13.2](v3.13.2.md) | 2026-07-24 | Stops hook-driven `brain.rvf`/`patterns.rvf` corruption loops by closing native stores after every hook and protecting same-process live locks (#574). |
 | [v3.13.1](v3.13.1.md) | 2026-07-23 | Honesty release: coverage analysis no longer reports numbers it never measured (real `cargo llvm-cov` for Rust; uncollected metrics are `null`, not 0 or 100), `test_generate_enhanced` actually calls your LLM (#567), and a HIGH advisory no longer ships via an optional peer (#565). Adds on-disk per-agent LLM routing (#568) and Codex CLI QE skills. BREAKING: coverage metrics are now `number \| null`. |
 | [v3.13.0](v3.13.0.md) | 2026-07-18 | QE-Court: adversarial review where a change is prosecuted by independent cross-vendor AI reviewers and a SHIP verdict must survive an escalating deeper review — it reviewed this release and blocked it, catching 3 data-loss/crash bugs. Adds a Codex (GPT) provider, a significance gate for the flywheel, automatic memory.db recovery, per-agent cost tracking, and clears 4 HIGH CVEs from consumer installs (#565). |

--- a/docs/releases/v3.13.3.md
+++ b/docs/releases/v3.13.3.md
@@ -1,0 +1,90 @@
+# v3.13.3 Release Notes
+
+**Release Date:** 2026-07-29
+
+## Highlights
+
+Two fixes about evidence you can trust. Learning capture could stop recording
+for days without saying so on any project that sets `AQE_DISABLE_WAL`, and
+QE-Court shipped a default review panel that broke the court's own
+anti-collusion rule the moment it was created.
+
+## Fixed
+
+### Learning capture no longer stops silently under `AQE_DISABLE_WAL`
+
+`AQE_DISABLE_WAL=1` exists for filesystems where SQLite's WAL journal is unsafe
+— notably macOS Docker bind mounts, where it has corrupted the learning database
+before. With the flag set, AQE attempted to switch the journal mode on **every**
+writable connection.
+
+Changing a database's journal mode requires exclusive access. Any other process
+holding the database open makes that attempt fail, and the failure took the
+whole persistence layer down with it: the memory manager could not initialize,
+so nothing was recorded. The hooks kept returning success, so from the outside
+everything looked healthy while no learning was being captured at all. The
+condition could not clear on its own, because the switch can never succeed while
+any reader exists.
+
+What changed:
+
+- AQE reads the current journal mode first and only attempts a change when it is
+  actually wrong. Normal operation no longer needs the exclusive lock at all, so
+  the one-time migration is out of the everyday path.
+- Only genuine lock contention is treated as such. Other faults — I/O errors,
+  corruption, permissions — now surface as themselves instead of being
+  misreported as "something else is using the database".
+- If the journal mode cannot be changed, AQE **refuses to write** rather than
+  continuing in a mode you have declared unsafe. Availability is not worth
+  risking the database you enabled the flag to protect.
+- The change is verified after it is applied, so a silently ignored switch
+  cannot leave AQE writing in the unsafe mode believing it is safe.
+- The diagnostic now prints the exact command that lists whatever is holding the
+  database, instead of naming processes it guessed at. The previous guidance
+  pointed at the wrong ones, which is most of why this went unnoticed for days.
+
+The bundled statusline also now refreshes every 60 seconds rather than every 5.
+It reopened the learning database on every tick, adding constant pressure to the
+same lock.
+
+### QE-Court's shipped panel violated its own `writerIsNeverJuror` rule ([#576])
+
+The bundled `config.json` — the template copied into every project on first run
+— seated the defense on `cognitum-low` and the jury on `cognitum-high`. Those
+are different tiers of the **same vendor**, and QE-Court measures collusion by
+vendor, not tier. A brand-new project therefore got a panel that failed the
+court's central rule before anyone had touched it.
+
+The deeper problem was that the rule could not have caught it. Nothing converted
+the configured routing into a seated panel, so `validatePanel` was never reached
+outside its own unit test, and the `options` block in the config was not wired to
+the validator at all — a rule with no caller is not enforced.
+
+What changed:
+
+- The default panel is genuinely cross-vendor. We moved the **defense** rather
+  than the jury: the deeper reviewer already runs on `codex`, so re-seating the
+  jury there would have put the jury and the escalation round on one vendor and
+  weakened the overturn mechanic the court depends on.
+- `panelFromRouting()` and `validateCourtConfig()` connect the config to the
+  validator, and running the validation is now a required step before a court
+  convenes — an invalid panel stops the run instead of quietly seating.
+- The `options` block takes effect: `minDistinctVendors` and `writerIsNeverJuror`
+  are read rather than decorative.
+- A routing map with no jury is now reported as invalid instead of passing.
+- CI validates the **shipped config files themselves**, so a future routing edit
+  fails the build rather than a user's court.
+
+Reported by @pacphi.
+
+## Upgrade notes
+
+No action required. If you set `AQE_DISABLE_WAL=1` and another process is
+holding your learning database open, AQE will now refuse that connection with a
+message naming the command that finds the holder — previously it failed silently.
+
+If you have already customized `.claude/skills/qe-court/config.json`, your file
+is untouched; check that your `defense` and `jury` providers are on different
+vendors, as the court now enforces.
+
+[#576]: https://github.com/proffesor-for-testing/agentic-qe/issues/576

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentic-qe",
-  "version": "3.13.2",
+  "version": "3.13.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentic-qe",
-      "version": "3.13.2",
+      "version": "3.13.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-qe",
-  "version": "3.13.2",
+  "version": "3.13.3",
   "description": "Agentic Quality Engineering V3 - Domain-Driven Design Architecture with 13 Bounded Contexts, O(log n) coverage analysis, ReasoningBank learning, 60 specialized QE agents, mathematical Coherence verification, deep Claude Flow integration",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/shared/safe-db.ts
+++ b/src/shared/safe-db.ts
@@ -10,6 +10,7 @@
  */
 
 import Database, { type Database as DatabaseType } from 'better-sqlite3';
+import { basename } from 'node:path';
 import { attemptAutoRestore } from './db-recovery.js';
 
 export interface SafeDbOptions {
@@ -95,7 +96,70 @@ export function openDatabase(dbPath: string, opts?: SafeDbOptions): DatabaseType
     // Explicit opt-out of WAL for this environment. Readonly connections cannot
     // change journal_mode, so only apply to writable opens.
     if (!readonly) {
-      db.pragma(`journal_mode = ${journalOverride || 'DELETE'}`);
+      const desired = (journalOverride || 'DELETE').toUpperCase();
+      const current = String(db.pragma('journal_mode', { simple: true }) ?? '').toUpperCase();
+
+      // Only attempt the migration when the mode is actually wrong. Setting a
+      // journal_mode that is already in effect is a no-op that needs NO lock, so
+      // the steady state never races. Re-attempting it on every open (the old
+      // behavior) kept a one-time migration permanently in the hot path.
+      if (current !== desired) {
+        // Switching OUT of WAL needs an EXCLUSIVE lock, and busy_timeout does not
+        // help against a long-lived reader that keeps re-acquiring.
+        //
+        // 2026-07-23..29 postmortem: a stale `npm exec agentic-qe mcp` (npx cache,
+        // NOT the `aqe-mcp` in .mcp.json) held memory.db + -wal open for days, so
+        // this threw SQLITE_BUSY on every writable open and capture froze for six
+        // days. The old health-log hint sent us hunting the wrong processes — the
+        // culprit did not match a search for "aqe".
+        //
+        // We FAIL CLOSED here rather than writing anyway. AQE_DISABLE_WAL=1 is the
+        // operator declaring "WAL corrupts on this mount" (observed 2026-06-08 and
+        // 2026-07-07), so continuing to write in WAL would trade a loud outage for
+        // silent corruption. Availability is not worth that; the message below
+        // carries the exact command that finds the real holder.
+        try {
+          db.pragma(`journal_mode = ${desired}`);
+        } catch (err) {
+          const code = (err as NodeJS.ErrnoException)?.code;
+          db.close();
+          // Anything that is NOT lock contention (I/O error, corruption, readonly
+          // FS, bad mode string) must surface unchanged instead of being reported
+          // as a lock problem.
+          if (code !== 'SQLITE_BUSY' && code !== 'SQLITE_LOCKED') throw err;
+          // Name the ACTUAL database being opened — openDatabase serves many paths,
+          // so a hardcoded "memory.db" would send the operator hunting for a file
+          // that isn't the one that failed (codex review r2 #1).
+          const dbFile = basename(dbPath);
+          // Report the effective setting, not an assumed one: AQE_JOURNAL_MODE
+          // alone triggers this path without AQE_DISABLE_WAL ever being set (r2 #4).
+          const via =
+            process.env.AQE_DISABLE_WAL === '1'
+              ? 'AQE_DISABLE_WAL=1'
+              : `AQE_JOURNAL_MODE=${journalOverride}`;
+          throw new Error(
+            `[safe-db] cannot switch ${dbPath} from '${current}' to '${desired}' — ` +
+              `another process holds the database open. ${via} declares WAL unsafe on ` +
+              `this filesystem, so writing in '${current}' is NOT safe and this open is ` +
+              `refused. Find the holder with:\n` +
+              `  for p in /proc/[0-9]*; do for f in $p/fd/*; do ` +
+              `readlink "$f" 2>/dev/null | grep -q ${JSON.stringify(dbFile)} && ` +
+              `echo "$(basename $p) $(tr '\\0' ' ' < $p/cmdline)"; done; done | sort -u\n` +
+              `then stop it and retry. Original error: ${(err as Error).message}`
+          );
+        }
+
+        // Verify the switch actually took effect — a silently-ignored pragma would
+        // otherwise leave us writing in the unsafe mode believing we were safe.
+        const after = String(db.pragma('journal_mode', { simple: true }) ?? '').toUpperCase();
+        if (after !== desired) {
+          db.close();
+          throw new Error(
+            `[safe-db] journal_mode switch to '${desired}' silently did not take on ` +
+              `${dbPath} (still '${after}'). Refusing to write in an unsafe mode.`
+          );
+        }
+      }
     }
   } else if (walMode) {
     // WAL mode for writable connections prevents corruption from concurrent

--- a/src/skills/qe-court/referee.ts
+++ b/src/skills/qe-court/referee.ts
@@ -64,6 +64,19 @@ export function resolveVerdict(charges: Charge[], overturnDepth: number): Verdic
 export interface PanelPolicy {
   /** Minimum number of DISTINCT vendors on the panel (default 2). */
   minVendors?: number;
+  /**
+   * Spelling used by the shipped `config.json` `options` block. Accepted as a
+   * synonym for `minVendors` so the config's declared policy actually binds to
+   * the validator instead of silently doing nothing (issue #576).
+   */
+  minDistinctVendors?: number;
+  /**
+   * Enforce that the jury vendor differs from the writer/defense vendor.
+   * Defaults to TRUE. Setting it to `false` deliberately weakens the court's
+   * central anti-collusion rule — the option exists so `config.json` controls
+   * what it claims to control, not as an invitation to disable it.
+   */
+  writerIsNeverJuror?: boolean;
 }
 
 /**
@@ -71,9 +84,10 @@ export interface PanelPolicy {
  * Returns a list of violation codes (empty == valid).
  *   - 'writerIsNeverJuror' : the jury shares a vendor with the writer/defense.
  *   - 'vendor-diversity'   : fewer than `minVendors` distinct vendors seated.
+ *   - 'missing-jury'       : no jury seated, so no verdict can be rendered.
  */
 export function validatePanel(panel: PanelSeat[], policy: PanelPolicy = {}): string[] {
-  const minVendors = policy.minVendors ?? 2;
+  const minVendors = policy.minVendors ?? policy.minDistinctVendors ?? 2;
   const violations: string[] = [];
 
   const vendorsSeated = new Set(panel.map((s) => vendorOf(s.provider)));
@@ -81,13 +95,57 @@ export function validatePanel(panel: PanelSeat[], policy: PanelPolicy = {}): str
 
   const jury = panel.find((s) => s.role === 'jury');
   const writerLike = panel.filter((s) => s.role === 'writer' || s.role === 'defense');
-  if (jury) {
+  if (!jury) {
+    violations.push('missing-jury');
+  } else if (policy.writerIsNeverJuror !== false) {
     const juryVendor = vendorOf(jury.provider);
     if (writerLike.some((w) => vendorOf(w.provider) === juryVendor)) {
       violations.push('writerIsNeverJuror');
     }
   }
   return violations;
+}
+
+/** A `routing` entry in the skill's `config.json`: one seat, one provider. */
+export interface RoutingSeat {
+  provider?: string;
+  model?: string;
+}
+
+/** The `routing` map in `config.json`, keyed by role. `_`-prefixed keys are notes. */
+export type CourtRouting = Record<string, RoutingSeat | undefined>;
+
+/**
+ * Seat a panel from the skill's `config.json` `routing` map.
+ *
+ * This is the missing link that let a bad panel ship: the invariants were
+ * enforceable but nothing converted config → panel, so `validatePanel` was
+ * never reached outside its own unit test (issue #576). Meta keys (`_note`,
+ * `_description`, …) and provider-less entries are skipped, never seated.
+ */
+export function panelFromRouting(routing: CourtRouting): PanelSeat[] {
+  return Object.entries(routing ?? {})
+    .filter(([role]) => !role.startsWith('_'))
+    .filter(([, seat]) => typeof seat?.provider === 'string' && seat.provider.length > 0)
+    .map(([role, seat]) => ({ role, provider: seat!.provider! }));
+}
+
+/** The subset of the skill's `config.json` the referee needs to rule on a panel. */
+export interface CourtConfig {
+  routing?: CourtRouting;
+  options?: PanelPolicy;
+}
+
+/**
+ * Validate a whole `config.json` — seat the panel from `routing`, then apply
+ * `options` as the policy. Returns violation codes (empty == valid).
+ *
+ * The court MUST call this before convening; a non-empty result means the panel
+ * cannot render a trustworthy verdict and the run should abort rather than seat
+ * a colluding panel.
+ */
+export function validateCourtConfig(config: CourtConfig): string[] {
+  return validatePanel(panelFromRouting(config.routing ?? {}), config.options ?? {});
 }
 
 /**

--- a/tests/unit/shared/safe-db-waloverride.test.ts
+++ b/tests/unit/shared/safe-db-waloverride.test.ts
@@ -10,6 +10,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
 import { openDatabase } from '../../../src/shared/safe-db.js';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -59,5 +60,142 @@ describe('openDatabase — WAL env override (ADR/bind-mount fix)', () => {
   it('should_ignore_unrelated_AQE_JOURNAL_MODE_and_keep_wal', () => {
     process.env.AQE_JOURNAL_MODE = 'nonsense';
     expect(journalModeOf()).toBe('wal');
+  });
+
+  /**
+   * THE SIX-DAY-OUTAGE REGRESSION (2026-07-23 .. 2026-07-29).
+   *
+   * A WAL->DELETE switch needs an EXCLUSIVE lock, and busy_timeout does not help
+   * against a long-lived reader. A stale `npm exec agentic-qe mcp` (npx cache, NOT
+   * the `aqe-mcp` in .mcp.json) held memory.db + -wal open for days, so the pragma
+   * threw SQLITE_BUSY on every writable open and capture froze for six days.
+   *
+   * The fix is NOT "swallow the error and write anyway": AQE_DISABLE_WAL=1 means
+   * the operator has declared WAL unsafe on this mount, so writing in WAL would
+   * trade a loud outage for silent corruption. We fail closed, with a message that
+   * names the real holder-finding command.
+   */
+  function seedWalDbWithBlocker() {
+    const seed = openDatabase(dbPath);
+    seed.exec('CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)');
+    seed.exec("INSERT INTO t (v) VALUES ('x')");
+    expect((seed.pragma('journal_mode', { simple: true }) as string).toLowerCase()).toBe('wal');
+    const blocker = openDatabase(dbPath);
+    blocker.exec('BEGIN');
+    blocker.prepare('SELECT COUNT(*) AS c FROM t').get();
+    return { seed, blocker };
+  }
+
+  it('should_fail_closed_when_journal_switch_is_blocked_by_another_reader', () => {
+    const { seed, blocker } = seedWalDbWithBlocker();
+    process.env.AQE_DISABLE_WAL = '1';
+
+    // Refuses the open rather than writing in the mode declared unsafe.
+    expect(() => openDatabase(dbPath, { busyTimeout: 200 })).toThrow(/another process holds the database open/);
+
+    blocker.exec('ROLLBACK');
+    blocker.close();
+    seed.close();
+  });
+
+  it('should_name_the_holder_finding_command_in_the_error', () => {
+    const { seed, blocker } = seedWalDbWithBlocker();
+    process.env.AQE_DISABLE_WAL = '1';
+
+    // The 2026-07 outage ran six days because the guidance pointed at the wrong
+    // processes. The error must carry a command that finds ANY holder.
+    expect(() => openDatabase(dbPath, { busyTimeout: 200 })).toThrow(/\/proc\/\[0-9\]\*/);
+
+    blocker.exec('ROLLBACK');
+    blocker.close();
+    seed.close();
+  });
+
+  it('should_reference_the_actual_db_file_not_a_hardcoded_memory_db', () => {
+    // codex review r2 #1: openDatabase serves many paths. A hardcoded "memory.db"
+    // in the diagnostic sends the operator hunting for the wrong file.
+    const { seed, blocker } = seedWalDbWithBlocker();
+    process.env.AQE_DISABLE_WAL = '1';
+
+    expect(() => openDatabase(dbPath, { busyTimeout: 200 })).toThrow(/test\.db/);
+    expect(() => openDatabase(dbPath, { busyTimeout: 200 })).not.toThrow(/grep -q "memory\.db"/);
+
+    blocker.exec('ROLLBACK');
+    blocker.close();
+    seed.close();
+  });
+
+  it('should_report_the_effective_setting_when_only_AQE_JOURNAL_MODE_is_set', () => {
+    // codex review r2 #4: claiming "AQE_DISABLE_WAL is set" is false when the
+    // TRUNCATE path was reached via AQE_JOURNAL_MODE alone.
+    const { seed, blocker } = seedWalDbWithBlocker();
+    process.env.AQE_JOURNAL_MODE = 'truncate';
+
+    expect(() => openDatabase(dbPath, { busyTimeout: 200 })).toThrow(/AQE_JOURNAL_MODE=TRUNCATE/);
+    expect(() => openDatabase(dbPath, { busyTimeout: 200 })).not.toThrow(/AQE_DISABLE_WAL=1/);
+
+    blocker.exec('ROLLBACK');
+    blocker.close();
+    seed.close();
+  });
+
+  it('should_rethrow_non_lock_errors_unchanged_instead_of_calling_them_contention', () => {
+    // codex review r2 #3: the narrow catch had no proof. Inject a NON-lock SQLite
+    // failure and assert the original error escapes untouched — misreporting an
+    // I/O or corruption fault as "another process holds the DB" is the exact
+    // wrong-diagnosis failure this whole incident was made of.
+    process.env.AQE_JOURNAL_MODE = 'truncate';
+    const seed = openDatabase(dbPath); // creates the file in WAL
+    seed.close();
+
+    const original = Object.getOwnPropertyDescriptor(Database.prototype, 'pragma')!;
+    const boom = Object.assign(new Error('disk I/O error'), { code: 'SQLITE_IOERR' });
+    let calls = 0;
+    Object.defineProperty(Database.prototype, 'pragma', {
+      ...original,
+      value(this: unknown, sql: string, o?: unknown) {
+        // Let busy_timeout + the current-mode read through; fail only the switch.
+        if (/journal_mode\s*=/i.test(sql) && ++calls === 1) throw boom;
+        return (original.value as (s: string, o?: unknown) => unknown).call(this, sql, o);
+      },
+    });
+    try {
+      expect(() => openDatabase(dbPath, { fileMustExist: true })).toThrow(boom);
+    } finally {
+      Object.defineProperty(Database.prototype, 'pragma', original);
+    }
+  });
+
+  it('should_not_attempt_a_switch_when_already_in_the_desired_mode', () => {
+    // Steady state must need NO exclusive lock: with the DB already in DELETE, a
+    // concurrent reader must not be able to block an open. This is what keeps the
+    // one-time migration out of the permanent hot path.
+    process.env.AQE_DISABLE_WAL = '1';
+    const first = openDatabase(dbPath);
+    first.exec('CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)');
+    expect((first.pragma('journal_mode', { simple: true }) as string).toLowerCase()).toBe('delete');
+
+    const reader = openDatabase(dbPath, { readonly: true });
+    reader.prepare('SELECT COUNT(*) AS c FROM t').get();
+
+    expect(() => openDatabase(dbPath, { busyTimeout: 200 }).close()).not.toThrow();
+
+    reader.close();
+    first.close();
+  });
+
+  it('should_actually_persist_writes_durably_across_reopen', () => {
+    // codex review #3: a SELECT proves readability, not persistence. Write, close,
+    // reopen from scratch, and verify the row survived AND the DB is still sound.
+    process.env.AQE_DISABLE_WAL = '1';
+    const w = openDatabase(dbPath);
+    w.exec('CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)');
+    w.prepare('INSERT INTO t (v) VALUES (?)').run('durable');
+    w.close();
+
+    const r = openDatabase(dbPath, { fileMustExist: true });
+    expect(r.prepare('SELECT v FROM t WHERE id = 1').get()).toEqual({ v: 'durable' });
+    expect(r.pragma('integrity_check', { simple: true })).toBe('ok');
+    r.close();
   });
 });

--- a/tests/unit/skills/qe-court/referee.test.ts
+++ b/tests/unit/skills/qe-court/referee.test.ts
@@ -7,12 +7,17 @@
  * mechanic that lets a mutant SHIP).
  */
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import {
   resolveVerdict,
   validatePanel,
+  validateCourtConfig,
+  panelFromRouting,
   shouldEmitScore,
   vendorOf,
   type Charge,
+  type CourtConfig,
   type PanelSeat,
 } from '../../../../src/skills/qe-court/referee';
 
@@ -87,5 +92,90 @@ describe('qe-court referee', () => {
     expect(vendorOf('cognitum-high')).toBe('cognitum');
     expect(vendorOf('codex')).toBe('gpt');
     expect(vendorOf('ollama')).toBe('local');
+  });
+
+  it('missing_jury__is_a_violation__no_jury_no_verdict', () => {
+    const juryless: PanelSeat[] = [
+      { role: 'defense', provider: 'claude-code' },
+      { role: 'prosecutor.codex-review', provider: 'codex' },
+    ];
+    expect(validatePanel(juryless)).toContain('missing-jury');
+  });
+
+  it('config_option_names_bind__minDistinctVendors_is_honored', () => {
+    // KILL CONDITION: config.json spells the policy `minDistinctVendors`, but
+    // PanelPolicy only accepted `minVendors` — so the shipped policy silently did
+    // nothing and only APPEARED to work because both defaulted to 2 (issue #576).
+    const twoVendors: PanelSeat[] = [
+      { role: 'defense', provider: 'claude-code' },  // claude
+      { role: 'jury', provider: 'cognitum-high' },   // cognitum
+    ];
+    expect(validatePanel(twoVendors, { minDistinctVendors: 2 })).not.toContain('vendor-diversity');
+    expect(validatePanel(twoVendors, { minDistinctVendors: 3 })).toContain('vendor-diversity');
+  });
+
+  it('writerIsNeverJuror_option_binds__false_disables_the_check', () => {
+    const colluding: PanelSeat[] = [
+      { role: 'defense', provider: 'cognitum-low' },
+      { role: 'jury', provider: 'cognitum-high' },
+      { role: 'prosecutor.codex-review', provider: 'codex' },
+    ];
+    // Default (and explicit true) enforce it; only an explicit false weakens it.
+    expect(validatePanel(colluding)).toContain('writerIsNeverJuror');
+    expect(validatePanel(colluding, { writerIsNeverJuror: true })).toContain('writerIsNeverJuror');
+    expect(validatePanel(colluding, { writerIsNeverJuror: false })).not.toContain('writerIsNeverJuror');
+  });
+
+  it('panelFromRouting__seats_roles_and_skips_meta_keys', () => {
+    const panel = panelFromRouting({
+      _note: undefined,
+      defense: { provider: 'claude-code' },
+      jury: { provider: 'cognitum-high' },
+      'prosecutor.broken': {},           // no provider → never seated
+    } as never);
+    expect(panel).toEqual([
+      { role: 'defense', provider: 'claude-code' },
+      { role: 'jury', provider: 'cognitum-high' },
+    ]);
+  });
+});
+
+/**
+ * THE REGRESSION GUARD for issue #576.
+ *
+ * The court's invariants were enforceable and unit-tested, but nothing ever ran
+ * them against the config we actually SHIP — so the default template violated
+ * `writerIsNeverJuror` from the moment it was copied into a user's project, with
+ * zero user action. These cases validate the real files on disk, so a future
+ * routing edit that re-breaks the panel fails here instead of in a user's court.
+ */
+describe('qe-court shipped config is a valid panel (issue #576)', () => {
+  const CONFIGS = {
+    'assets/skills/qe-court/config.json': resolve(__dirname, '../../../../assets/skills/qe-court/config.json'),
+    '.claude/skills/qe-court/config.json': resolve(__dirname, '../../../../.claude/skills/qe-court/config.json'),
+  };
+
+  for (const [label, path] of Object.entries(CONFIGS)) {
+    it(`${label}__seats_a_panel_with_no_violations`, () => {
+      const config = JSON.parse(readFileSync(path, 'utf8')) as CourtConfig;
+      expect(validateCourtConfig(config)).toEqual([]);
+    });
+  }
+
+  it('the_two_shipped_copies_do_not_drift', () => {
+    const [a, b] = Object.values(CONFIGS).map((p) => readFileSync(p, 'utf8'));
+    expect(a).toEqual(b);
+  });
+
+  it('shipped_panel_keeps_the_overturn_round_cross_vendor', () => {
+    // Not a validatePanel rule, but the reason we moved `defense` rather than
+    // `jury`: an escalation reviewed by the jury's own vendor is a weaker
+    // overturn round, which is the mechanic the whole court rests on.
+    const config = JSON.parse(
+      readFileSync(CONFIGS['assets/skills/qe-court/config.json'], 'utf8'),
+    ) as CourtConfig;
+    const seatOf = (role: string) =>
+      panelFromRouting(config.routing!).find((s) => s.role === role)!;
+    expect(vendorOf(seatOf('jury').provider)).not.toBe(vendorOf(seatOf('deeperReviewer').provider));
   });
 });


### PR DESCRIPTION
## Summary

Two independent quality-of-evidence fixes.

**Learning capture could stop silently for days.** On any project setting `AQE_DISABLE_WAL=1`, AQE tried to switch the SQLite journal mode on *every* writable connection. That switch needs exclusive access, so any other process holding the database open made it fail — and the failure took the whole persistence layer down. Hooks kept reporting `success: true` while nothing was recorded. It could not self-heal, because the switch can never succeed while a reader exists.

**QE-Court shipped a default panel that broke its own anti-collusion rule.** The bundled `config.json` seated defense and jury on two tiers of the same vendor, which `writerIsNeverJuror` forbids — so a new project got an invalid panel with zero user action. The rule could never have caught it: nothing converted the configured routing into a panel, so validation never ran outside its own unit test, and the config's `options` block was wired to nothing.

## Verification

```
npm run build       exit 0   (CLI + MCP bundles, v3.13.3)
npm run typecheck   exit 0
npx vitest run tests/unit/
                    Test Files  668 passed | 1 skipped (669)
                    Tests       17875 passed | 14 skipped (17889)
                    Duration    1051.17s
```

Artifacts:
```
dist/cli/bundle.js   12595 bytes
dist/index.js         5245 bytes
dist/mcp/bundle.js  3841658 bytes
node dist/cli/bundle.js --version  ->  3.13.3
```

Isolated consumer install (packed tarball into a clean prefix):
```
npm install ./agentic-qe-3.13.3.tgz   ->  found 0 vulnerabilities
node node_modules/.bin/aqe --version  ->  3.13.3   (exit 0)
typescript in consumer install        ->  ABSENT (lazy-loaded by design)
```

Live verification of the memory fix on a real database:
```
journal_mode = delete      integrity_check = ok
captured_experiences 21157 -> 21171   (had been frozen since 2026-07-23)
```

The qe-court regression guard is mutation-verified: restoring the previous
`defense` provider turns it red with `expected [ 'writerIsNeverJuror' ] to deeply equal []`.
The safe-db fail-closed path is likewise mutation-verified (removing the guard
fails with `SqliteError: database is locked`).

## Failure modes

- **Fail-closed refuses writes when the journal mode cannot be changed.** This is deliberate: `AQE_DISABLE_WAL=1` declares WAL unsafe on that filesystem, so continuing to write in WAL would trade a loud outage for silent corruption. The trade-off is that a stuck holder now blocks writes instead of degrading. Covered by `should_fail_closed_when_journal_switch_is_blocked_by_another_reader`, and the error names the command that finds the holder.
- **Non-lock failures must not be misreported as contention.** I/O errors, corruption and permission faults are rethrown unchanged. Covered by `should_rethrow_non_lock_errors_unchanged_instead_of_calling_them_contention`.
- **A silently-ignored pragma could leave AQE writing in the unsafe mode.** The switch is verified after it is applied and the open is refused on mismatch.
- **Not covered: power-loss durability.** The persistence test proves write -> close -> reopen -> `integrity_check`, not crash consistency. The word "durable" in that test name is stronger than its evidence.
- **Not covered: the virtiofs filesystem itself.** Tests run on ordinary local storage under `/tmp`, not the bind mount that motivates `AQE_DISABLE_WAL`. They prove the lock behaviour, not that any journal mode is safe on that mount.
- **Changed default for existing users:** anyone who customized `.claude/skills/qe-court/config.json` keeps their file; if their `defense` and `jury` share a vendor, the court will now refuse to convene rather than seating a colluding panel. This is the intended behaviour change and is documented in the release notes.

## Review provenance

The memory fix was reviewed adversarially by `codex exec` (cross-vendor). Its
first verdict was **FAIL** on an earlier revision that degraded instead of
failing closed — that finding was correct and the approach was reversed. Second
pass returned **CONDITIONAL**; its remaining findings (hardcoded db filename in
the diagnostic, over-confident hook guidance, missing error-path tests,
inaccurate env-var attribution) are all addressed in this branch.

---

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.** "Unlikely" is not an acceptable substitute. If you wrote "I don't think this can happen but...", that sentence is a failure mode and needs a test or an issue link.

### Optional context

- Linked issues: #576
- Trust tier change (if any): none
- Affects published API or CLI surface: no (behavioural change to database opening and to the bundled qe-court config)
- Touches the init flow / `npm-publish.yml` / `tests/fixtures/init-corpus/`: no

See [CHANGELOG](CHANGELOG.md) for details.
