### PR TITLE
fix(memory): scope semantic search before limiting

### DIFF
--- a/src/kernel/hybrid-backend.ts
+++ b/src/kernel/hybrid-backend.ts
@@ -237,10 +237,14 @@ export class HybridMemoryBackend implements MemoryBackend {
    * Vector similarity search
    * Now uses unified memory's persistent vector storage
    */
-  async vectorSearch(embedding: number[], k: number): Promise<VectorSearchResult[]> {
+  async vectorSearch(
+    embedding: number[],
+    k: number,
+    keyPrefix?: string
+  ): Promise<VectorSearchResult[]> {
     this.ensureInitialized();
 
-    const results = await this.unifiedMemory!.vectorSearch(embedding, k);
+    const results = await this.unifiedMemory!.vectorSearch(embedding, k, undefined, keyPrefix);
 
     // Convert to VectorSearchResult format
     return results.map(r => ({

--- a/src/kernel/interfaces.ts
+++ b/src/kernel/interfaces.ts
@@ -298,8 +298,8 @@ export interface MemoryBackend extends Initializable, Disposable {
   /** Search by pattern (`options.namespace` mirrors `get`). */
   search(pattern: string, limit?: number, options?: RetrieveOptions): Promise<string[]>;
 
-  /** Vector similarity search (HNSW) */
-  vectorSearch(embedding: number[], k: number): Promise<VectorSearchResult[]>;
+  /** Vector similarity search (HNSW), optionally scoped by logical key prefix. */
+  vectorSearch(embedding: number[], k: number, keyPrefix?: string): Promise<VectorSearchResult[]>;
 
   /** Store vector embedding */
   storeVector(key: string, embedding: number[], metadata?: unknown): Promise<void>;

--- a/src/kernel/memory-backend.ts
+++ b/src/kernel/memory-backend.ts
@@ -109,10 +109,15 @@ export class InMemoryBackend implements MemoryBackend {
     return results;
   }
 
-  async vectorSearch(embedding: number[], k: number): Promise<VectorSearchResult[]> {
+  async vectorSearch(
+    embedding: number[],
+    k: number,
+    keyPrefix?: string
+  ): Promise<VectorSearchResult[]> {
     const results: VectorSearchResult[] = [];
 
     for (const [key, entry] of this.vectors.entries()) {
+      if (keyPrefix && !key.startsWith(keyPrefix)) continue;
       const score = cosineSimilarity(embedding, entry.embedding);
       results.push({ key, score, metadata: entry.metadata });
     }

--- a/src/kernel/unified-memory.ts
+++ b/src/kernel/unified-memory.ts
@@ -852,7 +852,7 @@ export class UnifiedMemoryManager {
   }
 
   async vectorSearch(
-    query: number[], k: number = 10, namespace?: string
+    query: number[], k: number = 10, namespace?: string, keyPrefix?: string
   ): Promise<Array<{ id: string; score: number; metadata?: unknown }>> {
     this.ensureInitialized();
 
@@ -860,7 +860,21 @@ export class UnifiedMemoryManager {
       await this.loadVectorIndex();
     }
 
-    const results = this.vectorIndex.search(query, k * 2);
+    // Logical namespaces are encoded in vector ids (`namespace:key`), while
+    // the vectors table namespace identifies the physical backend. Widen the
+    // ANN query until enough logical matches are found so global top-K results
+    // cannot hide a valid namespaced hit.
+    const indexSize = this.vectorIndex.size();
+    let candidateCount = Math.min(indexSize, Math.max(k * 2, 1));
+    let results = this.vectorIndex.search(query, candidateCount);
+    while (
+      keyPrefix &&
+      results.filter(result => result.id.startsWith(keyPrefix)).length < k &&
+      candidateCount < indexSize
+    ) {
+      candidateCount = Math.min(indexSize, candidateCount * 2);
+      results = this.vectorIndex.search(query, candidateCount);
+    }
     if (results.length === 0) return [];
 
     const ids = results.map(r => r.id);
@@ -875,7 +889,7 @@ export class UnifiedMemoryManager {
       const filteredResults: Array<{ id: string; score: number; metadata?: unknown }> = [];
       for (const result of results) {
         const row = metadataMap.get(result.id);
-        if (row && row.namespace === namespace) {
+        if (row && row.namespace === namespace && (!keyPrefix || result.id.startsWith(keyPrefix))) {
           filteredResults.push({
             id: result.id, score: result.score,
             metadata: row.metadata ? safeJsonParse(row.metadata) : undefined,
@@ -886,7 +900,11 @@ export class UnifiedMemoryManager {
       return filteredResults;
     }
 
-    return results.slice(0, k).map(result => {
+    const scopedResults = keyPrefix
+      ? results.filter(result => result.id.startsWith(keyPrefix)).slice(0, k)
+      : results.slice(0, k);
+
+    return scopedResults.map(result => {
       const row = metadataMap.get(result.id);
       return {
         id: result.id, score: result.score,

--- a/src/mcp/handlers/memory-handlers.ts
+++ b/src/mcp/handlers/memory-handlers.ts
@@ -245,12 +245,12 @@ export async function handleMemoryQuery(
       try {
         // Generate real 384-dim transformer embedding for accurate cosine similarity search
         const embedding = await computeRealEmbedding(params.pattern);
-        const vectorResults = await kernel!.memory.vectorSearch(embedding, limit + offset);
-
-        // Filter by namespace if specified
-        const filtered = namespace !== 'default'
-          ? vectorResults.filter(r => r.key.startsWith(`${namespace}:`))
-          : vectorResults;
+        const keyPrefix = namespace !== 'default' ? `${namespace}:` : undefined;
+        const filtered = await kernel!.memory.vectorSearch(
+          embedding,
+          limit + offset,
+          keyPrefix
+        );
 
         const paginatedResults = filtered.slice(offset, offset + limit);
 

--- a/tests/unit/kernel/unified-memory.test.ts
+++ b/tests/unit/kernel/unified-memory.test.ts
@@ -394,6 +394,16 @@ describe('UnifiedMemoryManager', () => {
     });
 
     describe('vectorSearch', () => {
+      it('scopes candidates by logical key prefix before applying the limit', async () => {
+        await manager.vectorStore('other:closer', [1, 0, 0], 'qe-kernel');
+        await manager.vectorStore('target:only', [0.9, 0.1, 0], 'qe-kernel');
+
+        const results = await manager.vectorSearch([1, 0, 0], 1, undefined, 'target:');
+
+        expect(results).toHaveLength(1);
+        expect(results[0].id).toBe('target:only');
+      });
+
       beforeEach(async () => {
         // Store orthogonal vectors
         await manager.vectorStore('v1', [1, 0, 0], 'default', { axis: 'x' });


### PR DESCRIPTION
## Summary

Closes #601. Agentic-QE stores logical namespaces in vector IDs (`namespace:key`) while the persistent vector table uses a physical backend namespace. Semantic queries previously requested the global top-K and only then filtered by logical namespace, so valid persisted vectors disappeared in a large index.

The memory backend now accepts logical key-prefix scoping. Persistent ANN search progressively widens candidates until it finds enough scoped results or exhausts the index; the in-memory backend follows the same contract, and the MCP handler supplies the requested namespace prefix.

## Verification

- `npm test -- --run tests/unit/kernel/unified-memory.test.ts tests/unit/kernel/hybrid-backend.test.ts --reporter=dot` — 100 passed
- `npm run typecheck` — passed
- `git diff --check` — passed
- Regression proves a lower-ranked vector in the requested namespace is returned even when an unrelated vector ranks higher globally.

## Failure modes

- Mitigated and tested: a valid namespaced vector falls outside the initial global top-K.
- Mitigated by bounded progressive widening: sparse namespaces may require scanning the full in-process index before returning fewer than K results.
- Existing fallback behavior remains unchanged if embedding or vector search fails.
- Live `.agentic-qe/memory.db`, Ruflo `.swarm/memory.db`, RVF files, and migration state were not modified.

---

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.**

### Optional context

- Linked issues: #601
- Trust tier change (if any): none
- Affects published API or CLI surface: internal optional argument only; no CLI schema change
- Touches the init flow / `npm-publish.yml` / `tests/fixtures/init-corpus/`: no