### PR TITLE
chore(release): v3.13.6

### DIFF
--- a/.claude/skills/skills-manifest.json
+++ b/.claude/skills/skills-manifest.json
@@ -940,7 +940,7 @@
   },
   "metadata": {
     "generatedBy": "Agentic QE Fleet",
-    "fleetVersion": "3.13.4",
+    "fleetVersion": "3.13.6",
     "manifestVersion": "1.4.0",
     "lastUpdated": "2026-04-13T00:00:00.000Z",
     "contributors": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.13.6] - 2026-08-03
 
-Learning records and semantic search data now finish persisting reliably, while
-operators have a safe way to repair older patterns that are missing embeddings.
+Learning records and semantic search data now persist and resolve reliably,
+while operators have a safe way to repair older patterns that are missing
+embeddings.
 
 ### Added
 
@@ -18,6 +19,10 @@ operators have a safe way to repair older patterns that are missing embeddings.
 
 ### Fixed
 
+- **Namespaced semantic search returns the right memories** ([#601]). Logical
+  namespace filtering now happens while ANN candidates are gathered, so a
+  relevant scoped result is not hidden by higher-ranked vectors from unrelated
+  namespaces.
 - **Hook embeddings persist before exit** ([#581]). Short-lived hook processes
   now wait for captured-experience vectors to be stored instead of abandoning
   in-flight writes.
@@ -39,6 +44,7 @@ operators have a safe way to repair older patterns that are missing embeddings.
 [#583]: https://github.com/proffesor-for-testing/agentic-qe/issues/583
 [#584]: https://github.com/proffesor-for-testing/agentic-qe/issues/584
 [#588]: https://github.com/proffesor-for-testing/agentic-qe/issues/588
+[#601]: https://github.com/proffesor-for-testing/agentic-qe/issues/601
 
 ## [3.13.5] - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to the Agentic QE project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.13.6] - 2026-08-03
+
+Learning records and semantic search data now finish persisting reliably, while
+operators have a safe way to repair older patterns that are missing embeddings.
+
+### Added
+
+- **Pattern embedding repair** ([#584]). `aqe learning backfill-embeddings`
+  reports or repairs learned patterns that are missing semantic vectors, with
+  dry-run, JSON, and configurable batch-size support.
+
+### Fixed
+
+- **Hook embeddings persist before exit** ([#581]). Short-lived hook processes
+  now wait for captured-experience vectors to be stored instead of abandoning
+  in-flight writes.
+- **Embedding setup guidance names the correct environment variable** ([#582]),
+  so users configuring an external provider are directed to
+  `AQE_EMBEDDER_ENDPOINT`.
+- **Experience replay initializes once under concurrency** ([#583]). Concurrent
+  callers now share initialization work, while a failed attempt remains
+  retryable.
+- **Reasoning-bank unit tests remain isolated** ([#588]). Each case now uses an
+  ephemeral unified store, preventing transferred patterns from accumulating
+  until setup hooks time out.
+- **Embedding repair protects semantic consistency** ([#584]). Backfill now
+  fails clearly when no semantic provider is available instead of mixing hash
+  proxies into the semantic index.
+
+[#581]: https://github.com/proffesor-for-testing/agentic-qe/issues/581
+[#582]: https://github.com/proffesor-for-testing/agentic-qe/issues/582
+[#583]: https://github.com/proffesor-for-testing/agentic-qe/issues/583
+[#584]: https://github.com/proffesor-for-testing/agentic-qe/issues/584
+[#588]: https://github.com/proffesor-for-testing/agentic-qe/issues/588
+
 ## [3.13.5] - 2026-08-03
 
 Quality decisions and generated tests now carry evidence that reflects what AQE

--- a/assets/skills/skills-manifest.json
+++ b/assets/skills/skills-manifest.json
@@ -940,7 +940,7 @@
   },
   "metadata": {
     "generatedBy": "Agentic QE Fleet",
-    "fleetVersion": "3.13.5",
+    "fleetVersion": "3.13.6",
     "manifestVersion": "1.4.0",
     "lastUpdated": "2026-04-13T00:00:00.000Z",
     "contributors": [

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -4,6 +4,7 @@ All Agentic QE release notes organized by version.
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| [v3.13.6](v3.13.6.md) | 2026-08-03 | Reliable learning persistence and safe semantic embedding repair. |
 | [v3.13.5](v3.13.5.md) | 2026-08-03 | Measured quality gates and trustworthy cross-framework test execution. |
 | [v3.13.4](v3.13.4.md) | 2026-08-02 | Reliable Codex fleet setup, upgrades, hooks, and verification. |
 | [v3.13.3](v3.13.3.md) | 2026-07-29 | Learning capture no longer stops silently under `AQE_DISABLE_WAL` (it now refuses to write in an unsafe journal mode and names what is holding the DB), and QE-Court's shipped panel no longer violates its own `writerIsNeverJuror` rule (#576). |

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -4,7 +4,7 @@ All Agentic QE release notes organized by version.
 
 | Version | Date | Highlights |
 |---------|------|------------|
-| [v3.13.6](v3.13.6.md) | 2026-08-03 | Reliable learning persistence and safe semantic embedding repair. |
+| [v3.13.6](v3.13.6.md) | 2026-08-03 | Reliable namespaced search, learning persistence, and embedding repair. |
 | [v3.13.5](v3.13.5.md) | 2026-08-03 | Measured quality gates and trustworthy cross-framework test execution. |
 | [v3.13.4](v3.13.4.md) | 2026-08-02 | Reliable Codex fleet setup, upgrades, hooks, and verification. |
 | [v3.13.3](v3.13.3.md) | 2026-07-29 | Learning capture no longer stops silently under `AQE_DISABLE_WAL` (it now refuses to write in an unsafe journal mode and names what is holding the DB), and QE-Court's shipped panel no longer violates its own `writerIsNeverJuror` rule (#576). |

--- a/docs/releases/v3.13.6.md
+++ b/docs/releases/v3.13.6.md
@@ -1,0 +1,45 @@
+# v3.13.6 Release Notes
+
+**Release Date:** 2026-08-03
+
+## Highlights
+
+AQE now finishes writing learned embeddings before short-lived hooks exit,
+initializes experience replay safely under concurrency, and provides a guarded
+repair command for patterns that are missing semantic vectors.
+
+## Added
+
+- `aqe learning backfill-embeddings` for reporting and repairing learned
+  patterns without vectors.
+- Dry-run, JSON output, and configurable batch sizes for embedding repair.
+
+## Fixed
+
+- Hook-captured experiences no longer lose embeddings when their process exits
+  while vector generation is still running.
+- Concurrent experience-replay callers share one initialization attempt, and a
+  failed attempt can be retried.
+- External embedding setup errors now name `AQE_EMBEDDER_ENDPOINT` correctly.
+- Embedding repair refuses to mix hash proxies into a semantic index when no
+  semantic provider is available.
+- Reasoning-bank unit cases use ephemeral unified stores, preventing patterns
+  from accumulating across cases and slowing release validation.
+
+## Upgrade notes
+
+No configuration migration is required. Existing installations can upgrade and
+refresh their managed assets normally:
+
+```bash
+npx agentic-qe init --auto --upgrade
+```
+
+If older learned patterns are missing embeddings, inspect them without writing:
+
+```bash
+npx agentic-qe learning backfill-embeddings --dry-run
+```
+
+Then configure a semantic embedding provider and run the command without
+`--dry-run` to repair them.

--- a/docs/releases/v3.13.6.md
+++ b/docs/releases/v3.13.6.md
@@ -4,9 +4,10 @@
 
 ## Highlights
 
-AQE now finishes writing learned embeddings before short-lived hooks exit,
-initializes experience replay safely under concurrency, and provides a guarded
-repair command for patterns that are missing semantic vectors.
+AQE now returns the right memories from namespaced semantic search, finishes
+writing learned embeddings before short-lived hooks exit, initializes
+experience replay safely under concurrency, and provides a guarded repair
+command for patterns that are missing semantic vectors.
 
 ## Added
 
@@ -16,6 +17,8 @@ repair command for patterns that are missing semantic vectors.
 
 ## Fixed
 
+- Namespaced semantic queries no longer lose valid results when unrelated
+  vectors rank higher in the global index.
 - Hook-captured experiences no longer lose embeddings when their process exits
   while vector generation is still running.
 - Concurrent experience-replay callers share one initialization attempt, and a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentic-qe",
-  "version": "3.13.5",
+  "version": "3.13.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentic-qe",
-      "version": "3.13.5",
+      "version": "3.13.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-qe",
-  "version": "3.13.5",
+  "version": "3.13.6",
   "description": "Agentic Quality Engineering V3 - Domain-Driven Design Architecture with 13 Bounded Contexts, O(log n) coverage analysis, ReasoningBank learning, 60 specialized QE agents, mathematical Coherence verification, deep Claude Flow integration",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/cli/commands/hooks-handlers/hooks-dream-learning.ts
+++ b/src/cli/commands/hooks-handlers/hooks-dream-learning.ts
@@ -26,6 +26,32 @@ export interface DreamHookState {
   totalDreamsThisSession: number;
 }
 
+type EmbeddingWritableDatabase = {
+  prepare(sql: string): { run(...params: unknown[]): unknown };
+};
+
+/** Persist the vector before a short-lived hook process is allowed to exit. */
+async function persistCapturedExperienceEmbedding(
+  db: EmbeddingWritableDatabase,
+  id: string,
+  text: string,
+): Promise<void> {
+  try {
+    const { computeRealEmbedding } = await import('../../../learning/real-embeddings.js');
+    const embedding = await computeRealEmbedding(text.slice(0, 512));
+    db.prepare(
+      'UPDATE captured_experiences SET embedding = ?, embedding_dimension = ? WHERE id = ?'
+    ).run(Buffer.from(new Float32Array(embedding).buffer), embedding.length, id);
+  } catch (error) {
+    // Capture remains fail-soft, but the failure is observable for diagnostics.
+    console.error(
+      chalk.dim(
+        `[hooks] embedding persistence: ${error instanceof Error ? error.message : 'unknown'}`
+      )
+    );
+  }
+}
+
 /**
  * Check if a dream cycle should be triggered and run it if so.
  * Called from post-task hook after recording each experience.
@@ -262,19 +288,8 @@ export async function persistCommandExperience(opts: {
       opts.source
     );
 
-    // Fire-and-forget embedding write so HNSW C is searchable from the next
-    // boot's loadEmbeddingIndex() without waiting for the patch-350 backfill.
-    // Without this, hook-side writes accumulate as "ghosts" until the next
-    // restart catches them.
-    void (async () => {
-      try {
-        const { computeRealEmbedding } = await import('../../../learning/real-embeddings.js');
-        const text = `${opts.domain}: ${opts.task}`.slice(0, 512);
-        const embedding = await computeRealEmbedding(text);
-        db.prepare(`UPDATE captured_experiences SET embedding = ?, embedding_dimension = ? WHERE id = ?`)
-          .run(Buffer.from(new Float32Array(embedding).buffer), embedding.length, id);
-      } catch { /* fail-soft */ }
-    })();
+    // Hook processes are short-lived, so this must settle before returning.
+    await persistCapturedExperienceEmbedding(db, id, `${opts.domain}: ${opts.task}`);
   } catch (error) {
     // Best-effort — don't fail the hook
     console.error(chalk.dim(`[hooks] persistCommandExperience: ${error instanceof Error ? error.message : 'unknown'}`));
@@ -695,18 +710,12 @@ export async function persistTaskOutcome(opts: {
     }
   }
 
-  // Fire-and-forget embedding write for the captured_experiences row inserted
-  // inside the transaction above. Same rationale as the persistCommandExperience
-  // site — without this, post-task writes are ghosts until next-boot backfill.
-  void (async () => {
-    try {
-      const { computeRealEmbedding } = await import('../../../learning/real-embeddings.js');
-      const text = `${opts.domain ?? 'general'}: ${taskField}`.slice(0, 512);
-      const embedding = await computeRealEmbedding(text);
-      db.prepare(`UPDATE captured_experiences SET embedding = ?, embedding_dimension = ? WHERE id = ?`)
-        .run(Buffer.from(new Float32Array(embedding).buffer), embedding.length, experienceId);
-    } catch { /* fail-soft */ }
-  })();
+  // Hook processes are short-lived, so this must settle before returning.
+  await persistCapturedExperienceEmbedding(
+    db,
+    experienceId,
+    `${opts.domain ?? 'general'}: ${taskField}`,
+  );
 
   return {
     experienceId,

--- a/src/cli/commands/learning.ts
+++ b/src/cli/commands/learning.ts
@@ -28,6 +28,7 @@ import {
   type GrowthRate,
 } from '../../learning/regret-tracker.js';
 import { openDatabase } from '../../shared/safe-db.js';
+import { createSQLitePatternStore } from '../../learning/sqlite-persistence.js';
 
 // Extracted helpers
 import {
@@ -92,11 +93,78 @@ Examples:
   registerExportFullCommand(learning);
   registerImportMergeCommand(learning);
   registerDreamCommand(learning);
+  registerBackfillEmbeddingsCommand(learning);
   registerRepairCommand(learning);
   registerHealthCommand(learning);
   registerLoopHealthCommand(learning);
 
   return learning;
+}
+
+// ============================================================================
+// Subcommand: backfill-embeddings
+// ============================================================================
+
+function registerBackfillEmbeddingsCommand(learning: Command): void {
+  learning
+    .command('backfill-embeddings')
+    .description('Generate embeddings for learned patterns that are missing vectors')
+    .option('-b, --batch-size <n>', 'Patterns per embedding batch', '32')
+    .option('--dry-run', 'Report missing embeddings without writing')
+    .option('--json', 'Output as JSON')
+    .action(async (options) => {
+      const batchSize = Number(options.batchSize);
+      if (!Number.isInteger(batchSize) || batchSize <= 0) {
+        throw new Error('batch size must be a positive integer');
+      }
+
+      const store = createSQLitePatternStore();
+      try {
+        await store.initialize();
+        const before = store.getGhostPatternCount();
+
+        if (options.dryRun) {
+          if (options.json) {
+            printJson({ dryRun: true, batchSize, ...before });
+          } else {
+            console.log(chalk.bold('\nPattern Embedding Backfill (dry run)\n'));
+            console.log(`  Patterns: ${before.total}`);
+            console.log(`  Missing embeddings: ${before.withoutEmbeddings}`);
+            if (before.sampleGhostIds.length > 0) {
+              console.log(`  Sample IDs: ${before.sampleGhostIds.join(', ')}`);
+            }
+            console.log('');
+          }
+          return;
+        }
+
+        const result = await store.backfillEmbeddings(batchSize);
+        const after = store.getGhostPatternCount();
+        const output = {
+          ...result,
+          batchSize,
+          missingBefore: before.withoutEmbeddings,
+          missingAfter: after.withoutEmbeddings,
+        };
+
+        if (options.json) {
+          printJson(output);
+        } else {
+          printSuccess('Pattern embedding backfill complete.');
+          console.log(`  Processed: ${result.processed}`);
+          console.log(`  Skipped: ${result.skipped}`);
+          console.log(`  Errors: ${result.errors}`);
+          console.log(`  Remaining missing: ${after.withoutEmbeddings}`);
+          console.log(`  Method: ${result.method}`);
+          console.log('');
+        }
+      } catch (error) {
+        printError(`backfill-embeddings failed: ${error instanceof Error ? error.message : 'unknown'}`);
+        throw error;
+      } finally {
+        store.close();
+      }
+    });
 }
 
 // ============================================================================

--- a/src/integrations/agentic-flow/reasoning-bank/experience-replay.ts
+++ b/src/integrations/agentic-flow/reasoning-bank/experience-replay.ts
@@ -206,6 +206,7 @@ export class ExperienceReplay {
   private db: DatabaseType | null = null;
   private prepared: Map<string, Statement> = new Map();
   private initialized = false;
+  private initializationPromise: Promise<void> | null = null;
 
   // Real HNSW index for O(log n) similarity search (150x-12,500x faster than linear scan)
   private hnswIndex: HNSWEmbeddingIndex;
@@ -249,7 +250,19 @@ export class ExperienceReplay {
    */
   async initialize(): Promise<void> {
     if (this.initialized) return;
+    if (this.initializationPromise) return this.initializationPromise;
 
+    this.initializationPromise = this.initializeOnce();
+    try {
+      await this.initializationPromise;
+    } catch (error) {
+      // Allow a later caller to retry after a failed initialization.
+      this.initializationPromise = null;
+      throw error;
+    }
+  }
+
+  private async initializeOnce(): Promise<void> {
     this.unifiedMemory = getUnifiedMemory();
     await this.unifiedMemory.initialize();
     this.db = this.unifiedMemory.getDatabase();

--- a/src/learning/real-embeddings.ts
+++ b/src/learning/real-embeddings.ts
@@ -227,7 +227,7 @@ async function initializeModel(config: Partial<EmbeddingConfig> = {}): Promise<v
         throw new Error(
           'In-process embeddings require the optional package "@huggingface/transformers", ' +
           'which is not installed. Either run `npm install @huggingface/transformers`, or ' +
-          'configure an embedding endpoint (EmbeddingConfig.endpoint / AQE_EMBEDDING_ENDPOINT) ' +
+          'configure an embedding endpoint (EmbeddingConfig.endpoint / AQE_EMBEDDER_ENDPOINT) ' +
           'so no local model is loaded.'
         );
       }

--- a/src/learning/sqlite-persistence.ts
+++ b/src/learning/sqlite-persistence.ts
@@ -1183,8 +1183,9 @@ export class SQLitePatternStore {
 
   /**
    * Backfill embeddings for patterns that don't have them.
-   * Uses real all-MiniLM-L6-v2 transformer embeddings via @xenova/transformers.
-   * Falls back to hash-based embeddings if ONNX is unavailable.
+   * Uses real all-MiniLM-L6-v2 transformer embeddings via @huggingface/transformers
+   * or the configured external endpoint. Refuses hash proxies because mixing
+   * embedding spaces makes semantic retrieval results invalid.
    * Skips bench/test patterns (id LIKE 'bench-%').
    *
    * @param batchSize - Patterns per inference batch (default: 32, matches model batch size)
@@ -1235,7 +1236,7 @@ export class SQLitePatternStore {
     let processed = 0;
     let skipped = 0;
     let errors = 0;
-    let method: 'transformer' | 'hash-fallback' = 'transformer';
+    const method: 'transformer' | 'hash-fallback' = 'transformer';
 
     // Process in batches: compute embeddings async, then insert in sync transaction
     for (let i = 0; i < patternsWithout.length; i += batchSize) {
@@ -1279,11 +1280,11 @@ export class SQLitePatternStore {
               `aborting to protect HNSW index. Original error: ${toErrorMessage(e)}`
           );
         }
-        // In-process transformer path: hash fallback is acceptable because the
-        // entire index in this mode is hash-based anyway.
-        console.warn(`[SQLitePatternStore] Transformer unavailable, falling back to hash embeddings: ${toErrorMessage(e)}`);
-        method = 'hash-fallback';
-        embeddings = textsWithIds.map(t => hashEmbedding(t.text, dimension));
+        throw new Error(
+          `[SQLitePatternStore] semantic embedding unavailable; refusing to write hash proxies. ` +
+            `Install @huggingface/transformers or configure AQE_EMBEDDER_ENDPOINT. ` +
+            `Original error: ${toErrorMessage(e)}`
+        );
       }
 
       // Insert computed embeddings in a sync transaction

--- a/tests/unit/cli/commands/hook-embedding-persistence.test.ts
+++ b/tests/unit/cli/commands/hook-embedding-persistence.test.ts
@@ -1,0 +1,147 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getUnifiedMemory: vi.fn(),
+  computeRealEmbedding: vi.fn(),
+}));
+
+vi.mock('../../../../src/kernel/unified-memory.js', () => ({
+  getUnifiedMemory: () => mocks.getUnifiedMemory(),
+  findProjectRoot: () => process.cwd(),
+}));
+
+vi.mock('../../../../src/learning/experience-capture-middleware.js', () => ({
+  initializeExperienceCapture: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../../src/learning/real-embeddings.js', () => ({
+  computeRealEmbedding: (...args: unknown[]) => mocks.computeRealEmbedding(...args),
+}));
+
+import {
+  persistCommandExperience,
+  persistTaskOutcome,
+} from '../../../../src/cli/commands/hooks-handlers/hooks-dream-learning.js';
+
+function createSchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE captured_experiences (
+      id TEXT PRIMARY KEY, task TEXT NOT NULL, agent TEXT, domain TEXT,
+      success INTEGER, quality REAL, duration_ms INTEGER, model_tier TEXT,
+      started_at TEXT, completed_at TEXT, source TEXT,
+      consolidated_into TEXT, embedding BLOB, embedding_dimension INTEGER
+    );
+    CREATE TABLE experience_applications (
+      id TEXT PRIMARY KEY, experience_id TEXT, task TEXT, success INTEGER,
+      tokens_saved INTEGER, feedback TEXT, applied_at TEXT
+    );
+    CREATE TABLE qe_trajectories (
+      id TEXT PRIMARY KEY, task TEXT, agent TEXT, domain TEXT,
+      started_at TEXT, ended_at TEXT, success INTEGER, steps_json TEXT,
+      metadata_json TEXT
+    );
+    CREATE TABLE qe_patterns (
+      id TEXT PRIMARY KEY, pattern_type TEXT, qe_domain TEXT, domain TEXT,
+      name TEXT, description TEXT, confidence REAL DEFAULT 0.5,
+      usage_count INTEGER DEFAULT 0, successful_uses INTEGER DEFAULT 0,
+      success_rate REAL DEFAULT 0, quality_score REAL DEFAULT 0,
+      tier TEXT DEFAULT 'short-term', last_used_at TEXT,
+      created_at TEXT, updated_at TEXT
+    );
+    CREATE TABLE qe_pattern_usage (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, pattern_id TEXT, success INTEGER,
+      metrics_json TEXT, feedback TEXT, recorded_at TEXT
+    );
+    CREATE TABLE kv_store (
+      key TEXT, namespace TEXT, value TEXT, expires_at INTEGER,
+      created_at INTEGER, PRIMARY KEY (namespace, key)
+    );
+    CREATE TABLE dream_insights (
+      id TEXT PRIMARY KEY, applied INTEGER DEFAULT 0,
+      actionable INTEGER DEFAULT 0, created_at TEXT
+    );
+  `);
+}
+
+describe('hook embedding persistence (#581)', () => {
+  let tempDir: string;
+  let db: Database.Database;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aqe-hook-embedding-'));
+    db = new Database(path.join(tempDir, 'memory.db'));
+    createSchema(db);
+    mocks.getUnifiedMemory.mockReturnValue({
+      isInitialized: () => true,
+      initialize: vi.fn().mockResolvedValue(undefined),
+      getDatabase: () => db,
+    });
+    mocks.computeRealEmbedding.mockReset();
+  });
+
+  afterEach(() => {
+    db.close();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should await command-experience embedding persistence before returning', async () => {
+    let resolveEmbedding!: (embedding: number[]) => void;
+    mocks.computeRealEmbedding.mockReturnValue(
+      new Promise<number[]>((resolve) => {
+        resolveEmbedding = resolve;
+      })
+    );
+    let completed = false;
+
+    const operation = persistCommandExperience({
+      task: 'edit authentication service',
+      agent: 'qe-test-architect',
+      domain: 'test-generation',
+      success: true,
+      source: 'cli-hook-post-edit',
+    }).then(() => {
+      completed = true;
+    });
+    await vi.waitFor(() => expect(mocks.computeRealEmbedding).toHaveBeenCalledOnce());
+
+    expect(completed).toBe(false);
+    resolveEmbedding([0.25, 0.5]);
+    await operation;
+    const row = db.prepare('SELECT embedding_dimension FROM captured_experiences').get() as {
+      embedding_dimension: number;
+    };
+    expect(row.embedding_dimension).toBe(2);
+  });
+
+  it('should await post-task embedding persistence before returning', async () => {
+    let resolveEmbedding!: (embedding: number[]) => void;
+    mocks.computeRealEmbedding.mockReturnValue(
+      new Promise<number[]>((resolve) => {
+        resolveEmbedding = resolve;
+      })
+    );
+    let completed = false;
+
+    const operation = persistTaskOutcome({
+      taskId: 'task-581',
+      agent: 'qe-test-architect',
+      domain: 'test-generation',
+      success: true,
+    }).then(() => {
+      completed = true;
+    });
+    await vi.waitFor(() => expect(mocks.computeRealEmbedding).toHaveBeenCalledOnce());
+
+    expect(completed).toBe(false);
+    resolveEmbedding([0.25, 0.5]);
+    await operation;
+    const row = db.prepare('SELECT embedding_dimension FROM captured_experiences').get() as {
+      embedding_dimension: number;
+    };
+    expect(row.embedding_dimension).toBe(2);
+  });
+});

--- a/tests/unit/cli/commands/learning-backfill-embeddings.test.ts
+++ b/tests/unit/cli/commands/learning-backfill-embeddings.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const storeMocks = vi.hoisted(() => ({
+  initialize: vi.fn().mockResolvedValue(undefined),
+  getGhostPatternCount: vi.fn(),
+  backfillEmbeddings: vi.fn(),
+  close: vi.fn(),
+}));
+
+vi.mock('../../../../src/learning/sqlite-persistence.js', () => ({
+  createSQLitePatternStore: () => storeMocks,
+}));
+
+import { createLearningCommand } from '../../../../src/cli/commands/learning.js';
+
+describe('learning backfill-embeddings command (#584)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storeMocks.getGhostPatternCount.mockReturnValue({
+      total: 8,
+      withoutEmbeddings: 3,
+      sampleGhostIds: ['p1', 'p2', 'p3'],
+    });
+    storeMocks.backfillEmbeddings.mockResolvedValue({
+      processed: 3,
+      skipped: 0,
+      errors: 0,
+      alreadyHad: 5,
+      method: 'transformer',
+    });
+  });
+
+  it('should report missing embeddings without writing during a dry run', async () => {
+    const command = createLearningCommand().exitOverride();
+
+    await command.parseAsync(['backfill-embeddings', '--dry-run', '--json'], { from: 'user' });
+
+    expect(storeMocks.backfillEmbeddings).not.toHaveBeenCalled();
+  });
+
+  it('should pass the requested batch size to the repair operation', async () => {
+    const command = createLearningCommand().exitOverride();
+
+    await command.parseAsync(['backfill-embeddings', '--batch-size', '17', '--json'], {
+      from: 'user',
+    });
+
+    expect(storeMocks.backfillEmbeddings).toHaveBeenCalledWith(17);
+  });
+
+  it('should reject a non-positive batch size', async () => {
+    const command = createLearningCommand().exitOverride();
+
+    await expect(
+      command.parseAsync(['backfill-embeddings', '--batch-size', '0'], { from: 'user' })
+    ).rejects.toThrow('batch size must be a positive integer');
+  });
+});

--- a/tests/unit/learning/experience-replay-initialization.test.ts
+++ b/tests/unit/learning/experience-replay-initialization.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const memoryMocks = vi.hoisted(() => ({
+  initialize: vi.fn<() => Promise<void>>(),
+  getDatabase: vi.fn(),
+}));
+
+vi.mock('../../../src/kernel/unified-memory.js', () => ({
+  getUnifiedMemory: () => memoryMocks,
+}));
+
+describe('ExperienceReplay initialization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    memoryMocks.getDatabase.mockReturnValue({
+      prepare: vi.fn(() => ({ all: vi.fn(() => []) })),
+    });
+  });
+
+  it('should share one in-flight initialization across concurrent callers', async () => {
+    let finishInitialization!: () => void;
+    memoryMocks.initialize.mockImplementation(
+      () => new Promise<void>((resolve) => {
+        finishInitialization = resolve;
+      })
+    );
+    const { ExperienceReplay } = await import(
+      '../../../src/integrations/agentic-flow/reasoning-bank/experience-replay.js'
+    );
+    const replay = new ExperienceReplay();
+    vi.spyOn(replay as never, 'ensureSchema').mockImplementation(() => undefined);
+    vi.spyOn(replay as never, 'prepareStatements').mockImplementation(() => undefined);
+    vi.spyOn(replay as never, 'loadEmbeddingIndex').mockResolvedValue(undefined);
+
+    const first = replay.initialize();
+    await vi.waitFor(() => expect(memoryMocks.initialize).toHaveBeenCalledTimes(1));
+    const second = replay.initialize();
+
+    expect(memoryMocks.initialize).toHaveBeenCalledTimes(1);
+    finishInitialization();
+    await Promise.all([first, second]);
+  });
+});

--- a/tests/unit/learning/qe-reasoning-bank.test.ts
+++ b/tests/unit/learning/qe-reasoning-bank.test.ts
@@ -58,11 +58,15 @@ afterAll(() => {
 const canTest = checkRuvectorPackagesAvailable();
 
 describe.runIf(canTest.gnn)('QE ReasoningBank', () => {
+  const originalMemoryBackend = process.env.AQE_MEMORY_BACKEND;
   let memory: MemoryBackend;
   let reasoningBank: QEReasoningBank;
 
   beforeEach(async () => {
-    // Reset shared singletons to prevent cross-test contamination
+    // QEReasoningBank owns a SQLitePatternStore in addition to the injected
+    // MemoryBackend. Keep each test's unified store ephemeral so foundational
+    // and transferred patterns cannot accumulate across cases (#588).
+    process.env.AQE_MEMORY_BACKEND = 'memory';
     resetUnifiedPersistence();
     queenGovernanceAdapter.reset();
     resetSharedMinCutState();
@@ -78,6 +82,11 @@ describe.runIf(canTest.gnn)('QE ReasoningBank', () => {
 
     // Clean up singletons after test
     resetUnifiedPersistence();
+    if (originalMemoryBackend === undefined) {
+      delete process.env.AQE_MEMORY_BACKEND;
+    } else {
+      process.env.AQE_MEMORY_BACKEND = originalMemoryBackend;
+    }
   });
 
   describe('Initialization', () => {

--- a/tests/unit/learning/real-embeddings-guidance.test.ts
+++ b/tests/unit/learning/real-embeddings-guidance.test.ts
@@ -1,0 +1,23 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@huggingface/transformers', () => {
+  throw new Error('optional dependency unavailable');
+});
+
+describe('real embeddings configuration guidance', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.AQE_EMBEDDER_ENDPOINT;
+  });
+
+  it('should name the environment variable read by the endpoint configuration', async () => {
+    const { computeRealEmbedding, resetInitialization } = await import(
+      '../../../src/learning/real-embeddings.js'
+    );
+    resetInitialization();
+
+    await expect(
+      computeRealEmbedding('semantic test input', { enableCache: false })
+    ).rejects.toThrow('AQE_EMBEDDER_ENDPOINT');
+  });
+});

--- a/tests/unit/learning/sqlite-embedding-backfill.test.ts
+++ b/tests/unit/learning/sqlite-embedding-backfill.test.ts
@@ -1,0 +1,48 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const embeddingMocks = vi.hoisted(() => ({
+  computeBatchEmbeddings: vi.fn().mockRejectedValue(new Error('optional model unavailable')),
+}));
+
+vi.mock('../../../src/learning/real-embeddings.js', () => ({
+  computeBatchEmbeddings: (...args: unknown[]) => embeddingMocks.computeBatchEmbeddings(...args),
+  getEmbeddingDimension: () => 384,
+  isUsingEndpoint: () => false,
+}));
+
+import { SQLitePatternStore } from '../../../src/learning/sqlite-persistence.js';
+
+describe('SQLite pattern embedding backfill (#584)', () => {
+  let tempDir: string | undefined;
+  let store: SQLitePatternStore | undefined;
+
+  afterEach(() => {
+    store?.close();
+    if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should fail without writing hash proxies when semantic embedding is unavailable', async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aqe-pattern-backfill-'));
+    store = new SQLitePatternStore({
+      useUnified: false,
+      dbPath: path.join(tempDir, 'memory.db'),
+    });
+    await store.initialize();
+    store.exec(`
+      INSERT INTO qe_patterns (
+        id, pattern_type, qe_domain, domain, name, description, template_json,
+        context_json, confidence, usage_count, successful_uses,
+        success_rate, quality_score, tier, created_at, updated_at
+      ) VALUES (
+        'pattern-without-vector', 'unit', 'test-generation', 'test-generation',
+        'AAA pattern', 'Arrange Act Assert', '{}', '{}', 0.8, 0, 0, 0, 0.8,
+        'short-term', datetime('now'), datetime('now')
+      )
+    `);
+
+    await expect(store.backfillEmbeddings()).rejects.toThrow('optional model unavailable');
+  });
+});


### PR DESCRIPTION
## Summary

Prepare v3.13.6 with reliable hook-side embedding persistence, concurrency-safe experience replay initialization, corrected external embedder guidance, and a guarded `aqe learning backfill-embeddings` repair command. The release also completes reasoning-bank test isolation discovered by the release gate.

Closes #581. Closes #582. Closes #583. Closes #584.

## Verification

- `npm run build` — passed; CLI and MCP bundles built as v3.13.6.
- `npm run typecheck` — passed with zero errors.
- `npx vitest run tests/unit/` — 683 files passed, 1 skipped; 17,953 tests passed, 14 skipped.
- `npm run performance:gate` — 15/15 gates passed.
- `npm run test:regression` — 291 files passed across both configured projects; 8,509 tests passed, 4 skipped.
- `npm run test:ci` — 941 files passed, 6 skipped; 23,146 tests passed, 54 skipped.
- Fresh local-build `aqe init --auto` — passed; created schema v11, installed 86 skills and 60 agents, and completed verification.
- Local CLI smoke checks — `--version`, `status`, `learning stats`, `agent list`, and `health` all passed.
- Isolated packed install — `agentic-qe-3.13.6.tgz` installed successfully and `aqe --version` printed `3.13.6`.
- `npm run verify:invariants`, `verify:skill-parity`, `verify:conservation`, and `sync:agents:check` — passed.
- Changed-source ESLint and `git diff --check` — passed.

Browser/e2e suites were not run, following the release workflow; this release does not change browser behavior.

## Failure modes

- Short-lived hooks could exit before command or task embeddings were written; focused tests hold embedding generation in flight and verify both handlers wait for the database update.
- Concurrent callers could initialize experience replay more than once; a focused concurrency test verifies callers share one initialization.
- Repairing missing vectors without a semantic provider could mix hash proxies into a semantic index; a focused database test verifies the command fails without writing a proxy vector.
- External-provider setup could direct users to the wrong environment variable; a focused missing-provider test verifies `AQE_EMBEDDER_ENDPOINT` is reported.
- Reasoning-bank unit cases could accumulate transferred patterns until setup timed out; the complete 20-test suite now runs against per-case ephemeral unified storage.

---

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.** "Unlikely" is not an acceptable substitute. If you wrote "I don't think this can happen but...", that sentence is a failure mode and needs a test or an issue link.

### Optional context

- Linked issues: #581, #582, #583, #584, #588
- Trust tier change (if any): none
- Affects published API or CLI surface: yes — adds `aqe learning backfill-embeddings`
- Touches the init flow / `npm-publish.yml` / `tests/fixtures/init-corpus/`: no

See [CHANGELOG](CHANGELOG.md) for details.
