### PR TITLE
chore(release): prepare v3.13.7

### DIFF
--- a/.claude/skills/skills-manifest.json
+++ b/.claude/skills/skills-manifest.json
@@ -940,7 +940,7 @@
   },
   "metadata": {
     "generatedBy": "Agentic QE Fleet",
-    "fleetVersion": "3.13.6",
+    "fleetVersion": "3.13.7",
     "manifestVersion": "1.4.0",
     "lastUpdated": "2026-04-13T00:00:00.000Z",
     "contributors": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to the Agentic QE project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.13.7] - 2026-08-04
+
+Memory operations now disclose partial semantic-index failures, and ANN search
+returns stable, qualified top-K results. The release also includes the latest
+merged dependency security remediations.
+
+### Fixed
+
+- **Memory stores disclose semantic-index failures** ([#603]). KV persistence
+  can still succeed when the optional embedding capability is unavailable, but
+  structured MCP/JSON output now reports `VECTOR_INDEX_UNAVAILABLE` and the
+  human CLI prints a warning instead of implying that vector indexing worked.
+- **ANN top-K results remain stable across requested limits** ([#604]). Native
+  HNSW queries use request-independent traversal breadth within their qualified
+  range, retain deduplication headroom, and iteratively qualify logical and
+  physical namespace filters. Semantic results now report backend, index type,
+  approximation status, estimated recall, and qualified K limits.
+- **Critical dependency alerts remediated** ([#607]). Root and shipped
+  development-tool lockfiles now resolve patched `fast-xml-parser`, `hono`,
+  `minimatch`, and `serialize-javascript` versions without changing public AQE
+  APIs.
+
+### Changed
+
+- Refreshed Ruflo development-tool dependency locks from [#605]. Ruflo remains
+  development-time tooling and is not added to AQE runtime dependencies.
+
+[#603]: https://github.com/proffesor-for-testing/agentic-qe/issues/603
+[#604]: https://github.com/proffesor-for-testing/agentic-qe/issues/604
+[#605]: https://github.com/proffesor-for-testing/agentic-qe/pull/605
+[#607]: https://github.com/proffesor-for-testing/agentic-qe/pull/607
+
 ## [3.13.6] - 2026-08-03
 
 Learning records and semantic search data now persist and resolve reliably,

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -4,6 +4,7 @@ All Agentic QE release notes organized by version.
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| [v3.13.7](v3.13.7.md) | 2026-08-04 | Explicit semantic-index status, stable ANN top-K results, and critical dependency fixes. |
 | [v3.13.6](v3.13.6.md) | 2026-08-03 | Reliable namespaced search, learning persistence, and embedding repair. |
 | [v3.13.5](v3.13.5.md) | 2026-08-03 | Measured quality gates and trustworthy cross-framework test execution. |
 | [v3.13.4](v3.13.4.md) | 2026-08-02 | Reliable Codex fleet setup, upgrades, hooks, and verification. |

--- a/docs/releases/v3.13.7.md
+++ b/docs/releases/v3.13.7.md
@@ -1,0 +1,46 @@
+# v3.13.7 Release Notes
+
+**Release Date:** 2026-08-04
+
+## Highlights
+
+AQE now tells callers when a memory was persisted without its semantic vector,
+keeps native ANN top-K results stable across qualified result limits, and ships
+the critical dependency remediations merged since v3.13.6.
+
+## Fixed
+
+- Memory stores return a structured vector-index outcome. If the optional
+  embedding capability is unavailable, JSON/MCP clients receive the stable
+  `VECTOR_INDEX_UNAVAILABLE` code and human CLI users see a warning while the
+  successful KV write remains available.
+- Native HNSW search uses stable traversal breadth with deduplication headroom,
+  so top-20 remains a prefix of top-100 within the qualified K range.
+- Namespace-qualified vector search expands candidates until it finds enough
+  matching results or exhausts the index, without constructing an unbounded
+  global SQL placeholder list.
+- Semantic search responses identify the active backend and index, whether the
+  result is approximate, estimated recall, and the qualified maximum K where
+  applicable.
+- Patched transitive versions resolve the recently opened critical
+  `fast-xml-parser`, `hono`, `minimatch`, and `serialize-javascript` alerts.
+
+## Verification highlights
+
+- Deterministic 5,000-vector top-K nesting test.
+- Recall@20 qualification against exact cosine ground truth (at least 0.95).
+- Partial vector-index failure tests for MCP, JSON, human CLI output, and
+  sanitized error handling.
+- Consumer and degraded-mode dependency audits from PR #607.
+
+## Upgrade notes
+
+No database or configuration migration is required. Semantic embeddings remain
+an optional capability; install or configure a supported embedding provider if
+semantic indexing is required.
+
+Upgrade and refresh managed assets normally:
+
+```bash
+npx agentic-qe init --auto --upgrade
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentic-qe",
-  "version": "3.13.6",
+  "version": "3.13.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentic-qe",
-      "version": "3.13.6",
+      "version": "3.13.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-qe",
-  "version": "3.13.6",
+  "version": "3.13.7",
   "description": "Agentic Quality Engineering V3 - Domain-Driven Design Architecture with 13 Bounded Contexts, O(log n) coverage analysis, ReasoningBank learning, 60 specialized QE agents, mathematical Coherence verification, deep Claude Flow integration",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -75,6 +75,9 @@ Examples:
           console.log(JSON.stringify(result, null, 2));
         } else if (result.success) {
           console.log(chalk.green(`  ✓ Stored "${options.key}" in namespace "${options.namespace}"`));
+          if (result.data?.vectorIndex?.status === 'failed') {
+            console.warn(chalk.yellow(`  ⚠ ${result.data.vectorIndex.error.message}`));
+          }
         } else {
           console.error(chalk.red(`  ✗ ${result.error}`));
           await cleanupAndExit(1);

--- a/src/kernel/hybrid-backend.ts
+++ b/src/kernel/hybrid-backend.ts
@@ -10,7 +10,13 @@
  * backward compatibility with existing MemoryBackend interface.
  */
 
-import { MemoryBackend, StoreOptions, RetrieveOptions, VectorSearchResult } from './interfaces';
+import {
+  MemoryBackend,
+  StoreOptions,
+  RetrieveOptions,
+  VectorSearchResult,
+  VectorSearchProvenance,
+} from './interfaces';
 import {
   UnifiedMemoryManager,
   getUnifiedMemory,
@@ -252,6 +258,11 @@ export class HybridMemoryBackend implements MemoryBackend {
       score: r.score,
       metadata: r.metadata,
     }));
+  }
+
+  getVectorSearchProvenance(): VectorSearchProvenance {
+    this.ensureInitialized();
+    return this.unifiedMemory!.getVectorSearchProvenance();
   }
 
   /**

--- a/src/kernel/interfaces.ts
+++ b/src/kernel/interfaces.ts
@@ -301,6 +301,9 @@ export interface MemoryBackend extends Initializable, Disposable {
   /** Vector similarity search (HNSW), optionally scoped by logical key prefix. */
   vectorSearch(embedding: number[], k: number, keyPrefix?: string): Promise<VectorSearchResult[]>;
 
+  /** Describe the index and guarantees used by vectorSearch. */
+  getVectorSearchProvenance?(): VectorSearchProvenance;
+
   /** Store vector embedding */
   storeVector(key: string, embedding: number[], metadata?: unknown): Promise<void>;
 
@@ -317,6 +320,15 @@ export interface MemoryBackend extends Initializable, Disposable {
    * @returns True if the code intelligence knowledge graph has been indexed
    */
   hasCodeIntelligenceIndex(): Promise<boolean>;
+}
+
+export interface VectorSearchProvenance {
+  backend: 'in-memory' | 'native-hnsw' | 'progressive-hnsw';
+  indexType: 'flat' | 'hnsw';
+  approximate: boolean;
+  estimatedRecall: number;
+  /** Largest K covered by request-independent HNSW traversal breadth. */
+  qualifiedMaxK?: number;
 }
 
 export interface StoreOptions {

--- a/src/kernel/memory-backend.ts
+++ b/src/kernel/memory-backend.ts
@@ -3,7 +3,13 @@
  * Hybrid memory implementation (in-memory + optional persistence)
  */
 
-import { MemoryBackend, StoreOptions, RetrieveOptions, VectorSearchResult } from './interfaces';
+import {
+  MemoryBackend,
+  StoreOptions,
+  RetrieveOptions,
+  VectorSearchResult,
+  VectorSearchProvenance,
+} from './interfaces';
 import { cosineSimilarity } from '../shared/utils/vector-math.js';
 import { MEMORY_CONSTANTS } from './constants.js';
 
@@ -126,6 +132,15 @@ export class InMemoryBackend implements MemoryBackend {
     return results
       .sort((a, b) => b.score - a.score)
       .slice(0, k);
+  }
+
+  getVectorSearchProvenance(): VectorSearchProvenance {
+    return {
+      backend: 'in-memory',
+      indexType: 'flat',
+      approximate: false,
+      estimatedRecall: 1,
+    };
   }
 
   async storeVector(

--- a/src/kernel/native-hnsw-backend.ts
+++ b/src/kernel/native-hnsw-backend.ts
@@ -382,12 +382,20 @@ export class NativeHnswBackend implements IHnswIndexProvider {
     const normalizedQuery = this.normalizeVector(query);
     const actualK = Math.min(k, this.liveIds.size);
 
-    // Overshoot k by 2x (capped at index size) so that defensive dedup
-    // below can drop any duplicate-label entries hnswlib may return after
-    // long add/remove churn and still leave us with at least k unique
-    // results when possible.
-    const overshoot = Math.min(actualK * 2, this.liveIds.size);
-    const native = this.nativeIndex.searchKnn(toNumberArray(normalizedQuery), overshoot);
+    // Keep the HNSW traversal breadth independent of the requested result
+    // count throughout the index's qualified range. hnswlib effectively uses
+    // max(k, efSearch) as its candidate breadth, so forwarding small K values
+    // directly can make top-20 and top-100 explore different graphs. Query a
+    // stable efSearch-sized pool with 2x defensive dedup headroom, then
+    // truncate. Requests above efSearch remain approximate and use 2x their K.
+    const searchBreadth = Math.min(
+      this.liveIds.size,
+      Math.max(actualK, this.config.efSearch) * 2,
+    );
+    const native = this.nativeIndex.searchKnn(
+      toNumberArray(normalizedQuery),
+      searchBreadth,
+    );
 
     // Convert hnswlib-node distances to similarity scores.
     //   cosine space: distance = 1 - cos_sim, so similarity = 1 - distance

--- a/src/kernel/unified-memory.ts
+++ b/src/kernel/unified-memory.ts
@@ -29,7 +29,8 @@ import { toErrorMessage } from '../shared/error-utils.js';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { MEMORY_CONSTANTS } from './constants.js';
+import { HNSW_CONSTANTS, MEMORY_CONSTANTS } from './constants.js';
+import type { VectorSearchProvenance } from './interfaces.js';
 import { LoggerFactory } from '../logging/index.js';
 import { HashChainGate } from '../integrations/ruvector/proof-gate.js';
 
@@ -856,6 +857,8 @@ export class UnifiedMemoryManager {
   ): Promise<Array<{ id: string; score: number; metadata?: unknown }>> {
     this.ensureInitialized();
 
+    if (!Number.isInteger(k) || k <= 0) return [];
+
     if (!this.vectorsLoaded) {
       await this.loadVectorIndex();
     }
@@ -865,11 +868,28 @@ export class UnifiedMemoryManager {
     // ANN query until enough logical matches are found so global top-K results
     // cannot hide a valid namespaced hit.
     const indexSize = this.vectorIndex.size();
-    let candidateCount = Math.min(indexSize, Math.max(k * 2, 1));
+    // Unscoped searches need exactly K ranked candidates. Let the backend use
+    // its request-independent efSearch breadth so changing K within that
+    // qualified range cannot change the traversal. Logical namespace filters
+    // still require oversampling and iterative expansion because matching
+    // keys may be hidden behind global neighbors from other namespaces.
+    const isScoped = Boolean(namespace || keyPrefix);
+    let candidateCount = Math.min(indexSize, Math.max(isScoped ? k * 2 : k, 1));
+    const namespaceRows = namespace
+      ? this.db!.prepare(
+        'SELECT id, namespace, metadata FROM vectors WHERE namespace = ?'
+      ).all(namespace) as Array<{ id: string; namespace: string; metadata: string | null }>
+      : undefined;
+    const namespaceMap = namespaceRows
+      ? new Map(namespaceRows.map(row => [row.id, row]))
+      : undefined;
     let results = this.vectorIndex.search(query, candidateCount);
     while (
-      keyPrefix &&
-      results.filter(result => result.id.startsWith(keyPrefix)).length < k &&
+      isScoped &&
+      results.filter(result =>
+        (!keyPrefix || result.id.startsWith(keyPrefix)) &&
+        (!namespaceMap || namespaceMap.has(result.id))
+      ).length < k &&
       candidateCount < indexSize
     ) {
       candidateCount = Math.min(indexSize, candidateCount * 2);
@@ -877,13 +897,14 @@ export class UnifiedMemoryManager {
     }
     if (results.length === 0) return [];
 
-    const ids = results.map(r => r.id);
-    const placeholders = ids.map(() => '?').join(',');
-    const rows = this.db!.prepare(
-      `SELECT id, namespace, metadata FROM vectors WHERE id IN (${placeholders})`
-    ).all(...ids) as Array<{ id: string; namespace: string; metadata: string | null }>;
-
-    const metadataMap = new Map(rows.map(row => [row.id, row]));
+    const metadataMap = namespaceMap ?? (() => {
+      const ids = results.map(r => r.id);
+      const placeholders = ids.map(() => '?').join(',');
+      const rows = this.db!.prepare(
+        `SELECT id, namespace, metadata FROM vectors WHERE id IN (${placeholders})`
+      ).all(...ids) as Array<{ id: string; namespace: string; metadata: string | null }>;
+      return new Map(rows.map(row => [row.id, row]));
+    })();
 
     if (namespace) {
       const filteredResults: Array<{ id: string; score: number; metadata?: unknown }> = [];
@@ -911,6 +932,25 @@ export class UnifiedMemoryManager {
         metadata: row?.metadata ? safeJsonParse(row.metadata) : undefined,
       };
     });
+  }
+
+  getVectorSearchProvenance(): VectorSearchProvenance {
+    const provider = this.vectorIndex.getProvider();
+    if (!provider.isNativeBackend()) {
+      return {
+        backend: 'progressive-hnsw',
+        indexType: 'flat',
+        approximate: false,
+        estimatedRecall: 1,
+      };
+    }
+    return {
+      backend: 'native-hnsw',
+      indexType: 'hnsw',
+      approximate: true,
+      estimatedRecall: this.vectorIndex.recall(),
+      qualifiedMaxK: HNSW_CONSTANTS.EF_SEARCH,
+    };
   }
 
   async vectorCount(namespace?: string): Promise<number> {

--- a/src/mcp/handlers/memory-handlers.ts
+++ b/src/mcp/handlers/memory-handlers.ts
@@ -29,6 +29,7 @@ import {
 
 // Real transformer embeddings for semantic search (384-dim, matches ExperienceReplay)
 import { computeRealEmbedding } from '../../learning/real-embeddings.js';
+import type { VectorSearchProvenance } from '../../kernel/interfaces.js';
 
 // ============================================================================
 // Memory Store Handler
@@ -98,6 +99,7 @@ export async function handleMemoryStore(
 
     // Store vector embedding for semantic search (HNSW)
     // Generate real 384-dim transformer embedding so memory_query semantic:true returns meaningful scores
+    let vectorIndex: MemoryStoreResult['vectorIndex'];
     try {
       const textForEmbedding = `${params.key} ${JSON.stringify(params.value)}`;
       const embedding = await computeRealEmbedding(textForEmbedding);
@@ -106,9 +108,19 @@ export async function handleMemoryStore(
         namespace,
         storedAt: Date.now(),
       });
-    } catch (vecErr) {
+      vectorIndex = { status: 'indexed' };
+    } catch {
       // Non-critical — KV store succeeded, vector indexing is best-effort
-      console.warn(`[MemoryHandler] Vector indexing failed for ${params.key}: ${toErrorMessage(vecErr)}`);
+      console.warn(
+        '[MemoryHandler] VECTOR_INDEX_UNAVAILABLE: Semantic vector indexing is unavailable for this entry.'
+      );
+      vectorIndex = {
+        status: 'failed',
+        error: {
+          code: 'VECTOR_INDEX_UNAVAILABLE',
+          message: 'Semantic vector indexing is unavailable for this entry.',
+        },
+      };
     }
 
     // ADR-058: Register pattern after successful write for future contradiction detection
@@ -128,6 +140,7 @@ export async function handleMemoryStore(
         namespace,
         timestamp: new Date().toISOString(),
         persisted: true,
+        vectorIndex,
       },
     };
   } catch (error) {
@@ -209,6 +222,7 @@ interface MemoryQueryResult {
   total: number;
   hasMore: boolean;
   searchType: 'pattern' | 'semantic';
+  searchProvenance?: VectorSearchProvenance;
 }
 
 /**
@@ -270,6 +284,7 @@ export async function handleMemoryQuery(
             total: filtered.length,
             hasMore: offset + limit < filtered.length,
             searchType: 'semantic',
+            searchProvenance: kernel!.memory.getVectorSearchProvenance?.(),
           },
         };
       } catch (vectorError) {

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -643,6 +643,16 @@ export interface MemoryStoreResult {
   namespace: string;
   timestamp: string;
   persisted: boolean;
+  /** Outcome of best-effort semantic vector indexing for this entry. */
+  vectorIndex?:
+    | { status: 'indexed' }
+    | {
+      status: 'failed';
+      error: {
+        code: 'VECTOR_INDEX_UNAVAILABLE';
+        message: string;
+      };
+    };
 }
 
 /**

--- a/tests/unit/cli/commands/memory-vector-warning.test.ts
+++ b/tests/unit/cli/commands/memory-vector-warning.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  handleMemoryStore: vi.fn(),
+}));
+
+vi.mock('../../../../src/mcp/handlers/memory-handlers.js', () => ({
+  handleMemoryStore: mocks.handleMemoryStore,
+}));
+
+import { createMemoryCommand } from '../../../../src/cli/commands/memory.js';
+
+describe('memory store vector indexing disclosure', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mocks.handleMemoryStore.mockReset();
+  });
+
+  it('should warn when KV storage succeeds but vector indexing fails', async () => {
+    mocks.handleMemoryStore.mockResolvedValue({
+      success: true,
+      data: {
+        stored: true,
+        key: 'example',
+        namespace: 'default',
+        timestamp: '2026-08-04T00:00:00.000Z',
+        persisted: true,
+        vectorIndex: {
+          status: 'failed',
+          error: {
+            code: 'VECTOR_INDEX_UNAVAILABLE',
+            message: 'Semantic vector indexing is unavailable for this entry.',
+          },
+        },
+      },
+    });
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const command = createMemoryCommand(
+      {} as never,
+      vi.fn() as never,
+      vi.fn().mockResolvedValue(true)
+    );
+
+    await command.parseAsync(
+      ['store', '--key', 'example', '--value', 'value'],
+      { from: 'user' }
+    );
+
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Stored "example"'));
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('Semantic vector indexing is unavailable for this entry.')
+    );
+  });
+});

--- a/tests/unit/kernel/native-hnsw-backend.test.ts
+++ b/tests/unit/kernel/native-hnsw-backend.test.ts
@@ -432,6 +432,67 @@ describe('NativeHnswBackend', () => {
       expect(dissimilarResult).toBeDefined();
       expect(similarResult!.score).toBeGreaterThan(dissimilarResult!.score);
     });
+
+    it('should keep top-K results nested when K is within efSearch', () => {
+      const dimensions = 32;
+      const backend = new NativeHnswBackend({
+        dimensions,
+        M: 8,
+        efConstruction: 50,
+        efSearch: 100,
+        metric: 'cosine',
+        maxElements: 5000,
+      });
+
+      try {
+        // This seeded fixture previously diverged at rank 17 because the
+        // native search breadth changed with requested K.
+        let state = 123456789;
+        const nextValue = (): number => {
+          state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+          return (state / 4294967296) * 2 - 1;
+        };
+        const vectors: Float32Array[] = [];
+        for (let id = 0; id < 5000; id++) {
+          const vector = new Float32Array(dimensions);
+          for (let index = 0; index < dimensions; index++) {
+            vector[index] = nextValue();
+          }
+          vectors.push(vector);
+          backend.add(id, vector);
+        }
+
+        const top20 = backend.search(vectors[0], 20);
+        const top100 = backend.search(vectors[0], 100);
+
+        expect(top20.map(result => result.id)).toEqual(
+          top100.slice(0, 20).map(result => result.id),
+        );
+
+        const query = vectors[0];
+        const exactTop20 = vectors
+          .map((vector, id) => {
+            let dot = 0;
+            let queryNorm = 0;
+            let vectorNorm = 0;
+            for (let index = 0; index < dimensions; index++) {
+              dot += query[index] * vector[index];
+              queryNorm += query[index] * query[index];
+              vectorNorm += vector[index] * vector[index];
+            }
+            return { id, score: dot / Math.sqrt(queryNorm * vectorNorm) };
+          })
+          .sort((left, right) => right.score - left.score)
+          .slice(0, 20)
+          .map(result => result.id);
+        const returnedIds = new Set(top20.map(result => result.id));
+        const recallAt20 = exactTop20.filter(id => returnedIds.has(id)).length / 20;
+
+        expect(recallAt20).toBeGreaterThanOrEqual(0.95);
+      } finally {
+        backend.dispose();
+      }
+    });
   });
 
   // ===========================================================================

--- a/tests/unit/kernel/unified-memory.test.ts
+++ b/tests/unit/kernel/unified-memory.test.ts
@@ -394,6 +394,41 @@ describe('UnifiedMemoryManager', () => {
     });
 
     describe('vectorSearch', () => {
+      it('reports HNSW approximation limits', () => {
+        expect(manager.getVectorSearchProvenance()).toMatchObject({
+          indexType: 'hnsw',
+          approximate: true,
+          qualifiedMaxK: 100,
+        });
+        expect(manager.getVectorSearchProvenance().estimatedRecall).toBeGreaterThanOrEqual(0.95);
+      });
+
+      it('reports the progressive fallback as an exact flat index', () => {
+        const vectorIndex = (manager as unknown as {
+          vectorIndex: { getProvider: () => { isNativeBackend: () => boolean } };
+        }).vectorIndex;
+        vi.spyOn(vectorIndex.getProvider(), 'isNativeBackend').mockReturnValue(false);
+
+        expect(manager.getVectorSearchProvenance()).toEqual({
+          backend: 'progressive-hnsw',
+          indexType: 'flat',
+          approximate: false,
+          estimatedRecall: 1,
+        });
+      });
+
+      it('requests exactly K candidates for an unscoped search', async () => {
+        await manager.vectorStore('v1', [1, 0, 0], 'default');
+        const vectorIndex = (manager as unknown as {
+          vectorIndex: { search: (query: number[], k: number) => Array<{ id: string; score: number }> };
+        }).vectorIndex;
+        const search = vi.spyOn(vectorIndex, 'search');
+
+        await manager.vectorSearch([1, 0, 0], 1);
+
+        expect(search).toHaveBeenCalledWith([1, 0, 0], 1);
+      });
+
       it('scopes candidates by logical key prefix before applying the limit', async () => {
         await manager.vectorStore('other:closer', [1, 0, 0], 'qe-kernel');
         await manager.vectorStore('target:only', [0.9, 0.1, 0], 'qe-kernel');
@@ -403,6 +438,24 @@ describe('UnifiedMemoryManager', () => {
         expect(results).toHaveLength(1);
         expect(results[0].id).toBe('target:only');
       });
+
+      it('does not let a closer vector from another physical namespace hide a match', async () => {
+        await manager.vectorStore('other:closer', [1, 0, 0], 'other');
+        await manager.vectorStore('target:only', [0.9, 0.1, 0], 'target');
+
+        const results = await manager.vectorSearch([1, 0, 0], 1, 'target');
+
+        expect(results).toHaveLength(1);
+        expect(results[0].id).toBe('target:only');
+      });
+
+      it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+        'returns no results for invalid K=%s',
+        async (k) => {
+          await manager.vectorStore('v1', [1, 0, 0], 'default');
+          expect(await manager.vectorSearch([1, 0, 0], k)).toEqual([]);
+        },
+      );
 
       beforeEach(async () => {
         // Store orthogonal vectors

--- a/tests/unit/mcp/handlers/memory-handlers.test.ts
+++ b/tests/unit/mcp/handlers/memory-handlers.test.ts
@@ -15,6 +15,7 @@ import {
 import {
   handleFleetInit,
   disposeFleet,
+  getFleetState,
 } from '../../../../src/mcp/handlers/core-handlers';
 import { resetUnifiedPersistence } from '../../../../src/kernel/unified-persistence';
 import type {
@@ -67,6 +68,35 @@ describe('Memory Handlers', { timeout: 30000 }, () => {
       expect(result.data!.key).toBe('test-key');
       expect(result.data!.namespace).toBe('default');
       expect(result.data!.timestamp).toBeDefined();
+      expect(result.data!.vectorIndex).toEqual({ status: 'indexed' });
+    });
+
+    it('should disclose a stable vector indexing failure without exposing internals', async () => {
+      const { kernel } = getFleetState();
+      vi.spyOn(kernel!.memory, 'storeVector').mockRejectedValueOnce(
+        new Error('secret provider path /private/model-cache')
+      );
+      const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      const result = await handleMemoryStore({
+        key: 'vector-failure',
+        value: 'still stored in KV memory',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data!.stored).toBe(true);
+      expect(result.data!.vectorIndex).toEqual({
+        status: 'failed',
+        error: {
+          code: 'VECTOR_INDEX_UNAVAILABLE',
+          message: 'Semantic vector indexing is unavailable for this entry.',
+        },
+      });
+      expect(JSON.stringify(result)).not.toContain('/private/model-cache');
+      expect(warning).toHaveBeenCalledWith(
+        '[MemoryHandler] VECTOR_INDEX_UNAVAILABLE: Semantic vector indexing is unavailable for this entry.'
+      );
+      expect(JSON.stringify(warning.mock.calls)).not.toContain('/private/model-cache');
     });
 
     it('should store complex object value', async () => {
@@ -298,6 +328,19 @@ describe('Memory Handlers', { timeout: 30000 }, () => {
       expect(result.data!.entries.length).toBeGreaterThanOrEqual(2);
       result.data!.entries.forEach(entry => {
         expect(entry.key).toMatch(/^test-/);
+      });
+    });
+
+    it('should report semantic search provenance', async () => {
+      const result = await handleMemoryQuery({ pattern: 'test value', semantic: true });
+
+      expect(result.success).toBe(true);
+      expect(result.data!.searchType).toBe('semantic');
+      expect(result.data!.searchProvenance).toEqual({
+        backend: 'in-memory',
+        indexType: 'flat',
+        approximate: false,
+        estimatedRecall: 1,
       });
     });
 


### PR DESCRIPTION
## Summary

Prepares Agentic QE v3.13.7 with explicit vector-index outcomes for partial memory-store failures, stable and qualified ANN top-K behavior, semantic search provenance, and the dependency security remediations merged in #605 and #607. Adds changelog and release notes and updates the package and fleet versions.

Closes #603.
Closes #604.

## Verification

- `npx vitest run tests/unit/kernel/native-hnsw-backend.test.ts tests/unit/kernel/unified-memory.test.ts tests/unit/mcp/handlers/memory-handlers.test.ts tests/unit/cli/commands/memory-vector-warning.test.ts --reporter=dot` — 164 passed
- independent adversarial review — PASS after remediation of dedup breadth, namespace qualification, API compatibility, invalid K, and fallback provenance
- `npm run build` — passed; CLI and MCP bundles report 3.13.7
- `npm run typecheck` — passed
- `npm run test:unit:fast` — 8,426 passed, 6 skipped
- `npm run test:unit:mcp` — 1,366 passed, 2 skipped
- `npm run test:integration:fast` — 26 passed
- `npm run performance:gate` — 15/15 passed
- invariants, skill parity, conservation, agent sync, counts, Tier-3 validators, and Codex package verification — passed
- clean packed consumer install — CLI reports 3.13.7; production audit reports 0 vulnerabilities
- fresh database-free init — success; no `memory.db` created
- `npm run test:ci` — two setup-hook timeouts in the pre-existing stateful learning-engine pattern suite; tracked in #610. No changed-memory assertion failed.

## Failure modes

- Optional embedding capability can be unavailable after a KV write. MCP/JSON and human CLI tests exercise the structured partial-success response and sanitized warning.
- Native HNSW remains approximate beyond its reported qualified K. Deterministic top-K nesting, exact cosine recall@20, and provenance tests cover the documented boundary.
- Logical or physical namespace filtering can require wider candidate search. Expansion and namespace-isolation tests cover both paths and bounded SQL lookup behavior.
- Coverage instrumentation can fail unrelated wall-clock assertions while dedicated performance gates pass; tracked in #608.
- The full learning-engine pattern suite can accumulate ephemeral state and time out in setup; tracked in #610.
- PR #606 overlaps the dependency lockfiles changed by #607 and is currently conflicting; it is not included in this release PR and should be rebased/regenerated separately.

---

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.** "Unlikely" is not an acceptable substitute. If you wrote "I don't think this can happen but...", that sentence is a failure mode and needs a test or an issue link.

### Optional context

- Linked issues: #603, #604, #608, #610
- Trust tier change (if any): none
- Affects published API or CLI surface: yes — additive status/provenance fields and a human warning
- Touches the init flow / `npm-publish.yml` / `tests/fixtures/init-corpus/`: no