### PR TITLE
chore(release): prepare v3.13.8

### DIFF
--- a/.claude/skills/skills-manifest.json
+++ b/.claude/skills/skills-manifest.json
@@ -940,7 +940,7 @@
   },
   "metadata": {
     "generatedBy": "Agentic QE Fleet",
-    "fleetVersion": "3.13.7",
+    "fleetVersion": "3.13.8",
     "manifestVersion": "1.4.0",
     "lastUpdated": "2026-04-13T00:00:00.000Z",
     "contributors": [

--- a/.github/workflows/optimized-ci.yml
+++ b/.github/workflows/optimized-ci.yml
@@ -296,6 +296,11 @@ jobs:
             fi
           fi
 
+      - name: Run instrumentation-sensitive performance baselines
+        run: |
+          npx vitest run tests/performance/milestone1-baselines.test.ts
+          npx vitest run tests/unit/integrations/ruvector/hopfield-memory.test.ts --testNamePattern='single recall'
+
   # ─── Coverage analysis (PRs only, after journey shards) ───
 
   coverage:
@@ -311,10 +316,14 @@ jobs:
       - run: npm ci
       - run: npm run build
       - name: Run tests with coverage (excluding browser E2E)
-        run: bash scripts/ci-vitest-run.sh --coverage --reporter=verbose
+        # Performance baselines remain authoritative in Performance Gates.
+        # V8 instrumentation adds nondeterministic wall-clock overhead, so the
+        # coverage job exercises correctness paths but excludes pure benchmarks.
+        run: bash scripts/ci-vitest-run.sh --coverage --reporter=verbose --exclude='tests/performance/**'
         env:
           NODE_OPTIONS: '--max-old-space-size=1024'
           CI: 'true'
+          AQE_COVERAGE: 'true'
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to the Agentic QE project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.13.8] - 2026-08-04
+
+CI performance checks are now measured without coverage instrumentation, and
+the remaining stateful learning-engine suite uses bounded, isolated storage.
+Development-time Ruflo dependency locks also include the latest security
+remediations.
+
+### Fixed
+
+- **Coverage no longer makes performance timing flaky** ([#608]). Pure
+  performance baselines run in the dedicated Performance Gates job, while
+  coverage continues to exercise Hopfield correctness without enforcing a
+  wall-clock threshold distorted by V8 instrumentation.
+- **Learning-engine pattern tests no longer accumulate database state**
+  ([#610]). Every case uses a fresh ephemeral unified store, asserts a stable
+  initial pattern count, closes the database, and removes only its temporary
+  directory after execution.
+
+### Changed
+
+- The dedicated Performance Gates job now runs the Milestone 1 baselines and
+  the Hopfield single-recall benchmark in addition to the aggregate gate.
+- Refreshed Ruflo development-tool dependency locks from [#612], including
+  patched versions of `hono`, `undici`, `sharp`, `qs`, `postcss`, and related
+  transitive packages. Ruflo remains development-time tooling and is not added
+  to AQE runtime dependencies.
+
+[#608]: https://github.com/proffesor-for-testing/agentic-qe/issues/608
+[#610]: https://github.com/proffesor-for-testing/agentic-qe/issues/610
+[#612]: https://github.com/proffesor-for-testing/agentic-qe/pull/612
+
 ## [3.13.7] - 2026-08-04
 
 Memory operations now disclose partial semantic-index failures, and ANN search

--- a/assets/skills/skills-manifest.json
+++ b/assets/skills/skills-manifest.json
@@ -940,7 +940,7 @@
   },
   "metadata": {
     "generatedBy": "Agentic QE Fleet",
-    "fleetVersion": "3.13.6",
+    "fleetVersion": "3.13.8",
     "manifestVersion": "1.4.0",
     "lastUpdated": "2026-04-13T00:00:00.000Z",
     "contributors": [

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -4,6 +4,7 @@ All Agentic QE release notes organized by version.
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| [v3.13.8](v3.13.8.md) | 2026-08-04 | Stable coverage gates and isolated learning-engine tests. |
 | [v3.13.7](v3.13.7.md) | 2026-08-04 | Explicit semantic-index status, stable ANN top-K results, and critical dependency fixes. |
 | [v3.13.6](v3.13.6.md) | 2026-08-03 | Reliable namespaced search, learning persistence, and embedding repair. |
 | [v3.13.5](v3.13.5.md) | 2026-08-03 | Measured quality gates and trustworthy cross-framework test execution. |

--- a/docs/releases/v3.13.8.md
+++ b/docs/releases/v3.13.8.md
@@ -1,0 +1,30 @@
+# v3.13.8 Release Notes
+
+**Release Date:** 2026-08-04
+
+## Highlights
+
+AQE's CI now separates correctness coverage from wall-clock performance
+measurement, and its remaining stateful learning-engine tests no longer grow a
+shared pattern database across cases. The release also incorporates the latest
+Ruflo development-tool security updates from #612.
+
+## Fixed
+
+- V8 coverage instrumentation no longer causes otherwise healthy performance
+  baselines to fail the Coverage Analysis job.
+- The learning-engine pattern suite gives every case a fresh ephemeral database
+  and verifies that initial pattern counts remain stable across the suite.
+- Temporary learning databases are closed and removed after every case without
+  reading or modifying a workspace learning database.
+
+## Changed
+
+- Milestone 1 and Hopfield recall timing checks now run under the dedicated,
+  non-instrumented Performance Gates job.
+- Ruflo development-only lockfiles now resolve patched dependency versions;
+  AQE's runtime dependency surface is unchanged.
+
+## Upgrade notes
+
+No API, database, or configuration migration is required.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentic-qe",
-  "version": "3.13.7",
+  "version": "3.13.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentic-qe",
-      "version": "3.13.7",
+      "version": "3.13.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-qe",
-  "version": "3.13.7",
+  "version": "3.13.8",
   "description": "Agentic Quality Engineering V3 - Domain-Driven Design Architecture with 13 Bounded Contexts, O(log n) coverage analysis, ReasoningBank learning, 60 specialized QE agents, mathematical Coherence verification, deep Claude Flow integration",
   "type": "module",
   "main": "./dist/index.js",

--- a/tests/unit/integrations/ruvector/hopfield-memory.test.ts
+++ b/tests/unit/integrations/ruvector/hopfield-memory.test.ts
@@ -434,7 +434,10 @@ describe('HopfieldMemory', () => {
   // Benchmark (ADR-087 requirement)
   // --------------------------------------------------------------------------
 
-  describe('benchmark', () => {
+  // Coverage instrumentation distorts this wall-clock threshold. Correctness
+  // cases above still run under coverage; the dedicated Performance Gates job
+  // runs this benchmark without instrumentation.
+  describe.skipIf(process.env.AQE_COVERAGE === 'true')('benchmark', () => {
     it('single recall < 1ms for 1K stored patterns', () => {
       const memory = createHopfieldMemory({ dimension: DIM });
       const rng = seededRandom(42);

--- a/tests/unit/learning/aqe-learning-engine-patterns.test.ts
+++ b/tests/unit/learning/aqe-learning-engine-patterns.test.ts
@@ -11,7 +11,11 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { setRuVectorFeatureFlags, resetRuVectorFeatureFlags } from '../../../src/integrations/ruvector/feature-flags.js';
+import { resetUnifiedPersistence } from '../../../src/kernel/unified-persistence.js';
 import { clearEmbeddingCache, resetInitialization } from '../../../src/learning/real-embeddings';
 import { _resetWitnessChainForTests } from '../../../src/audit/witness-chain';
 import {
@@ -39,21 +43,43 @@ describe('AQELearningEngine — pattern + tracking + experience capture', () => 
   let memory: MemoryBackend;
   let eventBus: EventBus;
   let engine: AQELearningEngine;
+  let testProjectRoot: string;
+  const originalProjectRoot = process.env.AQE_PROJECT_ROOT;
+  const initialPatternCounts: number[] = [];
 
   beforeEach(async () => {
+    // SQLitePatternStore uses the shared UnifiedMemory singleton even when the
+    // engine receives an in-memory MemoryBackend. Give every case a fresh DB so
+    // foundational/cross-domain seeding cannot compound across the suite.
+    resetUnifiedPersistence();
+    testProjectRoot = mkdtempSync(join(tmpdir(), 'aqe-learning-patterns-'));
+    process.env.AQE_PROJECT_ROOT = testProjectRoot;
     memory = createMockMemoryBackend();
     eventBus = createMockEventBus();
     engine = createAQELearningEngine(
       memory,
-      { projectRoot: '/test/project', enableClaudeFlow: false },
+      { projectRoot: testProjectRoot, enableClaudeFlow: false },
       eventBus
     );
     await engine.initialize();
+    initialPatternCounts.push((await engine.getStats()).totalPatterns);
   });
 
   afterEach(async () => {
     vi.clearAllMocks();
-    await engine.dispose();
+    try {
+      await engine.dispose();
+    } finally {
+      resetUnifiedPersistence();
+      if (originalProjectRoot === undefined) delete process.env.AQE_PROJECT_ROOT;
+      else process.env.AQE_PROJECT_ROOT = originalProjectRoot;
+      rmSync(testProjectRoot, { recursive: true, force: true });
+    }
+  });
+
+  afterAll(() => {
+    expect(new Set(initialPatternCounts).size).toBe(1);
+    expect(initialPatternCounts.every((count) => count < 100)).toBe(true);
   });
 
   describe('Pattern Learning', () => {


### PR DESCRIPTION
## Summary

Prepares v3.13.8 with fixes for #608 and #610 and includes the Ruflo development dependency security remediations merged in #612. Coverage now measures correctness without enforcing instrumentation-distorted wall-clock thresholds, while the dedicated Performance Gates job remains authoritative for those benchmarks; the stateful learning-engine suite now uses a fresh ephemeral unified store per test.

## Verification

- `npm run typecheck` — passed.
- `npm run build` — passed; bundles report 3.13.8.
- `npm run test:ci` — 942 files passed, 6 skipped; 23,157 tests passed, 57 skipped.
- `npx vitest run tests/unit/learning/aqe-learning-engine-patterns.test.ts` — 15/15 passed with stable fresh-store seeds.
- `AQE_COVERAGE=true npx vitest run tests/unit/integrations/ruvector/hopfield-memory.test.ts` — 27 passed, benchmark skipped as designed.
- `npx vitest run tests/performance/milestone1-baselines.test.ts` — 20/20 passed; retrieval energy 1683 µs against a 5000 µs ceiling.
- `npm run verify:skill-parity` — passed with no drift.
- #612 Security Audit and all functional CI lanes passed; its only failed lane was the exact instrumentation-sensitive timing checks fixed here, while Performance Gates passed.

## Failure modes

- Coverage could silently stop exercising Hopfield correctness. Mitigated by the coverage-mode focused test above: 27 correctness tests run and only the benchmark is skipped.
- Timing regressions could be hidden when performance tests leave coverage. Mitigated by explicitly running both Milestone 1 and Hopfield recall checks in Performance Gates.
- Test databases could leak state or cleanup could target a workspace database. Mitigated by per-case `mkdtemp` roots, singleton reset, bounded seed-count assertions, and cleanup limited to the generated temporary root.

---

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.** "Unlikely" is not an acceptable substitute. If you wrote "I don't think this can happen but...", that sentence is a failure mode and needs a test or an issue link.

### Optional context

- Linked issues: Fixes #608; fixes #610; includes #612.
- Trust tier change (if any): none.
- Affects published API or CLI surface: no.
- Touches the init flow / `npm-publish.yml` / `tests/fixtures/init-corpus/`: no.
