### PR TITLE
feat(learning): enforce embedding-space provenance

### DIFF
--- a/src/cli/commands/learning.ts
+++ b/src/cli/commands/learning.ts
@@ -29,6 +29,8 @@ import {
 } from '../../learning/regret-tracker.js';
 import { openDatabase } from '../../shared/safe-db.js';
 import { createSQLitePatternStore } from '../../learning/sqlite-persistence.js';
+import { getActiveEmbeddingSpaceIdentity } from '../../learning/real-embeddings.js';
+import { inspectEmbeddingSpaceRows } from '../../learning/embedding-space.js';
 
 // Extracted helpers
 import {
@@ -94,11 +96,62 @@ Examples:
   registerImportMergeCommand(learning);
   registerDreamCommand(learning);
   registerBackfillEmbeddingsCommand(learning);
+  registerEmbeddingHealthCommand(learning);
   registerRepairCommand(learning);
   registerHealthCommand(learning);
   registerLoopHealthCommand(learning);
 
   return learning;
+}
+
+// ============================================================================
+// Subcommand: embedding-health (#633)
+// ============================================================================
+
+function registerEmbeddingHealthCommand(learning: Command): void {
+  learning
+    .command('embedding-health')
+    .description('Display active and stored embedding-space provenance')
+    .option('--json', 'Output as JSON')
+    .action(async (options) => {
+      const dbPath = path.join(findProjectRoot(), '.agentic-qe', 'memory.db');
+      if (!existsSync(dbPath)) {
+        throw new Error('Database not found. Run "aqe init --auto" first.');
+      }
+      const db = openDatabase(dbPath, { readonly: true });
+      try {
+        const table = db.prepare(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name='qe_pattern_embeddings'",
+        ).get();
+        const hasSpaceId = table
+          ? (db.prepare("PRAGMA table_info('qe_pattern_embeddings')").all() as Array<{ name: string }>)
+              .some((column) => column.name === 'space_id')
+          : false;
+        const rows = table
+          ? db.prepare(
+              `SELECT ${hasSpaceId ? 'space_id' : 'NULL'} AS spaceId FROM qe_pattern_embeddings`,
+            ).all() as Array<{ spaceId: string | null }>
+          : [];
+        const diagnostics = inspectEmbeddingSpaceRows(
+          rows,
+          getActiveEmbeddingSpaceIdentity()?.spaceId ?? null,
+        );
+
+        if (options.json) {
+          printJson(diagnostics);
+          return;
+        }
+        console.log(chalk.bold('\nEmbedding Space Health\n'));
+        console.log(`  Status: ${diagnostics.status}`);
+        console.log(`  Active space: ${diagnostics.activeSpaceId ?? '(runtime not initialized)'}`);
+        console.log(`  Stored spaces: ${diagnostics.storedSpaceIds.join(', ') || '(none)'}`);
+        console.log(`  Verified vectors: ${diagnostics.verifiedVectors}`);
+        console.log(`  Mismatched vectors: ${diagnostics.mismatchedVectors}`);
+        console.log(`  Unverified vectors: ${diagnostics.unverifiedVectors}\n`);
+      } finally {
+        db.close();
+      }
+    });
 }
 
 // ============================================================================

--- a/src/integrations/ruvector/brain-rvf-exporter.ts
+++ b/src/integrations/ruvector/brain-rvf-exporter.ts
@@ -226,66 +226,31 @@ export function exportBrainToRvf(
     const embeddingEntries: RvfIngestEntry[] = [];
 
     if (tableExists(db, 'qe_pattern_embeddings')) {
+      const hasSpaceId = (db.prepare("PRAGMA table_info('qe_pattern_embeddings')").all() as Array<{ name: string }>)
+        .some((column) => column.name === 'space_id');
       const rows = db.prepare(
-        'SELECT pattern_id, embedding, dimension FROM qe_pattern_embeddings'
-      ).all() as Array<{ pattern_id: string; embedding: Buffer; dimension: number }>;
+        `SELECT pattern_id, embedding, dimension, ${hasSpaceId ? 'space_id' : 'NULL'} AS space_id
+           FROM qe_pattern_embeddings`
+      ).all() as Array<{ pattern_id: string; embedding: Buffer; dimension: number; space_id: string | null }>;
       for (const row of rows) {
-        if (row.embedding && row.dimension === dimension) {
+        // Legacy vectors without executable provenance remain in the embedded
+        // SQLite kernel for re-embedding, but must never enter the portable ANN
+        // index where their space would be indistinguishable from query vectors.
+        if (row.embedding && row.dimension === dimension && row.space_id) {
           embeddingEntries.push({
             id: `pe:${row.pattern_id}`,
             vector: new Float32Array(row.embedding.buffer, row.embedding.byteOffset, dimension),
-            metadata: { tableName: 'qe_pattern_embeddings' },
+            metadata: { tableName: 'qe_pattern_embeddings', spaceId: row.space_id },
           });
         }
       }
     }
 
-    if (tableExists(db, 'captured_experiences')) {
-      const rows = db.prepare(
-        'SELECT id, embedding, embedding_dimension, domain, quality FROM captured_experiences WHERE embedding IS NOT NULL'
-      ).all() as Array<{
-        id: string; embedding: Buffer; embedding_dimension: number;
-        domain?: string; quality?: number;
-      }>;
-      for (const row of rows) {
-        if (row.embedding_dimension === dimension) {
-          embeddingEntries.push({
-            id: `exp:${row.id}`,
-            vector: new Float32Array(row.embedding.buffer, row.embedding.byteOffset, dimension),
-            metadata: {
-              tableName: 'captured_experiences',
-              domain: row.domain,
-              confidence: row.quality,
-            },
-          });
-        }
-      }
-    }
-
-    if (tableExists(db, 'sona_patterns')) {
-      const rows = db.prepare(
-        'SELECT id, state_embedding, domain, confidence FROM sona_patterns WHERE state_embedding IS NOT NULL'
-      ).all() as Array<{
-        id: string; state_embedding: Buffer;
-        domain?: string; confidence?: number;
-      }>;
-      for (const row of rows) {
-        const dim = row.state_embedding.byteLength / 4;
-        if (dim === dimension) {
-          embeddingEntries.push({
-            id: `sona:${row.id}`,
-            vector: new Float32Array(
-              row.state_embedding.buffer, row.state_embedding.byteOffset, dimension
-            ),
-            metadata: {
-              tableName: 'sona_patterns',
-              domain: row.domain,
-              confidence: row.confidence,
-            },
-          });
-        }
-      }
-    }
+    // captured_experiences and sona_patterns are still included in the kernel
+    // below, but their schemas do not yet carry embedding-space provenance.
+    // Mixing them into this ANN index would violate #633 even when dimensions
+    // and model labels happen to match, so they are intentionally excluded
+    // until their own write paths persist a space_id.
 
     if (embeddingEntries.length > 0) {
       const result = rvf.ingest(embeddingEntries);

--- a/src/integrations/ruvector/brain-table-ddl.ts
+++ b/src/integrations/ruvector/brain-table-ddl.ts
@@ -59,6 +59,7 @@ const BRAIN_TABLE_DDL: readonly string[] = [
   `CREATE TABLE IF NOT EXISTS qe_pattern_embeddings (
     pattern_id TEXT PRIMARY KEY, embedding BLOB NOT NULL,
     dimension INTEGER NOT NULL, model TEXT DEFAULT 'all-MiniLM-L6-v2',
+    space_id TEXT,
     created_at TEXT DEFAULT (datetime('now')),
     FOREIGN KEY (pattern_id) REFERENCES qe_patterns(id) ON DELETE CASCADE
   )`,
@@ -217,6 +218,12 @@ export function ensureAllBrainTables(db: Database.Database): void {
   for (const ddl of BRAIN_TABLE_DDL) {
     db.exec(ddl);
   }
+  const embeddingColumns = db.prepare("PRAGMA table_info('qe_pattern_embeddings')")
+    .all() as Array<{ name: string }>;
+  if (!embeddingColumns.some((column) => column.name === 'space_id')) {
+    db.exec('ALTER TABLE qe_pattern_embeddings ADD COLUMN space_id TEXT');
+  }
+  db.exec('CREATE INDEX IF NOT EXISTS idx_qe_pattern_embeddings_space ON qe_pattern_embeddings(space_id)');
 }
 
 /** List of all table names in creation/import order. */

--- a/src/integrations/ruvector/rvf-dual-writer.ts
+++ b/src/integrations/ruvector/rvf-dual-writer.ts
@@ -16,6 +16,7 @@ import type {
   RvfStatus as NativeRvfStatus,
 } from './rvf-native-adapter.js';
 import { getActiveEmbeddingSpaceIdentity } from '../../learning/real-embeddings.js';
+import { verifyOrCreateEmbeddingSpaceManifest } from '../../learning/embedding-space.js';
 
 // ============================================================================
 // Types
@@ -59,6 +60,8 @@ export interface DualWriteConfig {
   mode: 'dual-write' | 'rvf-primary' | 'sqlite-only';
   /** Whether to verify witness chain on startup */
   verifyOnStartup?: boolean;
+  /** Runtime provenance for an injected embedding pipeline. */
+  embeddingSpaceId?: string;
 }
 
 export interface DualWriteResult {
@@ -157,6 +160,14 @@ export class RvfDualWriter {
       ...config,
       dimensions: config.dimensions ?? 384,
     };
+    if (tableExists(this.db, 'qe_pattern_embeddings') && !columnExists(this.db, 'qe_pattern_embeddings', 'space_id')) {
+      this.db.exec('ALTER TABLE qe_pattern_embeddings ADD COLUMN space_id TEXT');
+      this.db.exec('CREATE INDEX IF NOT EXISTS idx_qe_pattern_embeddings_space ON qe_pattern_embeddings(space_id)');
+    }
+  }
+
+  private activeSpaceId(): string | undefined {
+    return getActiveEmbeddingSpaceIdentity()?.spaceId ?? this.config.embeddingSpaceId;
   }
 
   /**
@@ -204,6 +215,11 @@ export class RvfDualWriter {
       }
 
       this.rvfStore = wrapNativeAdapter(nativeAdapter, this.config.dimensions);
+      verifyOrCreateEmbeddingSpaceManifest(
+        this.config.rvfPath,
+        this.activeSpaceId() ?? null,
+        this.rvfStore.status().totalVectors,
+      );
       this.rvfAvailable = true;
     } catch (err) {
       // Native adapter unavailable, or recovery itself failed. Degrade to
@@ -239,7 +255,7 @@ export class RvfDualWriter {
       rvfSuccess: false,
     };
     const hasSpaceContract = columnExists(this.db, 'qe_pattern_embeddings', 'space_id');
-    if (hasSpaceContract && !getActiveEmbeddingSpaceIdentity()?.spaceId) {
+    if (!hasSpaceContract || !this.activeSpaceId()) {
       return { ...result, divergence: 'VECTOR_SPACE_UNVERIFIED' };
     }
 
@@ -462,8 +478,8 @@ export class RvfDualWriter {
   }
 
   private hasCompatibleEmbeddingSpace(): boolean {
-    if (!columnExists(this.db, 'qe_pattern_embeddings', 'space_id')) return true;
-    const activeSpaceId = getActiveEmbeddingSpaceIdentity()?.spaceId;
+    if (!columnExists(this.db, 'qe_pattern_embeddings', 'space_id')) return false;
+    const activeSpaceId = this.activeSpaceId();
     if (!activeSpaceId) return false;
     const row = this.db.prepare(`
       SELECT COUNT(*) AS incompatible
@@ -483,7 +499,7 @@ export class RvfDualWriter {
 
     // Upsert into qe_pattern_embeddings
     if (tableExists(this.db, 'qe_pattern_embeddings')) {
-      const spaceId = getActiveEmbeddingSpaceIdentity()?.spaceId;
+      const spaceId = this.activeSpaceId();
       if (columnExists(this.db, 'qe_pattern_embeddings', 'space_id')) {
         if (!spaceId) throw new Error('VECTOR_SPACE_UNVERIFIED: dual writer has no runtime provenance');
         this.db.prepare(`
@@ -497,14 +513,7 @@ export class RvfDualWriter {
         `).run(patternId, blob, dimension, spaceId);
         return;
       }
-      this.db.prepare(`
-        INSERT INTO qe_pattern_embeddings (pattern_id, embedding, dimension, model, created_at)
-        VALUES (?, ?, ?, 'all-MiniLM-L6-v2', datetime('now'))
-        ON CONFLICT(pattern_id) DO UPDATE SET
-          embedding = excluded.embedding,
-          dimension = excluded.dimension,
-          created_at = datetime('now')
-      `).run(patternId, blob, dimension);
+      throw new Error('VECTOR_SPACE_UNVERIFIED: canonical space_id column is unavailable');
     }
   }
 
@@ -533,14 +542,12 @@ export class RvfDualWriter {
   private searchSqlite(query: number[] | Float32Array, k: number): Array<{ id: string; score: number }> {
     if (!tableExists(this.db, 'qe_pattern_embeddings')) return [];
 
-    const activeSpaceId = getActiveEmbeddingSpaceIdentity()?.spaceId;
+    const activeSpaceId = this.activeSpaceId();
     const hasSpaceContract = columnExists(this.db, 'qe_pattern_embeddings', 'space_id');
-    if (hasSpaceContract && !activeSpaceId) return [];
+    if (!hasSpaceContract || !activeSpaceId) return [];
     const rows = this.db.prepare(
-      hasSpaceContract
-        ? 'SELECT pattern_id, embedding, dimension FROM qe_pattern_embeddings WHERE space_id = ?'
-        : 'SELECT pattern_id, embedding, dimension FROM qe_pattern_embeddings'
-    ).all(...(hasSpaceContract ? [activeSpaceId] : [])) as Array<{ pattern_id: string; embedding: Buffer; dimension: number }>;
+      'SELECT pattern_id, embedding, dimension FROM qe_pattern_embeddings WHERE space_id = ?'
+    ).all(activeSpaceId) as Array<{ pattern_id: string; embedding: Buffer; dimension: number }>;
 
     const queryArr = query instanceof Float32Array ? Array.from(query) : query;
     const queryMag = Math.sqrt(queryArr.reduce((s, v) => s + v * v, 0));

--- a/src/integrations/ruvector/rvf-dual-writer.ts
+++ b/src/integrations/ruvector/rvf-dual-writer.ts
@@ -15,6 +15,7 @@ import type {
   RvfNativeAdapter,
   RvfStatus as NativeRvfStatus,
 } from './rvf-native-adapter.js';
+import { getActiveEmbeddingSpaceIdentity } from '../../learning/real-embeddings.js';
 
 // ============================================================================
 // Types
@@ -135,6 +136,11 @@ function tableExists(db: SqliteDb, name: string): boolean {
   return (row?.cnt ?? 0) > 0;
 }
 
+function columnExists(db: SqliteDb, table: string, column: string): boolean {
+  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+  return rows.some((row) => row.name === column);
+}
+
 // ============================================================================
 // RvfDualWriter
 // ============================================================================
@@ -232,6 +238,10 @@ export class RvfDualWriter {
       sqliteSuccess: false,
       rvfSuccess: false,
     };
+    const hasSpaceContract = columnExists(this.db, 'qe_pattern_embeddings', 'space_id');
+    if (hasSpaceContract && !getActiveEmbeddingSpaceIdentity()?.spaceId) {
+      return { ...result, divergence: 'VECTOR_SPACE_UNVERIFIED' };
+    }
 
     // 1. Always write to SQLite qe_pattern_embeddings
     try {
@@ -302,6 +312,7 @@ export class RvfDualWriter {
    * falls back to SQLite on error. Otherwise uses SQLite.
    */
   search(query: number[] | Float32Array, k: number): Array<{ id: string; score: number }> {
+    if (!this.hasCompatibleEmbeddingSpace()) return [];
     if (this.config.mode === 'rvf-primary' && this.rvfAvailable && this.rvfStore) {
       try {
         return this.rvfStore.search(query, k);
@@ -450,6 +461,18 @@ export class RvfDualWriter {
     );
   }
 
+  private hasCompatibleEmbeddingSpace(): boolean {
+    if (!columnExists(this.db, 'qe_pattern_embeddings', 'space_id')) return true;
+    const activeSpaceId = getActiveEmbeddingSpaceIdentity()?.spaceId;
+    if (!activeSpaceId) return false;
+    const row = this.db.prepare(`
+      SELECT COUNT(*) AS incompatible
+        FROM qe_pattern_embeddings
+       WHERE space_id IS NULL OR space_id <> ?
+    `).get(activeSpaceId) as { incompatible: number } | undefined;
+    return (row?.incompatible ?? 0) === 0;
+  }
+
   private writeSqliteEmbedding(patternId: string, embedding: number[] | Float32Array): void {
     const blob = Buffer.from(
       embedding instanceof Float32Array
@@ -460,6 +483,20 @@ export class RvfDualWriter {
 
     // Upsert into qe_pattern_embeddings
     if (tableExists(this.db, 'qe_pattern_embeddings')) {
+      const spaceId = getActiveEmbeddingSpaceIdentity()?.spaceId;
+      if (columnExists(this.db, 'qe_pattern_embeddings', 'space_id')) {
+        if (!spaceId) throw new Error('VECTOR_SPACE_UNVERIFIED: dual writer has no runtime provenance');
+        this.db.prepare(`
+          INSERT INTO qe_pattern_embeddings (pattern_id, embedding, dimension, model, space_id, created_at)
+          VALUES (?, ?, ?, 'all-MiniLM-L6-v2', ?, datetime('now'))
+          ON CONFLICT(pattern_id) DO UPDATE SET
+            embedding = excluded.embedding,
+            dimension = excluded.dimension,
+            space_id = excluded.space_id,
+            created_at = datetime('now')
+        `).run(patternId, blob, dimension, spaceId);
+        return;
+      }
       this.db.prepare(`
         INSERT INTO qe_pattern_embeddings (pattern_id, embedding, dimension, model, created_at)
         VALUES (?, ?, ?, 'all-MiniLM-L6-v2', datetime('now'))
@@ -496,9 +533,14 @@ export class RvfDualWriter {
   private searchSqlite(query: number[] | Float32Array, k: number): Array<{ id: string; score: number }> {
     if (!tableExists(this.db, 'qe_pattern_embeddings')) return [];
 
+    const activeSpaceId = getActiveEmbeddingSpaceIdentity()?.spaceId;
+    const hasSpaceContract = columnExists(this.db, 'qe_pattern_embeddings', 'space_id');
+    if (hasSpaceContract && !activeSpaceId) return [];
     const rows = this.db.prepare(
-      'SELECT pattern_id, embedding, dimension FROM qe_pattern_embeddings'
-    ).all() as Array<{ pattern_id: string; embedding: Buffer; dimension: number }>;
+      hasSpaceContract
+        ? 'SELECT pattern_id, embedding, dimension FROM qe_pattern_embeddings WHERE space_id = ?'
+        : 'SELECT pattern_id, embedding, dimension FROM qe_pattern_embeddings'
+    ).all(...(hasSpaceContract ? [activeSpaceId] : [])) as Array<{ pattern_id: string; embedding: Buffer; dimension: number }>;
 
     const queryArr = query instanceof Float32Array ? Array.from(query) : query;
     const queryMag = Math.sqrt(queryArr.reduce((s, v) => s + v * v, 0));

--- a/src/integrations/ruvector/rvf-dual-writer.ts
+++ b/src/integrations/ruvector/rvf-dual-writer.ts
@@ -167,7 +167,10 @@ export class RvfDualWriter {
   }
 
   private activeSpaceId(): string | undefined {
-    return getActiveEmbeddingSpaceIdentity()?.spaceId ?? this.config.embeddingSpaceId;
+    // An injected writer belongs to the embedder that constructed it.  A
+    // process-global identity may describe a different pipeline initialized by
+    // another subsystem, so it is only a fallback for legacy callers.
+    return this.config.embeddingSpaceId ?? getActiveEmbeddingSpaceIdentity()?.spaceId;
   }
 
   /**

--- a/src/integrations/ruvector/rvf-store-integrity.ts
+++ b/src/integrations/ruvector/rvf-store-integrity.ts
@@ -34,7 +34,7 @@ const LOCK_MAGIC = 'FLVR';
 const LOCK_PID_OFFSET = 4;
 
 /** Sidecars that belong to a store and must be quarantined alongside it. */
-const STORE_SIDECAR_SUFFIXES = ['', '.idmap.json', '.manifest.json'] as const;
+const STORE_SIDECAR_SUFFIXES = ['', '.idmap.json', '.manifest.json', '.space.json'] as const;
 
 /** Read the first `n` bytes of a file, or null if unreadable/shorter. */
 function readHead(path: string, n: number): Buffer | null {

--- a/src/kernel/unified-memory-schemas.ts
+++ b/src/kernel/unified-memory-schemas.ts
@@ -15,7 +15,7 @@ export { HYPERGRAPH_SCHEMA, PATTERN_NULLS_SCHEMA };
 // Schema Version for Migrations
 // ============================================================================
 
-export const SCHEMA_VERSION = 11; // v11: adds goap_execution_steps — canonical GOAP execution history (A14)
+export const SCHEMA_VERSION = 12; // v12: embedding-space provenance for semantic vectors (#633)
 
 export const SCHEMA_VERSION_TABLE = `
   CREATE TABLE IF NOT EXISTS schema_version (

--- a/src/kernel/unified-memory-schemas.ts
+++ b/src/kernel/unified-memory-schemas.ts
@@ -301,6 +301,7 @@ export const QE_PATTERNS_SCHEMA = `
     embedding BLOB NOT NULL,
     dimension INTEGER NOT NULL,
     model TEXT DEFAULT 'all-MiniLM-L6-v2',
+    space_id TEXT,
     created_at TEXT DEFAULT (datetime('now')),
     FOREIGN KEY (pattern_id) REFERENCES qe_patterns(id) ON DELETE CASCADE
   );
@@ -407,6 +408,7 @@ export const QE_PATTERNS_SCHEMA = `
   CREATE INDEX IF NOT EXISTS idx_qe_patterns_type ON qe_patterns(pattern_type);
   CREATE INDEX IF NOT EXISTS idx_qe_patterns_tier ON qe_patterns(tier);
   CREATE INDEX IF NOT EXISTS idx_qe_patterns_quality ON qe_patterns(quality_score DESC);
+  CREATE INDEX IF NOT EXISTS idx_qe_pattern_embeddings_space ON qe_pattern_embeddings(space_id);
   CREATE INDEX IF NOT EXISTS idx_qe_usage_pattern ON qe_pattern_usage(pattern_id);
   CREATE INDEX IF NOT EXISTS idx_qe_trajectories_domain ON qe_trajectories(domain);
   CREATE INDEX IF NOT EXISTS idx_embeddings_namespace ON embeddings(namespace);

--- a/src/kernel/unified-memory.ts
+++ b/src/kernel/unified-memory.ts
@@ -573,6 +573,7 @@ export class UnifiedMemoryManager {
         }
         if (currentVersion < 10) this.db!.exec(PATTERN_NULLS_SCHEMA);
         if (currentVersion < 11) this.migrateToV11GoapExecutionSteps();
+        if (currentVersion < 12) this.migrateToV12EmbeddingSpace();
 
         this.db!.prepare(`
           INSERT OR REPLACE INTO schema_version (id, version, migrated_at)
@@ -932,6 +933,23 @@ export class UnifiedMemoryManager {
         metadata: row?.metadata ? safeJsonParse(row.metadata) : undefined,
       };
     });
+  }
+
+  /** Additive provenance migration. Existing vectors remain explicitly unverified. */
+  private migrateToV12EmbeddingSpace(): void {
+    const db = this.db!;
+    const table = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='qe_pattern_embeddings'",
+    ).get();
+    if (!table) {
+      db.exec(QE_PATTERNS_SCHEMA);
+      return;
+    }
+    const columns = db.prepare("PRAGMA table_info('qe_pattern_embeddings')").all() as Array<{ name: string }>;
+    if (!columns.some((column) => column.name === 'space_id')) {
+      db.exec('ALTER TABLE qe_pattern_embeddings ADD COLUMN space_id TEXT');
+    }
+    db.exec('CREATE INDEX IF NOT EXISTS idx_qe_pattern_embeddings_space ON qe_pattern_embeddings(space_id)');
   }
 
   getVectorSearchProvenance(): VectorSearchProvenance {

--- a/src/learning/embed-and-insert-pattern.ts
+++ b/src/learning/embed-and-insert-pattern.ts
@@ -23,6 +23,7 @@ import type Database from 'better-sqlite3';
 import {
   computeRealEmbedding,
   DEFAULT_EMBEDDING_CONFIG,
+  getActiveEmbeddingSpaceIdentity,
   type EmbeddingConfig,
 } from './real-embeddings.js';
 
@@ -55,11 +56,13 @@ export async function ensurePatternEmbedding(
 
     const buffer = Buffer.from(new Float32Array(embedding).buffer);
     const fullConfig = { ...DEFAULT_EMBEDDING_CONFIG, ...config };
+    const spaceId = getActiveEmbeddingSpaceIdentity()?.spaceId;
+    if (!spaceId) throw new Error('VECTOR_SPACE_UNVERIFIED: embedder has no runtime provenance');
 
     db.prepare(
-      `INSERT OR REPLACE INTO qe_pattern_embeddings (pattern_id, embedding, dimension, model)
-       VALUES (?, ?, ?, ?)`,
-    ).run(patternId, buffer, embedding.length, fullConfig.modelName);
+      `INSERT OR REPLACE INTO qe_pattern_embeddings (pattern_id, embedding, dimension, model, space_id)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run(patternId, buffer, embedding.length, fullConfig.modelName, spaceId);
   } catch (error) {
     // Non-fatal: pattern row already persisted; embedding can be backfilled later.
     console.debug(

--- a/src/learning/embedding-space.ts
+++ b/src/learning/embedding-space.ts
@@ -1,0 +1,135 @@
+/**
+ * Executable embedding-space provenance (#633).
+ *
+ * Model names and dimensions are declarations, not proof that two vectors are
+ * comparable.  An embedding space is therefore identified by canonical runtime
+ * configuration plus a fingerprint of a fixed canary vector.
+ */
+
+import { createHash } from 'node:crypto';
+import { cosineSimilarity } from '../shared/utils/vector-math.js';
+
+export const EMBEDDING_SPACE_CANARY = 'aqe embedding-space compatibility canary v1';
+export const EMBEDDING_ROUND_TRIP_MIN_COSINE = 0.999;
+
+export interface EmbeddingSpaceIdentity {
+  provider: string;
+  model: string;
+  dimensions: number;
+  pooling?: string;
+  normalized: boolean;
+  preprocessingVersion?: string;
+  implementation?: string;
+  runtimeFingerprint: string;
+  spaceId: string;
+}
+
+export type EmbeddingSpaceStatus = 'healthy' | 'vector_space_mismatch' | 'unverified';
+
+export interface EmbeddingSpaceDiagnostics {
+  status: EmbeddingSpaceStatus;
+  activeSpaceId: string | null;
+  storedSpaceIds: string[];
+  verifiedVectors: number;
+  mismatchedVectors: number;
+  unverifiedVectors: number;
+}
+
+export class EmbeddingSpaceError extends Error {
+  constructor(
+    readonly code: 'VECTOR_SPACE_MISMATCH' | 'VECTOR_SPACE_UNVERIFIED',
+    message: string,
+  ) {
+    super(`${code}: ${message}`);
+    this.name = 'EmbeddingSpaceError';
+  }
+}
+
+function canonicalIdentity(identity: Omit<EmbeddingSpaceIdentity, 'spaceId'>): string {
+  return JSON.stringify({
+    provider: identity.provider,
+    model: identity.model,
+    dimensions: identity.dimensions,
+    pooling: identity.pooling ?? null,
+    normalized: identity.normalized,
+    preprocessingVersion: identity.preprocessingVersion ?? null,
+    implementation: identity.implementation ?? null,
+    runtimeFingerprint: identity.runtimeFingerprint,
+  });
+}
+
+/** Fingerprint a normalized canary vector after stable int16 quantization. */
+export function fingerprintEmbeddingRuntime(vector: readonly number[]): string {
+  const bytes = Buffer.alloc(vector.length * 2);
+  for (let i = 0; i < vector.length; i++) {
+    const quantized = Math.max(-32768, Math.min(32767, Math.round(vector[i] * 32767)));
+    bytes.writeInt16LE(quantized, i * 2);
+  }
+  return createHash('sha256').update(bytes).digest('hex').slice(0, 16);
+}
+
+export function deriveEmbeddingSpaceIdentity(
+  identity: Omit<EmbeddingSpaceIdentity, 'spaceId'>,
+): EmbeddingSpaceIdentity {
+  if (!identity.runtimeFingerprint) {
+    throw new Error('Embedding space identity requires executable runtime evidence');
+  }
+  const spaceId = createHash('sha256')
+    .update('aqe:embedding-space:v1\0')
+    .update(canonicalIdentity(identity))
+    .digest('hex');
+  return { ...identity, spaceId };
+}
+
+/** Execute the same-text write/read canary before semantic ranking is trusted. */
+export async function verifyEmbeddingRoundTrip(
+  writeEmbed: (text: string) => Promise<number[]>,
+  queryEmbed: (text: string) => Promise<number[]>,
+  minimumCosine = EMBEDDING_ROUND_TRIP_MIN_COSINE,
+): Promise<number> {
+  const [written, queried] = await Promise.all([
+    writeEmbed(EMBEDDING_SPACE_CANARY),
+    queryEmbed(EMBEDDING_SPACE_CANARY),
+  ]);
+  if (written.length !== queried.length) {
+    throw new EmbeddingSpaceError(
+      'VECTOR_SPACE_MISMATCH',
+      `round-trip dimensions differ (${written.length} != ${queried.length})`,
+    );
+  }
+  const similarity = cosineSimilarity(written, queried);
+  if (!Number.isFinite(similarity) || similarity < minimumCosine) {
+    throw new EmbeddingSpaceError(
+      'VECTOR_SPACE_MISMATCH',
+      `write/read canary cosine ${similarity.toFixed(6)} is below ${minimumCosine}`,
+    );
+  }
+  return similarity;
+}
+
+export function inspectEmbeddingSpaceRows(
+  rows: ReadonlyArray<{ spaceId: string | null }>,
+  activeSpaceId: string | null,
+): EmbeddingSpaceDiagnostics {
+  const storedSpaceIds = [...new Set(rows.flatMap((row) => row.spaceId ? [row.spaceId] : []))].sort();
+  const unverifiedVectors = rows.filter((row) => !row.spaceId).length;
+  const verifiedVectors = activeSpaceId
+    ? rows.filter((row) => row.spaceId === activeSpaceId).length
+    : 0;
+  const mismatchedVectors = activeSpaceId
+    ? rows.filter((row) => row.spaceId !== null && row.spaceId !== activeSpaceId).length
+    : rows.length - unverifiedVectors;
+  const status: EmbeddingSpaceStatus = unverifiedVectors > 0 || !activeSpaceId
+    ? 'unverified'
+    : mismatchedVectors > 0 || storedSpaceIds.length > 1
+      ? 'vector_space_mismatch'
+      : 'healthy';
+  return {
+    status,
+    activeSpaceId,
+    storedSpaceIds,
+    verifiedVectors,
+    mismatchedVectors,
+    unverifiedVectors,
+  };
+}

--- a/src/learning/embedding-space.ts
+++ b/src/learning/embedding-space.ts
@@ -7,6 +7,7 @@
  */
 
 import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
 import { cosineSimilarity } from '../shared/utils/vector-math.js';
 
 export const EMBEDDING_SPACE_CANARY = 'aqe embedding-space compatibility canary v1';
@@ -33,6 +34,11 @@ export interface EmbeddingSpaceDiagnostics {
   verifiedVectors: number;
   mismatchedVectors: number;
   unverifiedVectors: number;
+}
+
+interface EmbeddingSpaceManifest {
+  version: 1;
+  spaceId: string;
 }
 
 export class EmbeddingSpaceError extends Error {
@@ -132,4 +138,65 @@ export function inspectEmbeddingSpaceRows(
     mismatchedVectors,
     unverifiedVectors,
   };
+}
+
+/** Sidecar path used to bind a persistent ANN index to one embedding space. */
+export function embeddingSpaceManifestPath(indexPath: string): string {
+  return `${indexPath}.space.json`;
+}
+
+/**
+ * Bind an empty persistent index to the active space, or verify an existing
+ * binding. A populated index without a manifest is legacy/unverified and must
+ * be rebuilt rather than silently adopted by the current runtime.
+ */
+export function verifyOrCreateEmbeddingSpaceManifest(
+  indexPath: string,
+  activeSpaceId: string | null,
+  vectorCount: number,
+): void {
+  if (!activeSpaceId) {
+    throw new EmbeddingSpaceError(
+      'VECTOR_SPACE_UNVERIFIED',
+      `cannot open ANN index ${indexPath} without runtime provenance`,
+    );
+  }
+
+  const manifestPath = embeddingSpaceManifestPath(indexPath);
+  if (existsSync(manifestPath)) {
+    let manifest: EmbeddingSpaceManifest;
+    try {
+      manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as EmbeddingSpaceManifest;
+    } catch {
+      throw new EmbeddingSpaceError(
+        'VECTOR_SPACE_UNVERIFIED',
+        `ANN index manifest ${manifestPath} is unreadable`,
+      );
+    }
+    if (manifest.version !== 1 || !manifest.spaceId) {
+      throw new EmbeddingSpaceError(
+        'VECTOR_SPACE_UNVERIFIED',
+        `ANN index manifest ${manifestPath} has no verified space`,
+      );
+    }
+    if (manifest.spaceId !== activeSpaceId) {
+      throw new EmbeddingSpaceError(
+        'VECTOR_SPACE_MISMATCH',
+        `ANN index space ${manifest.spaceId} != active space ${activeSpaceId}`,
+      );
+    }
+    return;
+  }
+
+  if (vectorCount > 0) {
+    throw new EmbeddingSpaceError(
+      'VECTOR_SPACE_UNVERIFIED',
+      `populated ANN index ${indexPath} has no embedding-space manifest; rebuild required`,
+    );
+  }
+
+  const manifest: EmbeddingSpaceManifest = { version: 1, spaceId: activeSpaceId };
+  const temporaryPath = `${manifestPath}.${process.pid}.tmp`;
+  writeFileSync(temporaryPath, `${JSON.stringify(manifest)}\n`, { encoding: 'utf8', mode: 0o600 });
+  renameSync(temporaryPath, manifestPath);
 }

--- a/src/learning/pattern-store.ts
+++ b/src/learning/pattern-store.ts
@@ -65,6 +65,7 @@ import {
   type HyperbolicPatternResult,
 } from './hyperbolic-pattern-index.js';
 import { PatternNullStore, type NullSummary } from './pattern-null-store.js';
+import { getActiveEmbeddingSpaceIdentity } from './real-embeddings.js';
 
 // ============================================================================
 // R1: HDC Fingerprint Singleton (lazy-initialized)
@@ -160,6 +161,9 @@ export interface PatternStoreConfig {
 
   /** Dimension of embedding vectors */
   embeddingDimension: number;
+
+  /** Runtime-provided provenance override (primarily for injected embedders/tests). */
+  embeddingSpaceId?: string;
 
   /** HNSW configuration */
   hnsw: {
@@ -301,6 +305,9 @@ export interface PatternSearchOptions {
   /** Include vector similarity search */
   useVectorSearch?: boolean;
 
+  /** Provenance of a pre-computed query vector. Required for semantic ranking. */
+  embeddingSpaceId?: string;
+
   /**
    * Composable metadata filter expression (Task 1.2: ruvector-filter).
    * Applied post-search to refine results by domain, severity,
@@ -431,6 +438,7 @@ export class PatternStore implements IPatternStore {
   // HNSW index for vector search (lazy loaded - ADR-048)
   // Using dynamic import type since HNSWIndex is lazily loaded
   private hnswIndex: import('../domains/coverage-analysis/services/hnsw-index.js').IHNSWIndex | null = null;
+  private hnswSpaceId: string | null = null;
   private hnswAvailable = false;
   private hnswInitPromise: Promise<void> | null = null;
 
@@ -539,6 +547,11 @@ export class PatternStore implements IPatternStore {
   private async ensureHNSW(): Promise<import('../domains/coverage-analysis/services/hnsw-index.js').IHNSWIndex | null> {
     // Already initialized
     if (this.hnswIndex !== null) {
+      const activeSpaceId = getActiveEmbeddingSpaceIdentity()?.spaceId ?? this.config.embeddingSpaceId ?? null;
+      if (this.hnswSpaceId !== activeSpaceId) {
+        console.warn('[PatternStore] VECTOR_SPACE_MISMATCH: active embedder changed; semantic index disabled');
+        return null;
+      }
       return this.hnswIndex;
     }
 
@@ -571,6 +584,10 @@ export class PatternStore implements IPatternStore {
    */
   private async initializeHNSWInternal(): Promise<void> {
     try {
+      this.hnswSpaceId = getActiveEmbeddingSpaceIdentity()?.spaceId ?? this.config.embeddingSpaceId ?? null;
+      if (!this.hnswSpaceId) {
+        throw new Error('VECTOR_SPACE_UNVERIFIED: cannot initialize HNSW without runtime provenance');
+      }
       // ADR-071: Use unified HNSW via bridge when flag is enabled
       const unifiedFlags = getRuVectorFeatureFlags();
       if (unifiedFlags.useUnifiedHnsw) {
@@ -653,9 +670,10 @@ export class PatternStore implements IPatternStore {
       const maxBootstrap = this.config.hnsw.maxElements;
       let loaded = 0;
       let skipped = 0;
-      for (const { patternId, embedding } of embeddings) {
+      const activeSpaceId = getActiveEmbeddingSpaceIdentity()?.spaceId ?? this.config.embeddingSpaceId;
+      for (const { patternId, embedding, spaceId } of embeddings) {
         if (loaded >= maxBootstrap) break;
-        if (!embedding || embedding.length !== this.config.embeddingDimension) {
+        if (!activeSpaceId || spaceId !== activeSpaceId || !embedding || embedding.length !== this.config.embeddingDimension) {
           skipped++;
           continue;
         }
@@ -801,6 +819,10 @@ export class PatternStore implements IPatternStore {
         )
       );
     }
+    const activeSpaceId = getActiveEmbeddingSpaceIdentity()?.spaceId ?? this.config.embeddingSpaceId;
+    if (pattern.embedding && !activeSpaceId) {
+      return err(new Error('VECTOR_SPACE_UNVERIFIED: refusing to persist or index an embedding without runtime provenance'));
+    }
 
     // Check domain limit
     const domainCount = this.domainIndex.get(pattern.qeDomain)?.size || 0;
@@ -818,7 +840,7 @@ export class PatternStore implements IPatternStore {
     // Persist to SQLite (pattern + embedding atomically)
     if (this.sqliteStore) {
       try {
-        const actualId = this.sqliteStore.storePattern(pattern, pattern.embedding);
+        const actualId = this.sqliteStore.storePattern(pattern, pattern.embedding, activeSpaceId);
         // #447: ON CONFLICT(name, qe_domain, pattern_type) may preserve an
         // existing row's id instead of the one we generated — realign the
         // in-memory indices (and pattern.id itself) or every later
@@ -1091,6 +1113,12 @@ export class PatternStore implements IPatternStore {
 
       // Vector search if query is embedding and HNSW available (lazy-load)
       if (Array.isArray(query) && options.useVectorSearch !== false) {
+        const activeSpaceId = getActiveEmbeddingSpaceIdentity()?.spaceId ?? this.config.embeddingSpaceId;
+        if (!activeSpaceId || options.embeddingSpaceId !== activeSpaceId) {
+          throw new Error(
+            'VECTOR_SPACE_UNVERIFIED: pre-computed query vectors require the active embeddingSpaceId',
+          );
+        }
         const hnsw = await this.ensureHNSW();
         if (hnsw) {
           const hnswResults = await hnsw.search(query, limit * 2);
@@ -1999,4 +2027,3 @@ export function createPatternStore(
 
   return new PatternStore(memory, config);
 }
-

--- a/src/learning/pattern-store.ts
+++ b/src/learning/pattern-store.ts
@@ -7,6 +7,8 @@
  */
 
 import { v4 as uuidv4 } from 'uuid';
+import { existsSync } from 'node:fs';
+import { join as joinPath } from 'node:path';
 import type { MemoryBackend } from '../kernel/interfaces.js';
 // Issue #516: lightweight, sqlite-free project-root resolver (static import so it
 // resolves under the test runner; avoids pulling unified-memory's sqlite graph).
@@ -1939,8 +1941,6 @@ export function createPatternStore(
       // Only use RVF if the data directory exists (created by kernel init).
       // Issue #516: anchor to the project root so a subfolder cwd reads/writes
       // the project's own .agentic-qe/ rather than a cwd-relative stray store.
-      const { existsSync } = require('fs');
-      const { join: joinPath } = require('path');
       const projectRoot = process.env.AQE_PROJECT_ROOT ?? findProjectRoot();
       const rvfDir = joinPath(projectRoot, '.agentic-qe');
       const rvfPath = joinPath(rvfDir, 'patterns.rvf');
@@ -1962,7 +1962,12 @@ export function createPatternStore(
             useSharedAdapter = true;
             const store = new RvfPatternStore(
               () => shared,
-              { rvfPath, base: mergedConfig, skipCloseOnDispose: true },
+              {
+                rvfPath,
+                base: mergedConfig,
+                skipCloseOnDispose: true,
+                embeddingSpaceId: mergedConfig.embeddingSpaceId,
+              },
             );
             console.log('[PatternStore] Using RVF-backed store (ADR-066)');
             return store;
@@ -2013,7 +2018,11 @@ export function createPatternStore(
                 throw createErr;
               }
             },
-            { rvfPath, base: mergedConfig },
+            {
+              rvfPath,
+              base: mergedConfig,
+              embeddingSpaceId: mergedConfig.embeddingSpaceId,
+            },
           );
           console.log('[PatternStore] Using RVF-backed store (ADR-066)');
           return store;

--- a/src/learning/qe-flywheel/coupled-anchor.ts
+++ b/src/learning/qe-flywheel/coupled-anchor.ts
@@ -184,7 +184,6 @@ export interface SemanticRetrieverOptions {
  */
 export function createSemanticRetriever(opts: SemanticRetrieverOptions): RetrieveFn {
   const embed = opts.embed ?? ((t: string) => computeRealEmbedding(t));
-  const writeEmbed = opts.writeEmbed ?? embed;
   const topK = opts.topK ?? 3;
   const hasSpaceId = (opts.db.prepare("PRAGMA table_info('qe_pattern_embeddings')").all() as Array<{ name: string }>)
     .some((column) => column.name === 'space_id');
@@ -208,8 +207,21 @@ export function createSemanticRetriever(opts: SemanticRetrieverOptions): Retriev
   return async (query: string, policy: RetrievalPolicy): Promise<RetrievedExample[]> => {
     if (docs.length === 0) return [];
     try {
-      compatibilityCheck ??= verifyEmbeddingRoundTrip(writeEmbed, embed);
-      await compatibilityCheck;
+      if (!opts.writeEmbed) {
+        throw new EmbeddingSpaceError(
+          'VECTOR_SPACE_UNVERIFIED',
+          'an independent storage-side embedder is required for the write/read canary',
+        );
+      }
+      if (!compatibilityCheck) {
+        compatibilityCheck = verifyEmbeddingRoundTrip(opts.writeEmbed, embed);
+      }
+      try {
+        await compatibilityCheck;
+      } catch (error) {
+        compatibilityCheck = null;
+        throw error;
+      }
       const activeIdentity = opts.embeddingSpace ?? getActiveEmbeddingSpaceIdentity();
       const writeIdentity = opts.writeEmbeddingSpace ?? activeIdentity;
       if (!activeIdentity || !writeIdentity) {

--- a/src/learning/qe-flywheel/coupled-anchor.ts
+++ b/src/learning/qe-flywheel/coupled-anchor.ts
@@ -22,7 +22,13 @@
  */
 
 import type { Database as DatabaseType } from 'better-sqlite3';
-import { computeRealEmbedding } from '../real-embeddings.js';
+import { computeRealEmbedding, getActiveEmbeddingSpaceIdentity } from '../real-embeddings.js';
+import {
+  EmbeddingSpaceError,
+  inspectEmbeddingSpaceRows,
+  verifyEmbeddingRoundTrip,
+  type EmbeddingSpaceIdentity,
+} from '../embedding-space.js';
 import { evaluateOracle } from '../../validation/oracle-eval.js';
 import { loadAnchorSet, anchorMean as meanOf, type AnchorItem } from '../../validation/anchor-set.js';
 import type { RetrievalPolicy } from './policy.js';
@@ -154,6 +160,13 @@ export interface SemanticRetrieverOptions {
   db: DatabaseType;
   /** Embed a query into the pattern-embedding space. Default: all-MiniLM-L6-v2. */
   embed?: (text: string) => Promise<number[]>;
+  /** Storage-side embedding path used by the executable round-trip canary. */
+  writeEmbed?: (text: string) => Promise<number[]>;
+  /** Runtime identities for injected embedders. Defaults to the active AQE embedder. */
+  embeddingSpace?: EmbeddingSpaceIdentity;
+  writeEmbeddingSpace?: EmbeddingSpaceIdentity;
+  /** Explicit non-semantic fallback used when provenance cannot be verified. */
+  fallback?: RetrieveFn;
   topK?: number;
 }
 
@@ -171,25 +184,73 @@ export interface SemanticRetrieverOptions {
  */
 export function createSemanticRetriever(opts: SemanticRetrieverOptions): RetrieveFn {
   const embed = opts.embed ?? ((t: string) => computeRealEmbedding(t));
+  const writeEmbed = opts.writeEmbed ?? embed;
   const topK = opts.topK ?? 3;
+  const hasSpaceId = (opts.db.prepare("PRAGMA table_info('qe_pattern_embeddings')").all() as Array<{ name: string }>)
+    .some((column) => column.name === 'space_id');
   const rows = opts.db.prepare(
     `SELECT p.id AS id, p.name AS name, COALESCE(p.description,'') AS body,
-            e.embedding AS embedding, e.dimension AS dimension
+            e.embedding AS embedding, e.dimension AS dimension, ${hasSpaceId ? 'e.space_id' : 'NULL'} AS space_id
        FROM qe_patterns p JOIN qe_pattern_embeddings e ON e.pattern_id = p.id
       WHERE p.deprecated_at IS NULL`,
-  ).all() as { id: string; name: string; body: string; embedding: Buffer; dimension: number }[];
+  ).all() as { id: string; name: string; body: string; embedding: Buffer; dimension: number; space_id: string | null }[];
 
   const toks = (s: string) => new Set(s.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean));
   const docs = rows.map((r) => ({
-    id: r.id, name: r.name, body: r.body,
+    id: r.id, name: r.name, body: r.body, spaceId: r.space_id,
     vec: new Float32Array(r.embedding.buffer, r.embedding.byteOffset, r.dimension),
     nameToks: toks(r.name), bodyToks: toks(r.body),
   }));
 
   const queryCache = new Map<string, Float32Array>();
+  let compatibilityCheck: Promise<number> | null = null;
 
   return async (query: string, policy: RetrievalPolicy): Promise<RetrievedExample[]> => {
     if (docs.length === 0) return [];
+    try {
+      compatibilityCheck ??= verifyEmbeddingRoundTrip(writeEmbed, embed);
+      await compatibilityCheck;
+      const activeIdentity = opts.embeddingSpace ?? getActiveEmbeddingSpaceIdentity();
+      const writeIdentity = opts.writeEmbeddingSpace ?? activeIdentity;
+      if (!activeIdentity || !writeIdentity) {
+        throw new EmbeddingSpaceError(
+          'VECTOR_SPACE_UNVERIFIED',
+          'runtime embedding-space identity is unavailable',
+        );
+      }
+      if (writeIdentity.spaceId !== activeIdentity.spaceId) {
+        throw new EmbeddingSpaceError(
+          'VECTOR_SPACE_MISMATCH',
+          `write space ${writeIdentity.spaceId} != query space ${activeIdentity.spaceId}`,
+        );
+      }
+      const invalidDimensions = docs.filter((doc) => doc.vec.length !== activeIdentity.dimensions);
+      if (invalidDimensions.length > 0) {
+        throw new EmbeddingSpaceError(
+          'VECTOR_SPACE_MISMATCH',
+          `${invalidDimensions.length} stored vectors have dimensions incompatible with ${activeIdentity.dimensions}`,
+        );
+      }
+      const diagnostics = inspectEmbeddingSpaceRows(
+        docs.map((doc) => ({ spaceId: doc.spaceId })),
+        activeIdentity.spaceId,
+      );
+      if (diagnostics.unverifiedVectors > 0) {
+        throw new EmbeddingSpaceError(
+          'VECTOR_SPACE_UNVERIFIED',
+          `${diagnostics.unverifiedVectors} stored vectors have no provenance`,
+        );
+      }
+      if (diagnostics.status === 'vector_space_mismatch') {
+        throw new EmbeddingSpaceError(
+          'VECTOR_SPACE_MISMATCH',
+          `stored spaces [${diagnostics.storedSpaceIds.join(', ')}] do not match ${activeIdentity.spaceId}`,
+        );
+      }
+    } catch (error) {
+      if (opts.fallback) return opts.fallback(query, policy);
+      throw error;
+    }
     let qv = queryCache.get(query);
     if (!qv) { qv = new Float32Array(await embed(query)); queryCache.set(query, qv); }
     const q = toks(query);

--- a/src/learning/qe-reasoning-bank.ts
+++ b/src/learning/qe-reasoning-bank.ts
@@ -51,6 +51,7 @@ import {
 } from './sqlite-persistence.js';
 import { getWitnessChain } from '../audit/witness-chain.js';
 import type { RvfDualWriter } from '../integrations/ruvector/rvf-dual-writer.js';
+import { getActiveEmbeddingSpaceIdentity } from './real-embeddings.js';
 
 // Import extracted modules
 import { DEFAULT_QE_REASONING_BANK_CONFIG } from './qe-reasoning-bank-types.js';
@@ -399,6 +400,9 @@ export class QEReasoningBank implements IQEReasoningBank {
     return this.patternStore.search(searchQuery, {
       ...options,
       useVectorSearch,
+      embeddingSpaceId: typeof query === 'string'
+        ? getActiveEmbeddingSpaceIdentity()?.spaceId
+        : options?.embeddingSpaceId,
     });
   }
 

--- a/src/learning/real-embeddings.ts
+++ b/src/learning/real-embeddings.ts
@@ -19,6 +19,12 @@ import {
   resetEmbedderIdentityStore,
   saveEmbedderIdentity,
 } from './embedder-identity-store.js';
+import {
+  EMBEDDING_SPACE_CANARY,
+  deriveEmbeddingSpaceIdentity,
+  fingerprintEmbeddingRuntime,
+  type EmbeddingSpaceIdentity,
+} from './embedding-space.js';
 
 /**
  * Type for the @xenova/transformers pipeline function
@@ -59,6 +65,7 @@ let failureReason = '';
  */
 let endpointClient: EmbedderEndpointClient | null = null;
 let endpointIdentity: EndpointIdentity | null = null;
+let activeEmbeddingSpaceIdentity: EmbeddingSpaceIdentity | null = null;
 
 /**
  * Embedding model configuration
@@ -182,6 +189,16 @@ async function initializeModel(config: Partial<EmbeddingConfig> = {}): Promise<v
         });
         // Probe + identity fingerprint. Fails loud on dim mismatch.
         endpointIdentity = await endpointClient.probe();
+        activeEmbeddingSpaceIdentity = deriveEmbeddingSpaceIdentity({
+          provider: 'openai-compatible-endpoint',
+          model: fullConfig.modelName,
+          dimensions: endpointIdentity.dim,
+          pooling: 'mean',
+          normalized: true,
+          preprocessingVersion: 'aqe-text-v1',
+          implementation: endpointIdentity.endpoint,
+          runtimeFingerprint: endpointIdentity.fingerprint,
+        });
         console.log(
           `[RealEmbeddings] Endpoint identity: dim=${endpointIdentity.dim} fingerprint=${endpointIdentity.fingerprint}`
         );
@@ -239,6 +256,24 @@ async function initializeModel(config: Partial<EmbeddingConfig> = {}): Promise<v
       // Create feature extraction pipeline
       embeddingModel = await pipeline('feature-extraction', fullConfig.modelName, {
         quantized: fullConfig.quantized,
+      });
+
+      const initializedModel = embeddingModel;
+      if (!initializedModel) throw new Error('Transformer pipeline returned no embedding model');
+      const canary = await initializedModel(EMBEDDING_SPACE_CANARY, {
+        pooling: 'mean',
+        normalize: true,
+      });
+      const canaryVector = Array.from(canary.data as Float32Array);
+      activeEmbeddingSpaceIdentity = deriveEmbeddingSpaceIdentity({
+        provider: 'huggingface-transformers',
+        model: fullConfig.modelName,
+        dimensions: canaryVector.length,
+        pooling: 'mean',
+        normalized: true,
+        preprocessingVersion: 'aqe-text-v1',
+        implementation: `transformers:${fullConfig.quantized ? 'quantized' : 'full'}`,
+        runtimeFingerprint: fingerprintEmbeddingRuntime(canaryVector),
       });
 
       const loadTime = performance.now() - startTime;
@@ -483,6 +518,7 @@ export function resetInitialization(): void {
   }
   endpointClient = null;
   endpointIdentity = null;
+  activeEmbeddingSpaceIdentity = null;
   // Drop the identity-store's cached DB connection so tests that flip cwd or
   // AQE_MEMORY_PATH between runs don't write into a stale handle.
   resetEmbedderIdentityStore();
@@ -501,4 +537,9 @@ export function isUsingEndpoint(): boolean {
  */
 export function getEndpointIdentity(): EndpointIdentity | null {
   return endpointIdentity;
+}
+
+/** Runtime-backed identity of the initialized embedding space. */
+export function getActiveEmbeddingSpaceIdentity(): EmbeddingSpaceIdentity | null {
+  return activeEmbeddingSpaceIdentity;
 }

--- a/src/learning/real-qe-reasoning-bank.ts
+++ b/src/learning/real-qe-reasoning-bank.ts
@@ -20,6 +20,7 @@ import { LoggerFactory } from '../logging/index.js';
 import type { Logger } from '../logging/index.js';
 import { toError, toErrorMessage } from '../shared/error-utils.js';
 import { maybeEnhanceRoutingWithPatterns } from './pattern-routing-guidance.js';
+import { EMBEDDING_SPACE_CANARY } from './embedding-space.js';
 
 const logger: Logger = LoggerFactory.create('RealQEReasoningBank');
 import {
@@ -27,6 +28,7 @@ import {
   isTransformerAvailable,
   getEmbeddingDimension,
   clearEmbeddingCache,
+  getActiveEmbeddingSpaceIdentity,
   type EmbeddingConfig,
 } from './real-embeddings.js';
 import {
@@ -329,6 +331,9 @@ export class RealQEReasoningBank {
     await this.sqliteStore.initialize();
     logger.info('SQLite persistence initialized');
 
+    // Establish executable provenance before any persisted vectors enter ANN.
+    await computeRealEmbedding(EMBEDDING_SPACE_CANARY, this.qeConfig.embeddings);
+
     // Initialize HNSW index
     await this.initializeHNSW();
     logger.info('HNSW index initialized');
@@ -406,9 +411,10 @@ export class RealQEReasoningBank {
     let loaded = 0;
     let skipped = 0;
 
-    for (const { patternId, embedding } of embeddings) {
+    const activeSpaceId = getActiveEmbeddingSpaceIdentity()?.spaceId;
+    for (const { patternId, embedding, spaceId } of embeddings) {
       // Skip invalid or corrupted embeddings
-      if (!embedding || !Array.isArray(embedding) || embedding.length !== expectedDim) {
+      if (!activeSpaceId || spaceId !== activeSpaceId || !embedding || !Array.isArray(embedding) || embedding.length !== expectedDim) {
         skipped++;
         continue;
       }

--- a/src/learning/rvf-pattern-migration.ts
+++ b/src/learning/rvf-pattern-migration.ts
@@ -17,6 +17,7 @@ import type {
   RvfNativeAdapter,
 } from '../integrations/ruvector/rvf-native-adapter.js';
 import type { SQLitePatternStore } from './sqlite-persistence.js';
+import { getActiveEmbeddingSpaceIdentity } from './real-embeddings.js';
 
 // ============================================================================
 // Types
@@ -42,6 +43,8 @@ export interface MigrationOptions {
   dimension?: number;
   /** Log progress every N patterns (default: 1000) */
   progressInterval?: number;
+  /** Runtime embedding space that the destination RVF index is bound to. */
+  embeddingSpaceId?: string;
 }
 
 // ============================================================================
@@ -79,7 +82,7 @@ export function migratePatterns(
   };
 
   // Read all embeddings from SQLite
-  let allEmbeddings: Array<{ patternId: string; embedding: number[] }>;
+  let allEmbeddings: Array<{ patternId: string; embedding: number[]; spaceId: string | null }>;
   try {
     allEmbeddings = sqliteStore.getAllEmbeddings();
   } catch (error) {
@@ -94,12 +97,13 @@ export function migratePatterns(
 
   // Process in batches
   let batch: Array<{ id: string; vector: Float32Array }> = [];
+  const activeSpaceId = getActiveEmbeddingSpaceIdentity()?.spaceId ?? options.embeddingSpaceId;
 
   for (let i = 0; i < allEmbeddings.length; i++) {
-    const { patternId, embedding } = allEmbeddings[i];
+    const { patternId, embedding, spaceId } = allEmbeddings[i];
 
-    // Skip if dimension doesn't match
-    if (embedding.length !== dimension) {
+    // Never mix unknown or incompatible spaces in an ANN file.
+    if (!activeSpaceId || spaceId !== activeSpaceId || embedding.length !== dimension) {
       result.totalSkipped++;
       continue;
     }

--- a/src/learning/rvf-pattern-store.ts
+++ b/src/learning/rvf-pattern-store.ts
@@ -39,6 +39,7 @@ import type {
 } from './pattern-store.js';
 import { DEFAULT_PATTERN_STORE_CONFIG } from './pattern-store.js';
 import { getActiveEmbeddingSpaceIdentity } from './real-embeddings.js';
+import { verifyOrCreateEmbeddingSpaceManifest } from './embedding-space.js';
 
 // ============================================================================
 // RVF Pattern Store Configuration
@@ -121,6 +122,12 @@ export class RvfPatternStore implements IPatternStore {
         this.rvfPath,
         this.config.embeddingDimension,
       );
+      const activeSpaceId = getActiveEmbeddingSpaceIdentity()?.spaceId ?? this.embeddingSpaceId ?? null;
+      verifyOrCreateEmbeddingSpaceManifest(
+        this.rvfPath,
+        activeSpaceId,
+        this.adapter.status()?.totalVectors ?? 0,
+      );
       this.initialized = true;
       console.log(
         `[RvfPatternStore] Initialized: ${this.rvfPath} (dim=${this.config.embeddingDimension})`,
@@ -130,6 +137,7 @@ export class RvfPatternStore implements IPatternStore {
       // so they need to know RVF is not working. Log a clear error, set
       // adapter to null, and mark nativeAvailable=false in stats.
       this.rvfInitError = toErrorMessage(error);
+      try { this.adapter?.close(); } catch { /* best effort */ }
       console.error(
         `[RvfPatternStore] ERROR: RVF native init failed — vector search is DISABLED. ` +
         `Cause: ${this.rvfInitError}. ` +

--- a/src/learning/rvf-pattern-store.ts
+++ b/src/learning/rvf-pattern-store.ts
@@ -38,6 +38,7 @@ import type {
   PatternSearchResult,
 } from './pattern-store.js';
 import { DEFAULT_PATTERN_STORE_CONFIG } from './pattern-store.js';
+import { getActiveEmbeddingSpaceIdentity } from './real-embeddings.js';
 
 // ============================================================================
 // RVF Pattern Store Configuration
@@ -50,6 +51,8 @@ export interface RvfPatternStoreConfig {
   base: PatternStoreConfig;
   /** When true, dispose() will not close the adapter (shared singleton) */
   skipCloseOnDispose?: boolean;
+  /** Runtime provenance for an injected embedder. */
+  embeddingSpaceId?: string;
 }
 
 // ============================================================================
@@ -66,6 +69,7 @@ export class RvfPatternStore implements IPatternStore {
   private readonly config: PatternStoreConfig;
   private readonly rvfPath: string;
   private readonly skipCloseOnDispose: boolean;
+  private readonly embeddingSpaceId?: string;
   private adapter: RvfNativeAdapter | null = null;
   private sqliteStore: import('./sqlite-persistence.js').SQLitePatternStore | null = null;
   private initialized = false;
@@ -80,6 +84,7 @@ export class RvfPatternStore implements IPatternStore {
     this.config = config?.base ?? DEFAULT_PATTERN_STORE_CONFIG;
     this.rvfPath = config?.rvfPath ?? '.agentic-qe/patterns.rvf';
     this.skipCloseOnDispose = config?.skipCloseOnDispose ?? false;
+    this.embeddingSpaceId = config?.embeddingSpaceId;
   }
 
   /**
@@ -233,6 +238,11 @@ export class RvfPatternStore implements IPatternStore {
       );
     }
 
+    const activeSpaceId = getActiveEmbeddingSpaceIdentity()?.spaceId ?? this.embeddingSpaceId;
+    if (pattern.embedding && !activeSpaceId) {
+      return err(new Error('VECTOR_SPACE_UNVERIFIED: refusing to persist or index an embedding without runtime provenance'));
+    }
+
     // Persist metadata to SQLite. #447: capture the returned id — ON CONFLICT
     // on (name, qe_domain, pattern_type) preserves the existing row's id, so
     // we must align pattern.id with what's actually stored before ingesting
@@ -240,7 +250,7 @@ export class RvfPatternStore implements IPatternStore {
     // with "Pattern not found" and qe_pattern_usage stays empty).
     if (this.sqliteStore) {
       try {
-        const actualId = this.sqliteStore.storePattern(pattern, pattern.embedding);
+        const actualId = this.sqliteStore.storePattern(pattern, pattern.embedding, activeSpaceId);
         if (actualId && actualId !== pattern.id) {
           // QEPattern.id is `readonly` for callers, but inside the store
           // we own the lifecycle and must align it with the persisted row
@@ -330,6 +340,13 @@ export class RvfPatternStore implements IPatternStore {
     const startTime = performance.now();
     const limit = options.limit ?? 10;
     const results: PatternSearchResult[] = [];
+
+    if (Array.isArray(query)) {
+      const activeSpaceId = getActiveEmbeddingSpaceIdentity()?.spaceId ?? this.embeddingSpaceId;
+      if (!activeSpaceId || options.embeddingSpaceId !== activeSpaceId) {
+        return err(new Error('VECTOR_SPACE_UNVERIFIED: pre-computed query vectors require the active embeddingSpaceId'));
+      }
+    }
 
     // Vector search via RVF native HNSW
     if (Array.isArray(query) && this.adapter) {

--- a/src/learning/sqlite-persistence.ts
+++ b/src/learning/sqlite-persistence.ts
@@ -23,7 +23,9 @@ import {
   computeBatchEmbeddings,
   getEmbeddingDimension,
   isUsingEndpoint,
+  getActiveEmbeddingSpaceIdentity,
 } from './real-embeddings.js';
+import { inspectEmbeddingSpaceRows, type EmbeddingSpaceDiagnostics } from './embedding-space.js';
 import { recordPatternUsage } from './pattern-usage-recorder.js';
 
 /**
@@ -105,6 +107,7 @@ interface EmbeddingRow {
   pattern_id: string;
   embedding: Buffer;
   dimension: number;
+  space_id: string | null;
 }
 
 /**
@@ -214,6 +217,9 @@ export class SQLitePatternStore {
       // Run deduplication migration (one-time, idempotent)
       this.deduplicatePatterns();
 
+      // Legacy rows remain NULL/unverified; only new writes receive provenance.
+      this.ensureEmbeddingSpaceSchema();
+
       // Prepare statements
       this.prepareStatements();
 
@@ -257,6 +263,7 @@ export class SQLitePatternStore {
         embedding BLOB NOT NULL,
         dimension INTEGER NOT NULL,
         model TEXT DEFAULT 'all-MiniLM-L6-v2',
+        space_id TEXT,
         created_at TEXT DEFAULT (datetime('now')),
         FOREIGN KEY (pattern_id) REFERENCES qe_patterns(id) ON DELETE CASCADE
       );
@@ -413,6 +420,15 @@ export class SQLitePatternStore {
   /**
    * Prepare commonly used statements
    */
+  private ensureEmbeddingSpaceSchema(): void {
+    if (!this.db) throw new Error('Database not initialized');
+    const columns = this.db.prepare("PRAGMA table_info('qe_pattern_embeddings')").all() as Array<{ name: string }>;
+    if (!columns.some((column) => column.name === 'space_id')) {
+      this.db.exec('ALTER TABLE qe_pattern_embeddings ADD COLUMN space_id TEXT');
+    }
+    this.db.exec('CREATE INDEX IF NOT EXISTS idx_qe_pattern_embeddings_space ON qe_pattern_embeddings(space_id)');
+  }
+
   private prepareStatements(): void {
     if (!this.db) throw new Error('Database not initialized');
 
@@ -439,8 +455,8 @@ export class SQLitePatternStore {
     `));
 
     this.prepared.set('insertEmbedding', this.db.prepare(`
-      INSERT OR REPLACE INTO qe_pattern_embeddings (pattern_id, embedding, dimension, model)
-      VALUES (?, ?, ?, ?)
+      INSERT OR REPLACE INTO qe_pattern_embeddings (pattern_id, embedding, dimension, model, space_id)
+      VALUES (?, ?, ?, ?, ?)
     `));
 
     this.prepared.set('getPattern', this.db.prepare(`
@@ -448,7 +464,7 @@ export class SQLitePatternStore {
     `));
 
     this.prepared.set('getPatternWithEmbedding', this.db.prepare(`
-      SELECT p.*, e.embedding, e.dimension
+      SELECT p.*, e.embedding, e.dimension, e.space_id
       FROM qe_patterns p
       LEFT JOIN qe_pattern_embeddings e ON p.id = e.pattern_id
       WHERE p.id = ?
@@ -484,14 +500,14 @@ export class SQLitePatternStore {
     `));
 
     this.prepared.set('getAllEmbeddings', this.db.prepare(`
-      SELECT pattern_id, embedding, dimension FROM qe_pattern_embeddings
+      SELECT pattern_id, embedding, dimension, space_id FROM qe_pattern_embeddings
     `));
 
     // Recent-first variant used by the RVF backfill path. Order by
     // qe_patterns.last_used_at (then created_at) so the bounded backfill keeps
     // the most actively-used patterns when the cap is hit.
     this.prepared.set('getRecentEmbeddings', this.db.prepare(`
-      SELECT e.pattern_id, e.embedding, e.dimension
+      SELECT e.pattern_id, e.embedding, e.dimension, e.space_id
         FROM qe_pattern_embeddings e
         LEFT JOIN qe_patterns p ON p.id = e.pattern_id
        ORDER BY COALESCE(p.last_used_at, p.created_at, e.created_at) DESC
@@ -510,7 +526,7 @@ export class SQLitePatternStore {
   /**
    * Store a pattern
    */
-  storePattern(pattern: QEPattern, embedding?: number[]): string {
+  storePattern(pattern: QEPattern, embedding?: number[], embeddingSpaceId?: string): string {
     if (!this.db) throw new Error('Database not initialized');
 
     const id = pattern.id || uuidv4();
@@ -549,9 +565,13 @@ export class SQLitePatternStore {
       actualId = actualRow ? actualRow.id : id;
 
       if (embedding) {
+        const spaceId = embeddingSpaceId ?? getActiveEmbeddingSpaceIdentity()?.spaceId;
+        if (!spaceId) {
+          throw new Error('VECTOR_SPACE_UNVERIFIED: refusing to persist an embedding without runtime provenance');
+        }
         // Store embedding as BLOB (Float32Array)
         const buffer = Buffer.from(new Float32Array(embedding).buffer);
-        insertEmbedding.run(actualId, buffer, embedding.length, 'all-MiniLM-L6-v2');
+        insertEmbedding.run(actualId, buffer, embedding.length, 'all-MiniLM-L6-v2', spaceId);
       }
     });
 
@@ -678,7 +698,7 @@ export class SQLitePatternStore {
   /**
    * Get all embeddings for HNSW indexing
    */
-  getAllEmbeddings(): Array<{ patternId: string; embedding: number[] }> {
+  getAllEmbeddings(): Array<{ patternId: string; embedding: number[]; spaceId: string | null }> {
     if (!this.db) throw new Error('Database not initialized');
 
     const stmt = this.prepared.get('getAllEmbeddings');
@@ -688,6 +708,7 @@ export class SQLitePatternStore {
     return rows.map(row => ({
       patternId: row.pattern_id,
       embedding: Array.from(new Float32Array(row.embedding.buffer, row.embedding.byteOffset, row.dimension)),
+      spaceId: row.space_id,
     }));
   }
 
@@ -698,7 +719,7 @@ export class SQLitePatternStore {
    * not trigger an unbounded re-ingest of every historical embedding (which
    * is what reproduces the "regrew to 59 GB" pathology after `: > patterns.rvf`).
    */
-  getRecentEmbeddings(limit: number): Array<{ patternId: string; embedding: number[] }> {
+  getRecentEmbeddings(limit: number): Array<{ patternId: string; embedding: number[]; spaceId: string | null }> {
     if (!this.db) throw new Error('Database not initialized');
     const cap = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : 1000;
 
@@ -709,7 +730,14 @@ export class SQLitePatternStore {
     return rows.map(row => ({
       patternId: row.pattern_id,
       embedding: Array.from(new Float32Array(row.embedding.buffer, row.embedding.byteOffset, row.dimension)),
+      spaceId: row.space_id,
     }));
+  }
+
+  getEmbeddingSpaceDiagnostics(activeSpaceId = getActiveEmbeddingSpaceIdentity()?.spaceId ?? null): EmbeddingSpaceDiagnostics {
+    if (!this.db) throw new Error('Database not initialized');
+    const rows = this.db.prepare('SELECT space_id AS spaceId FROM qe_pattern_embeddings').all() as Array<{ spaceId: string | null }>;
+    return inspectEmbeddingSpaceRows(rows, activeSpaceId);
   }
 
   /**
@@ -997,7 +1025,7 @@ export class SQLitePatternStore {
   /**
    * Store embedding for an existing pattern
    */
-  storePatternEmbedding(patternId: string, embedding: number[]): void {
+  storePatternEmbedding(patternId: string, embedding: number[], embeddingSpaceId?: string): void {
     if (!this.db) throw new Error('Database not initialized');
 
     const insertEmbedding = this.prepared.get('insertEmbedding');
@@ -1008,11 +1036,16 @@ export class SQLitePatternStore {
     // Convert embedding to Buffer for storage
     const buffer = Buffer.from(new Float32Array(embedding).buffer);
 
+    const spaceId = embeddingSpaceId ?? getActiveEmbeddingSpaceIdentity()?.spaceId;
+    if (!spaceId) {
+      throw new Error('VECTOR_SPACE_UNVERIFIED: refusing to persist an embedding without runtime provenance');
+    }
     insertEmbedding.run(
       patternId,
       buffer,
       embedding.length,
-      'all-MiniLM-L6-v2'
+      'all-MiniLM-L6-v2',
+      spaceId,
     );
   }
 
@@ -1289,6 +1322,10 @@ export class SQLitePatternStore {
 
       // Insert computed embeddings in a sync transaction
       const embeddingTag = method === 'transformer' ? 'transformer-backfill' : 'hash-backfill';
+      const spaceId = getActiveEmbeddingSpaceIdentity()?.spaceId;
+      if (!spaceId) {
+        throw new Error('VECTOR_SPACE_UNVERIFIED: backfill embedder has no runtime provenance');
+      }
       const insertBatch = this.db!.transaction(() => {
         for (let j = 0; j < textsWithIds.length; j++) {
           try {
@@ -1298,7 +1335,7 @@ export class SQLitePatternStore {
               continue;
             }
             const buffer = Buffer.from(new Float32Array(embedding).buffer);
-            insertEmbedding.run(textsWithIds[j].id, buffer, dimension, embeddingTag);
+            insertEmbedding.run(textsWithIds[j].id, buffer, dimension, embeddingTag, spaceId);
             processed++;
           } catch (e) {
             errors++;

--- a/src/learning/sqlite-persistence.ts
+++ b/src/learning/sqlite-persistence.ts
@@ -25,7 +25,11 @@ import {
   isUsingEndpoint,
   getActiveEmbeddingSpaceIdentity,
 } from './real-embeddings.js';
-import { inspectEmbeddingSpaceRows, type EmbeddingSpaceDiagnostics } from './embedding-space.js';
+import {
+  EMBEDDING_SPACE_CANARY,
+  inspectEmbeddingSpaceRows,
+  type EmbeddingSpaceDiagnostics,
+} from './embedding-space.js';
 import { recordPatternUsage } from './pattern-usage-recorder.js';
 
 /**
@@ -1235,14 +1239,23 @@ export class SQLitePatternStore {
 
     const dimension = getEmbeddingDimension(); // 384
 
-    // Find patterns without embeddings (skip bench patterns)
+    // Initialize the executable identity before choosing repair candidates.
+    // The canary is cached by the embedding layer and is never persisted.
+    await computeBatchEmbeddings([EMBEDDING_SPACE_CANARY]);
+    const activeSpaceId = getActiveEmbeddingSpaceIdentity()?.spaceId;
+    if (!activeSpaceId) {
+      throw new Error('VECTOR_SPACE_UNVERIFIED: backfill embedder has no runtime provenance');
+    }
+
+    // Repair absent, legacy/unverified, and mismatched embeddings.
     const patternsWithout = this.db.prepare(`
       SELECT p.id, p.name, p.description, p.pattern_type, p.qe_domain
       FROM qe_patterns p
-      WHERE p.id NOT IN (SELECT pattern_id FROM qe_pattern_embeddings)
+      LEFT JOIN qe_pattern_embeddings e ON e.pattern_id = p.id
+      WHERE (e.pattern_id IS NULL OR e.space_id IS NULL OR e.space_id <> ?)
         AND p.id NOT LIKE 'bench-%'
       ORDER BY p.quality_score DESC
-    `).all() as Array<{
+    `).all(activeSpaceId) as Array<{
       id: string;
       name: string;
       description: string;
@@ -1322,10 +1335,6 @@ export class SQLitePatternStore {
 
       // Insert computed embeddings in a sync transaction
       const embeddingTag = method === 'transformer' ? 'transformer-backfill' : 'hash-backfill';
-      const spaceId = getActiveEmbeddingSpaceIdentity()?.spaceId;
-      if (!spaceId) {
-        throw new Error('VECTOR_SPACE_UNVERIFIED: backfill embedder has no runtime provenance');
-      }
       const insertBatch = this.db!.transaction(() => {
         for (let j = 0; j < textsWithIds.length; j++) {
           try {
@@ -1335,7 +1344,7 @@ export class SQLitePatternStore {
               continue;
             }
             const buffer = Buffer.from(new Float32Array(embedding).buffer);
-            insertEmbedding.run(textsWithIds[j].id, buffer, dimension, embeddingTag, spaceId);
+            insertEmbedding.run(textsWithIds[j].id, buffer, dimension, embeddingTag, activeSpaceId);
             processed++;
           } catch (e) {
             errors++;

--- a/src/persistence/rvf-migration-adapter.ts
+++ b/src/persistence/rvf-migration-adapter.ts
@@ -16,6 +16,7 @@
  */
 
 import type { RvfStore, RvfStatus } from '../integrations/ruvector/rvf-dual-writer.js';
+import { getActiveEmbeddingSpaceIdentity } from '../learning/real-embeddings.js';
 
 // ============================================================================
 // Types
@@ -40,6 +41,8 @@ export interface MigrationAdapterConfig {
   dimensions: number;
   /** Enable fallback on RVF read failure in stage 3+ */
   enableFallback: boolean;
+  /** Runtime provenance for injected embedding pipelines. */
+  embeddingSpaceId?: string;
 }
 
 export interface WriteResult {
@@ -150,6 +153,11 @@ export class RvfMigrationAdapter {
       stage: this.config.stage,
       fallbackUsed: false,
     };
+    const hasSpaceContract = this.db
+      ? (this.db.prepare("PRAGMA table_info('qe_pattern_embeddings')").all() as Array<{ name: string }>).some((row) => row.name === 'space_id')
+      : false;
+    const spaceId = getActiveEmbeddingSpaceIdentity()?.spaceId ?? this.config.embeddingSpaceId;
+    if (hasSpaceContract && !spaceId) return result;
 
     const shouldWriteSqlite = this.config.stage < 4;
     const shouldWriteRvf = this.config.stage >= 2;
@@ -161,12 +169,22 @@ export class RvfMigrationAdapter {
         const blob = Buffer.from(
           vector instanceof Float32Array ? vector.buffer : new Float32Array(vector).buffer,
         );
-        this.db.prepare(`
-          INSERT INTO qe_pattern_embeddings (pattern_id, embedding, dimension, model, created_at)
-          VALUES (?, ?, ?, 'all-MiniLM-L6-v2', datetime('now'))
-          ON CONFLICT(pattern_id) DO UPDATE SET
-            embedding = excluded.embedding, dimension = excluded.dimension, created_at = datetime('now')
-        `).run(id, blob, vector.length);
+        if (hasSpaceContract) {
+          this.db.prepare(`
+            INSERT INTO qe_pattern_embeddings (pattern_id, embedding, dimension, model, space_id, created_at)
+            VALUES (?, ?, ?, 'all-MiniLM-L6-v2', ?, datetime('now'))
+            ON CONFLICT(pattern_id) DO UPDATE SET
+              embedding = excluded.embedding, dimension = excluded.dimension,
+              space_id = excluded.space_id, created_at = datetime('now')
+          `).run(id, blob, vector.length, spaceId);
+        } else {
+          this.db.prepare(`
+            INSERT INTO qe_pattern_embeddings (pattern_id, embedding, dimension, model, created_at)
+            VALUES (?, ?, ?, 'all-MiniLM-L6-v2', datetime('now'))
+            ON CONFLICT(pattern_id) DO UPDATE SET
+              embedding = excluded.embedding, dimension = excluded.dimension, created_at = datetime('now')
+          `).run(id, blob, vector.length);
+        }
         result.sqliteSuccess = true;
         this.sqliteWriteLatencies.push(performance.now() - start);
       } catch (err) {
@@ -196,12 +214,22 @@ export class RvfMigrationAdapter {
         const blob = Buffer.from(
           vector instanceof Float32Array ? vector.buffer : new Float32Array(vector).buffer,
         );
-        this.db.prepare(`
-          INSERT INTO qe_pattern_embeddings (pattern_id, embedding, dimension, model, created_at)
-          VALUES (?, ?, ?, 'all-MiniLM-L6-v2', datetime('now'))
-          ON CONFLICT(pattern_id) DO UPDATE SET
-            embedding = excluded.embedding, dimension = excluded.dimension, created_at = datetime('now')
-        `).run(id, blob, vector.length);
+        if (hasSpaceContract) {
+          this.db.prepare(`
+            INSERT INTO qe_pattern_embeddings (pattern_id, embedding, dimension, model, space_id, created_at)
+            VALUES (?, ?, ?, 'all-MiniLM-L6-v2', ?, datetime('now'))
+            ON CONFLICT(pattern_id) DO UPDATE SET
+              embedding = excluded.embedding, dimension = excluded.dimension,
+              space_id = excluded.space_id, created_at = datetime('now')
+          `).run(id, blob, vector.length, spaceId);
+        } else {
+          this.db.prepare(`
+            INSERT INTO qe_pattern_embeddings (pattern_id, embedding, dimension, model, created_at)
+            VALUES (?, ?, ?, 'all-MiniLM-L6-v2', datetime('now'))
+            ON CONFLICT(pattern_id) DO UPDATE SET
+              embedding = excluded.embedding, dimension = excluded.dimension, created_at = datetime('now')
+          `).run(id, blob, vector.length);
+        }
         result.sqliteSuccess = true;
         result.fallbackUsed = true;
         this.fallbacksUsed++;
@@ -257,6 +285,18 @@ export class RvfMigrationAdapter {
   search(query: Float32Array | number[], k: number): ReadResult<Array<{ id: string; score: number }>> {
     this.totalReads++;
     const useRvf = this.config.stage >= 3;
+    if (this.db) {
+      const hasSpaceContract = (this.db.prepare("PRAGMA table_info('qe_pattern_embeddings')").all() as Array<{ name: string }>).some((row) => row.name === 'space_id');
+      if (hasSpaceContract) {
+        const spaceId = getActiveEmbeddingSpaceIdentity()?.spaceId ?? this.config.embeddingSpaceId;
+        const incompatible = spaceId
+          ? (this.db.prepare('SELECT COUNT(*) AS count FROM qe_pattern_embeddings WHERE space_id IS NULL OR space_id <> ?').get(spaceId) as { count: number }).count
+          : 1;
+        if (incompatible > 0) {
+          return { data: null, source: useRvf ? 'rvf' : 'sqlite', latencyMs: 0, stage: this.config.stage };
+        }
+      }
+    }
 
     if (useRvf && this.rvfStore) {
       const start = performance.now();

--- a/src/persistence/rvf-migration-adapter.ts
+++ b/src/persistence/rvf-migration-adapter.ts
@@ -157,7 +157,7 @@ export class RvfMigrationAdapter {
       ? (this.db.prepare("PRAGMA table_info('qe_pattern_embeddings')").all() as Array<{ name: string }>).some((row) => row.name === 'space_id')
       : false;
     const spaceId = getActiveEmbeddingSpaceIdentity()?.spaceId ?? this.config.embeddingSpaceId;
-    if (hasSpaceContract && !spaceId) return result;
+    if (!hasSpaceContract || !spaceId) return result;
 
     const shouldWriteSqlite = this.config.stage < 4;
     const shouldWriteRvf = this.config.stage >= 2;
@@ -287,7 +287,10 @@ export class RvfMigrationAdapter {
     const useRvf = this.config.stage >= 3;
     if (this.db) {
       const hasSpaceContract = (this.db.prepare("PRAGMA table_info('qe_pattern_embeddings')").all() as Array<{ name: string }>).some((row) => row.name === 'space_id');
-      if (hasSpaceContract) {
+      if (!hasSpaceContract) {
+        return { data: null, source: useRvf ? 'rvf' : 'sqlite', latencyMs: 0, stage: this.config.stage };
+      }
+      {
         const spaceId = getActiveEmbeddingSpaceIdentity()?.spaceId ?? this.config.embeddingSpaceId;
         const incompatible = spaceId
           ? (this.db.prepare('SELECT COUNT(*) AS count FROM qe_pattern_embeddings WHERE space_id IS NULL OR space_id <> ?').get(spaceId) as { count: number }).count

--- a/tests/benchmarks/rvf-pattern-store.test.ts
+++ b/tests/benchmarks/rvf-pattern-store.test.ts
@@ -30,9 +30,10 @@ import type { QEPattern } from '../../src/learning/qe-patterns.js';
 const BENCH_DIR = join(tmpdir(), `aqe-rvf-bench-${process.pid}-${Date.now()}`);
 const RVF_PATH = join(BENCH_DIR, 'bench-patterns.rvf');
 const DIM = 384;
+const TEST_SPACE_ID = 'benchmark-runtime-embedding-space';
 
 function cleanupBenchFiles(): void {
-  for (const ext of ['', '.idmap.json']) {
+  for (const ext of ['', '.idmap.json', '.space.json']) {
     const p = `${RVF_PATH}${ext}`;
     if (existsSync(p)) unlinkSync(p);
   }
@@ -89,7 +90,7 @@ describe('RvfPatternStore — Real Native Benchmarks', () => {
     const start = performance.now();
     const store = new RvfPatternStore(
       (path, dim) => createRvfStore(path, dim),
-      { rvfPath: RVF_PATH, base: undefined as any },
+      { rvfPath: RVF_PATH, base: undefined as any, embeddingSpaceId: TEST_SPACE_ID },
     );
     await store.initialize();
     const coldStartMs = performance.now() - start;
@@ -106,7 +107,7 @@ describe('RvfPatternStore — Real Native Benchmarks', () => {
 
     const store = new RvfPatternStore(
       (path, dim) => createRvfStore(path, dim),
-      { rvfPath: RVF_PATH, base: undefined as any },
+      { rvfPath: RVF_PATH, base: undefined as any, embeddingSpaceId: TEST_SPACE_ID },
     );
     await store.initialize();
 
@@ -142,7 +143,7 @@ describe('RvfPatternStore — Real Native Benchmarks', () => {
 
     const store = new RvfPatternStore(
       (path, dim) => createRvfStore(path, dim),
-      { rvfPath: join(BENCH_DIR, 'search-bench.rvf'), base: undefined as any },
+      { rvfPath: join(BENCH_DIR, 'search-bench.rvf'), base: undefined as any, embeddingSpaceId: TEST_SPACE_ID },
     );
     await store.initialize();
 
@@ -165,7 +166,7 @@ describe('RvfPatternStore — Real Native Benchmarks', () => {
     for (let i = 0; i < 100; i++) {
       const query = randomEmbedding();
       const start = performance.now();
-      const result = await store.search(query, { limit: 10 });
+      const result = await store.search(query, { limit: 10, embeddingSpaceId: TEST_SPACE_ID });
       latencies.push(performance.now() - start);
 
       if (i === 0 && result.success) {
@@ -187,7 +188,7 @@ describe('RvfPatternStore — Real Native Benchmarks', () => {
 
     await store.dispose();
     // Cleanup
-    for (const ext of ['', '.idmap.json']) {
+    for (const ext of ['', '.idmap.json', '.space.json']) {
       const p = join(BENCH_DIR, `search-bench.rvf${ext}`);
       if (existsSync(p)) unlinkSync(p);
     }
@@ -199,7 +200,7 @@ describe('RvfPatternStore — Real Native Benchmarks', () => {
 
     const store = new RvfPatternStore(
       (path, dim) => createRvfStore(path, dim),
-      { rvfPath: RVF_PATH, base: undefined as any },
+      { rvfPath: RVF_PATH, base: undefined as any, embeddingSpaceId: TEST_SPACE_ID },
     );
     await store.initialize();
 
@@ -212,7 +213,7 @@ describe('RvfPatternStore — Real Native Benchmarks', () => {
     };
 
     // Search with the same embedding — should find it
-    const result = await store.search(pattern.embedding!, { limit: 5 });
+    const result = await store.search(pattern.embedding!, { limit: 5, embeddingSpaceId: TEST_SPACE_ID });
 
     expect(result.success).toBe(true);
     if (result.success) {

--- a/tests/integration/persistence/rvf-migration-lifecycle.test.ts
+++ b/tests/integration/persistence/rvf-migration-lifecycle.test.ts
@@ -23,6 +23,11 @@ import {
   type MigrationStage,
 } from '../../../src/persistence/rvf-migration-adapter.js';
 
+const TEST_SPACE_ID = 'rvf-migration-lifecycle-space';
+vi.mock('../../../src/learning/real-embeddings.js', () => ({
+  getActiveEmbeddingSpaceIdentity: () => ({ spaceId: TEST_SPACE_ID }),
+}));
+
 // ============================================================================
 // Test Helpers
 // ============================================================================
@@ -35,6 +40,7 @@ function createTestDb(): DatabaseType {
       embedding BLOB NOT NULL,
       dimension INTEGER NOT NULL,
       model TEXT DEFAULT 'all-MiniLM-L6-v2',
+      space_id TEXT,
       created_at TEXT DEFAULT (datetime('now'))
     )
   `);
@@ -43,12 +49,12 @@ function createTestDb(): DatabaseType {
 
 function seedEmbeddings(db: DatabaseType, count: number, dim = 384): void {
   const insert = db.prepare(
-    'INSERT OR REPLACE INTO qe_pattern_embeddings (pattern_id, embedding, dimension) VALUES (?, ?, ?)',
+    'INSERT OR REPLACE INTO qe_pattern_embeddings (pattern_id, embedding, dimension, space_id) VALUES (?, ?, ?, ?)',
   );
   for (let i = 0; i < count; i++) {
     const vec = new Float32Array(dim);
     for (let j = 0; j < dim; j++) vec[j] = Math.sin(i * 0.1 + j * 0.01);
-    insert.run(`pattern-${i}`, Buffer.from(vec.buffer), dim);
+    insert.run(`pattern-${i}`, Buffer.from(vec.buffer), dim, TEST_SPACE_ID);
   }
 }
 

--- a/tests/integration/rvf-brain-export-import.integration.test.ts
+++ b/tests/integration/rvf-brain-export-import.integration.test.ts
@@ -430,9 +430,9 @@ describe.skipIf(!NATIVE_AVAILABLE)('RVF Brain Export/Import Integration', () => 
     const emb = new Float32Array(dim);
     for (let i = 0; i < dim; i++) emb[i] = i * 0.1;
 
-    sourceDb.prepare(`INSERT INTO qe_pattern_embeddings (pattern_id, embedding, dimension, model)
-      VALUES (?, ?, ?, ?)`).run(
-      'pat-1', Buffer.from(emb.buffer), dim, 'test-model',
+    sourceDb.prepare(`INSERT INTO qe_pattern_embeddings (pattern_id, embedding, dimension, model, space_id)
+      VALUES (?, ?, ?, ?, ?)`).run(
+      'pat-1', Buffer.from(emb.buffer), dim, 'test-model', 'integration-space',
     );
 
     const rvfPath = tmpRvfPath('hnsw-vectors');

--- a/tests/integration/rvf-corruption-recovery.integration.test.ts
+++ b/tests/integration/rvf-corruption-recovery.integration.test.ts
@@ -64,7 +64,8 @@ function seedDb(path: string, patternCount = 25): Database.Database {
   const db = new Database(path);
   ensureAllBrainTables(db);
   const insertEmbedding = db.prepare(
-    `INSERT INTO qe_pattern_embeddings (pattern_id, embedding, dimension) VALUES (?, ?, ?)`,
+    `INSERT INTO qe_pattern_embeddings (pattern_id, embedding, dimension, space_id)
+     VALUES (?, ?, ?, ?)`,
   );
   const insert = db.prepare(
     `INSERT INTO qe_patterns (id, pattern_type, qe_domain, domain, name, description, confidence)
@@ -83,7 +84,7 @@ function seedDb(path: string, patternCount = 25): Database.Database {
     // Deterministic 384-dim float32 vector — content is irrelevant, presence
     // is what drives ingest → idmap.
     const vec = Float32Array.from({ length: 384 }, (_, j) => ((i + j) % 17) / 17);
-    insertEmbedding.run(`pat-${i}`, Buffer.from(vec.buffer), 384);
+    insertEmbedding.run(`pat-${i}`, Buffer.from(vec.buffer), 384, 'rvf-corruption-fixture-space');
   }
   return db;
 }

--- a/tests/integration/rvf-corruption-recovery.integration.test.ts
+++ b/tests/integration/rvf-corruption-recovery.integration.test.ts
@@ -236,7 +236,7 @@ describeNative('RVF export atomicity under interruption (#563)', () => {
     openRvfStore(rvfPath).close();
     // ...and no tmp debris is left behind.
     const tmpBase = `${rvfPath}.tmp.${process.pid}`;
-    for (const suffix of ['', '.idmap.json', '.manifest.json', '.lock']) {
+    for (const suffix of ['', '.idmap.json', '.manifest.json', '.space.json', '.lock']) {
       expect(existsSync(`${tmpBase}${suffix}`)).toBe(false);
     }
 
@@ -280,7 +280,12 @@ describeNative('Dual-writer recovery from an unusable store (#563)', () => {
 
     // Act: this is what every `aqe status` / session start does.
     const { RvfDualWriter } = await import('../../src/integrations/ruvector/rvf-dual-writer.js');
-    const writer = new RvfDualWriter(db, { rvfPath, mode: 'dual-write', dimensions: 384 });
+    const writer = new RvfDualWriter(db, {
+      rvfPath,
+      mode: 'dual-write',
+      dimensions: 384,
+      embeddingSpaceId: 'corruption-recovery-test-space',
+    });
     await writer.initialize();
 
     // Assert: RVF is live. Before the fix both opens threw FsyncFailed and the
@@ -313,6 +318,7 @@ describe('Unusable-store quarantine (#563)', () => {
     const rvfPath = join(dir, 'brain.rvf');
     writeFileSync(rvfPath, Buffer.concat([Buffer.from('SFVR'), Buffer.alloc(158)]));
     writeFileSync(`${rvfPath}.idmap.json`, '{"nextLabel":1,"entries":[]}');
+    writeFileSync(`${rvfPath}.space.json`, '{"spaceId":"test-space"}');
     // A stale lock: well-formed, but its owning process is long gone.
     writeFileSync(`${rvfPath}.lock`, lockRecord(0x7ffffffe));
 
@@ -325,6 +331,7 @@ describe('Unusable-store quarantine (#563)', () => {
     // ...and the bytes are preserved for diagnosis rather than deleted.
     expect(existsSync(quarantined as string)).toBe(true);
     expect(existsSync(`${quarantined}.idmap.json`)).toBe(true);
+    expect(existsSync(`${quarantined}.space.json`)).toBe(true);
   });
 
   it('refuses to quarantine a store whose lock is held by a live process', () => {

--- a/tests/integration/rvf/rvf-production-wiring.test.ts
+++ b/tests/integration/rvf/rvf-production-wiring.test.ts
@@ -29,6 +29,8 @@ import {
   createQEReasoningBank,
 } from '../../../src/learning/qe-reasoning-bank.js';
 
+const TEST_SPACE_ID = 'rvf-production-test-space';
+
 // ============================================================================
 // Helpers
 // ============================================================================
@@ -72,6 +74,7 @@ function createTestDb(): Database.Database {
       embedding BLOB NOT NULL,
       dimension INTEGER NOT NULL,
       model TEXT DEFAULT 'all-MiniLM-L6-v2',
+      space_id TEXT,
       created_at TEXT DEFAULT (datetime('now')),
       FOREIGN KEY (pattern_id) REFERENCES qe_patterns(id)
     );
@@ -161,6 +164,7 @@ describe('RVF Production Wiring', () => {
       const writer = new RvfDualWriter(db, {
         rvfPath: '/tmp/test.rvf',
         mode: 'dual-write',
+        embeddingSpaceId: TEST_SPACE_ID,
         dimensions: 384,
       });
 
@@ -183,6 +187,7 @@ describe('RVF Production Wiring', () => {
       const writer = new RvfDualWriter(db, {
         rvfPath: '/tmp/test.rvf',
         mode: 'dual-write',
+        embeddingSpaceId: TEST_SPACE_ID,
         dimensions: 384,
       });
 
@@ -208,6 +213,7 @@ describe('RVF Production Wiring', () => {
       const writer = new RvfDualWriter(db, {
         rvfPath: '/tmp/test.rvf',
         mode: 'dual-write',
+        embeddingSpaceId: TEST_SPACE_ID,
         dimensions: 384,
       });
 
@@ -237,6 +243,7 @@ describe('RVF Production Wiring', () => {
       const writer = new RvfDualWriter(db, {
         rvfPath: '/tmp/test.rvf',
         mode: 'dual-write',
+        embeddingSpaceId: TEST_SPACE_ID,
         dimensions: 384,
       });
 
@@ -287,6 +294,7 @@ describe('RVF Production Wiring', () => {
       const writer = new RvfDualWriter(db, {
         rvfPath: '/tmp/test.rvf',
         mode: 'dual-write',
+        embeddingSpaceId: TEST_SPACE_ID,
         dimensions: 384,
       });
 
@@ -325,6 +333,7 @@ describe.runIf(nativeAvailable)('RVF Native Path (real binding)', () => {
     for (const p of tmpFiles) {
       try { if (existsSync(p)) unlinkSync(p); } catch { /* best effort */ }
       try { if (existsSync(p + '.idmap.json')) unlinkSync(p + '.idmap.json'); } catch { /* best effort */ }
+      try { if (existsSync(p + '.space.json')) unlinkSync(p + '.space.json'); } catch { /* best effort */ }
     }
   });
 
@@ -335,6 +344,7 @@ describe.runIf(nativeAvailable)('RVF Native Path (real binding)', () => {
       const writer = new RvfDualWriter(db, {
         rvfPath,
         mode: 'dual-write',
+        embeddingSpaceId: TEST_SPACE_ID,
         dimensions: 8,
       });
 
@@ -356,6 +366,7 @@ describe.runIf(nativeAvailable)('RVF Native Path (real binding)', () => {
       const writer = new RvfDualWriter(db, {
         rvfPath,
         mode: 'dual-write',
+        embeddingSpaceId: TEST_SPACE_ID,
         dimensions: 8,
       });
       await writer.initialize();
@@ -394,6 +405,7 @@ describe.runIf(nativeAvailable)('RVF Native Path (real binding)', () => {
       const writer = new RvfDualWriter(db, {
         rvfPath,
         mode: 'rvf-primary',
+        embeddingSpaceId: TEST_SPACE_ID,
         dimensions: 4,
       });
       await writer.initialize();
@@ -417,6 +429,7 @@ describe.runIf(nativeAvailable)('RVF Native Path (real binding)', () => {
       const writer = new RvfDualWriter(db, {
         rvfPath,
         mode: 'dual-write',
+        embeddingSpaceId: TEST_SPACE_ID,
         dimensions: 4,
       });
       await writer.initialize();
@@ -441,6 +454,7 @@ describe.runIf(nativeAvailable)('RVF Native Path (real binding)', () => {
       const writer = new RvfDualWriter(db, {
         rvfPath,
         mode: 'dual-write',
+        embeddingSpaceId: TEST_SPACE_ID,
         dimensions: 4,
       });
       await writer.initialize();
@@ -494,12 +508,15 @@ describe.runIf(nativeAvailable)('RVF Native Path (real binding)', () => {
       const writer = new RvfDualWriter(db, {
         rvfPath,
         mode: 'dual-write',
+        embeddingSpaceId: TEST_SPACE_ID,
         dimensions: 384,
       });
       await withTimeout(writer.initialize(), 10000, 'writer.initialize');
 
       // Create ReasoningBank and wire dual-writer
-      const bank = createQEReasoningBank(memStub);
+      const bank = createQEReasoningBank(memStub, undefined, {
+        patternStore: { embeddingSpaceId: TEST_SPACE_ID },
+      });
       await withTimeout(bank.initialize(), 15000, 'bank.initialize');
       bank.setRvfDualWriter(writer);
 
@@ -512,7 +529,7 @@ describe.runIf(nativeAvailable)('RVF Native Path (real binding)', () => {
         context: { tags: ['test'] },
       }), 10000, 'bank.storePattern');
 
-      expect(result.success).toBe(true);
+      expect(result.success, result.success ? '' : result.error.message).toBe(true);
 
       // Check that the RVF store received the embedding.
       const status = writer.status();
@@ -532,11 +549,14 @@ describe.runIf(nativeAvailable)('RVF Native Path (real binding)', () => {
       const writer = new RvfDualWriter(db, {
         rvfPath,
         mode: 'dual-write',
+        embeddingSpaceId: TEST_SPACE_ID,
         dimensions: 384,
       });
       await withTimeout(writer.initialize(), 10000, 'writer.initialize');
 
-      const bank = createQEReasoningBank(memStub);
+      const bank = createQEReasoningBank(memStub, undefined, {
+        patternStore: { embeddingSpaceId: TEST_SPACE_ID },
+      });
       await withTimeout(bank.initialize(), 15000, 'bank.initialize');
       bank.setRvfDualWriter(writer);
 

--- a/tests/unit/brain-rvf-features.test.ts
+++ b/tests/unit/brain-rvf-features.test.ts
@@ -378,9 +378,9 @@ describe('Brain RVF Advanced Features (Phase 4)', () => {
       const embedding = Buffer.alloc(384 * 4);
       new Float32Array(embedding.buffer).fill(0.1);
       db.prepare(`
-        INSERT INTO qe_pattern_embeddings (pattern_id, embedding, dimension, model)
-        VALUES (?, ?, ?, ?)
-      `).run('p1', embedding, 384, 'test-model');
+        INSERT INTO qe_pattern_embeddings (pattern_id, embedding, dimension, model, space_id)
+        VALUES (?, ?, ?, ?, ?)
+      `).run('p1', embedding, 384, 'test-model', 'space-a');
 
       mocks.ingest.mockReturnValue({ accepted: 1, rejected: 0 });
 
@@ -390,10 +390,10 @@ describe('Brain RVF Advanced Features (Phase 4)', () => {
       const entries = mocks.ingest.mock.calls[0][0];
       expect(entries).toHaveLength(1);
       expect(entries[0].id).toBe('pe:p1');
-      expect(entries[0].metadata).toEqual({ tableName: 'qe_pattern_embeddings' });
+      expect(entries[0].metadata).toEqual({ tableName: 'qe_pattern_embeddings', spaceId: 'space-a' });
     });
 
-    it('should include domain and confidence metadata for captured experiences', () => {
+    it('should exclude captured-experience vectors without provenance from ANN export', () => {
       seedMinimalData(db);
       const embedding = Buffer.alloc(384 * 4);
       new Float32Array(embedding.buffer).fill(0.2);
@@ -406,18 +406,10 @@ describe('Brain RVF Advanced Features (Phase 4)', () => {
 
       exportBrainToRvf(db, { outputPath: '/tmp/test-export.rvf' });
 
-      expect(mocks.ingest).toHaveBeenCalledOnce();
-      const entries = mocks.ingest.mock.calls[0][0];
-      const expEntry = entries.find((e: { id: string }) => e.id === 'exp:exp1');
-      expect(expEntry).toBeDefined();
-      expect(expEntry.metadata).toEqual({
-        tableName: 'captured_experiences',
-        domain: 'test-gen',
-        confidence: 0.85,
-      });
+      expect(mocks.ingest).not.toHaveBeenCalled();
     });
 
-    it('should include domain and confidence metadata for sona patterns', () => {
+    it('should exclude SONA vectors without provenance from ANN export', () => {
       seedMinimalData(db);
       const stateEmb = Buffer.alloc(384 * 4);
       new Float32Array(stateEmb.buffer).fill(0.3);
@@ -430,15 +422,7 @@ describe('Brain RVF Advanced Features (Phase 4)', () => {
 
       exportBrainToRvf(db, { outputPath: '/tmp/test-export.rvf' });
 
-      expect(mocks.ingest).toHaveBeenCalledOnce();
-      const entries = mocks.ingest.mock.calls[0][0];
-      const sonaEntry = entries.find((e: { id: string }) => e.id === 'sona:sona1');
-      expect(sonaEntry).toBeDefined();
-      expect(sonaEntry.metadata).toEqual({
-        tableName: 'sona_patterns',
-        domain: 'test-gen',
-        confidence: 0.77,
-      });
+      expect(mocks.ingest).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/brain-shared.test.ts
+++ b/tests/unit/brain-shared.test.ts
@@ -47,6 +47,7 @@ import {
   type WitnessRow,
   type MergeStrategy,
 } from '../../src/integrations/ruvector/brain-shared.js';
+import { ensureAllBrainTables } from '../../src/integrations/ruvector/brain-table-ddl.js';
 
 // ============================================================================
 // Helpers
@@ -609,6 +610,23 @@ describe('Brain Shared Module', () => {
     it('should cover 6 tables', () => {
       expect(Object.keys(TABLE_BLOB_COLUMNS)).toHaveLength(6);
     });
+  });
+
+  it('creates and upgrades pattern embedding provenance for brain imports', () => {
+    const importDb = new Database(':memory:');
+    importDb.exec(`CREATE TABLE qe_pattern_embeddings (
+      pattern_id TEXT PRIMARY KEY,
+      embedding BLOB NOT NULL,
+      dimension INTEGER NOT NULL
+    )`);
+
+    ensureAllBrainTables(importDb);
+
+    const columns = importDb.prepare("PRAGMA table_info('qe_pattern_embeddings')").all() as Array<{ name: string }>;
+    expect(columns.map((column) => column.name)).toContain('space_id');
+    const indexes = importDb.prepare("PRAGMA index_list('qe_pattern_embeddings')").all() as Array<{ name: string }>;
+    expect(indexes.map((index) => index.name)).toContain('idx_qe_pattern_embeddings_space');
+    importDb.close();
   });
 
   describe('serializeRowBlobs', () => {

--- a/tests/unit/cli/commands/learning-embedding-health.test.ts
+++ b/tests/unit/cli/commands/learning-embedding-health.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  close: vi.fn(),
+  rows: [
+    { spaceId: 'active-space' },
+    { spaceId: 'other-space' },
+    { spaceId: null },
+  ],
+}));
+
+vi.mock('node:fs', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:fs')>()),
+  existsSync: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('../../../../src/kernel/unified-memory.js', () => ({
+  findProjectRoot: () => '/test-project',
+}));
+
+vi.mock('../../../../src/learning/real-embeddings.js', () => ({
+  getActiveEmbeddingSpaceIdentity: () => ({ spaceId: 'active-space' }),
+}));
+
+vi.mock('../../../../src/shared/safe-db.js', () => ({
+  openDatabase: () => ({
+    prepare: (sql: string) => ({
+      get: () => sql.includes('sqlite_master') ? { name: 'qe_pattern_embeddings' } : undefined,
+      all: () => sql.includes('table_info') ? [{ name: 'space_id' }] : mocks.rows,
+    }),
+    close: mocks.close,
+  }),
+}));
+
+import { createLearningCommand } from '../../../../src/cli/commands/learning.js';
+
+describe('learning embedding-health command (#633)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reports verified, mismatched, and unverified vectors as JSON', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const command = createLearningCommand().exitOverride();
+
+    await command.parseAsync(['embedding-health', '--json'], { from: 'user' });
+
+    const output = JSON.parse(log.mock.calls.map(([value]) => String(value)).join('\n'));
+    expect(output).toMatchObject({
+      status: 'unverified',
+      activeSpaceId: 'active-space',
+      storedSpaceIds: ['active-space', 'other-space'],
+      verifiedVectors: 1,
+      mismatchedVectors: 1,
+      unverifiedVectors: 1,
+    });
+    expect(mocks.close).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/kernel/unified-memory.test.ts
+++ b/tests/unit/kernel/unified-memory.test.ts
@@ -15,6 +15,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
+import Database from 'better-sqlite3';
 import {
   UnifiedMemoryManager,
   getUnifiedMemory,
@@ -173,6 +174,38 @@ describe('UnifiedMemoryManager', () => {
       expect(tableNames).toContain('kv_store');
       expect(tableNames).toContain('vectors');
       expect(tableNames).toContain('schema_version');
+    });
+
+    it('upgrades an existing v11 embedding table without trusting legacy vectors', async () => {
+      const dbPath = getTestDbPath('-v11');
+      const legacy = new Database(dbPath);
+      legacy.exec(`
+        CREATE TABLE schema_version (id INTEGER PRIMARY KEY, version INTEGER NOT NULL, migrated_at TEXT);
+        INSERT INTO schema_version (id, version) VALUES (1, 11);
+        CREATE TABLE qe_patterns (id TEXT PRIMARY KEY);
+        CREATE TABLE qe_pattern_embeddings (
+          pattern_id TEXT PRIMARY KEY,
+          embedding BLOB NOT NULL,
+          dimension INTEGER NOT NULL,
+          model TEXT,
+          created_at TEXT
+        );
+        INSERT INTO qe_pattern_embeddings (pattern_id, embedding, dimension)
+        VALUES ('legacy', X'00000000', 1);
+      `);
+      legacy.close();
+
+      const manager = getUnifiedMemory({ dbPath });
+      await manager.initialize();
+      const db = manager.getDatabase();
+      const columns = db.prepare("PRAGMA table_info('qe_pattern_embeddings')").all() as Array<{ name: string }>;
+      const row = db.prepare('SELECT space_id AS spaceId FROM qe_pattern_embeddings WHERE pattern_id = ?')
+        .get('legacy') as { spaceId: string | null };
+      const version = db.prepare('SELECT version FROM schema_version WHERE id = 1').get() as { version: number };
+
+      expect(columns.map((column) => column.name)).toContain('space_id');
+      expect(row.spaceId).toBeNull();
+      expect(version.version).toBe(12);
     });
   });
 

--- a/tests/unit/learning/embedding-space.test.ts
+++ b/tests/unit/learning/embedding-space.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EmbeddingSpaceError,
+  deriveEmbeddingSpaceIdentity,
+  fingerprintEmbeddingRuntime,
+  inspectEmbeddingSpaceRows,
+  verifyEmbeddingRoundTrip,
+} from '../../../src/learning/embedding-space.js';
+
+function identity(runtimeFingerprint: string) {
+  return deriveEmbeddingSpaceIdentity({
+    provider: 'test-provider',
+    model: 'same-advertised-model',
+    dimensions: 384,
+    pooling: 'mean',
+    normalized: true,
+    implementation: 'test-runtime',
+    runtimeFingerprint,
+  });
+}
+
+function basis(index: number): number[] {
+  return Array.from({ length: 384 }, (_, i) => i === index ? 1 : 0);
+}
+
+describe('embedding-space contract', () => {
+  it('includes executable canary evidence in spaceId', () => {
+    const a = identity(fingerprintEmbeddingRuntime(basis(0)));
+    const b = identity(fingerprintEmbeddingRuntime(basis(1)));
+
+    expect(a.model).toBe(b.model);
+    expect(a.dimensions).toBe(b.dimensions);
+    expect(a.spaceId).not.toBe(b.spaceId);
+    expect(a.spaceId).toHaveLength(64);
+  });
+
+  it('accepts a compatible write/read round trip', async () => {
+    const embed = async () => basis(0);
+    await expect(verifyEmbeddingRoundTrip(embed, embed)).resolves.toBeCloseTo(1, 10);
+  });
+
+  it('rejects different same-dimensional embedding spaces', async () => {
+    const writeEmbed = async () => basis(0);
+    const queryEmbed = async () => basis(1);
+
+    await expect(verifyEmbeddingRoundTrip(writeEmbed, queryEmbed)).rejects.toMatchObject({
+      code: 'VECTOR_SPACE_MISMATCH',
+    } satisfies Partial<EmbeddingSpaceError>);
+  });
+
+  it('classifies legacy and mismatched vectors explicitly', () => {
+    expect(inspectEmbeddingSpaceRows([{ spaceId: null }], 'active')).toMatchObject({
+      status: 'unverified',
+      unverifiedVectors: 1,
+    });
+    expect(inspectEmbeddingSpaceRows([{ spaceId: 'other' }], 'active')).toMatchObject({
+      status: 'vector_space_mismatch',
+      mismatchedVectors: 1,
+    });
+  });
+});

--- a/tests/unit/learning/embedding-space.test.ts
+++ b/tests/unit/learning/embedding-space.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   EmbeddingSpaceError,
   deriveEmbeddingSpaceIdentity,
+  embeddingSpaceManifestPath,
   fingerprintEmbeddingRuntime,
   inspectEmbeddingSpaceRows,
+  verifyOrCreateEmbeddingSpaceManifest,
   verifyEmbeddingRoundTrip,
 } from '../../../src/learning/embedding-space.js';
 
@@ -57,5 +62,32 @@ describe('embedding-space contract', () => {
       status: 'vector_space_mismatch',
       mismatchedVectors: 1,
     });
+  });
+
+  it('persists and verifies an ANN embedding-space binding', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'aqe-space-manifest-'));
+    const indexPath = join(dir, 'patterns.rvf');
+    try {
+      verifyOrCreateEmbeddingSpaceManifest(indexPath, 'space-a', 0);
+      expect(JSON.parse(readFileSync(embeddingSpaceManifestPath(indexPath), 'utf8'))).toEqual({
+        version: 1,
+        spaceId: 'space-a',
+      });
+      expect(() => verifyOrCreateEmbeddingSpaceManifest(indexPath, 'space-a', 5)).not.toThrow();
+      expect(() => verifyOrCreateEmbeddingSpaceManifest(indexPath, 'space-b', 5)).toThrow('VECTOR_SPACE_MISMATCH');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses to adopt a populated legacy ANN index', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'aqe-space-manifest-'));
+    const indexPath = join(dir, 'patterns.rvf');
+    try {
+      writeFileSync(indexPath, 'legacy-index');
+      expect(() => verifyOrCreateEmbeddingSpaceManifest(indexPath, 'space-a', 1)).toThrow('VECTOR_SPACE_UNVERIFIED');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/unit/learning/pattern-store-rvf-recovery.test.ts
+++ b/tests/unit/learning/pattern-store-rvf-recovery.test.ts
@@ -61,7 +61,7 @@ describeNative('createPatternStore RVF recovery (#563)', () => {
     const { createPatternStore } = await import('../../../src/learning/pattern-store.js');
     const memory = { store: async () => {}, retrieve: async () => null } as never;
 
-    const store = createPatternStore(memory);
+    const store = createPatternStore(memory, { embeddingSpaceId: 'rvf-recovery-test-space' });
     // The ladder is lazy — it only runs on initialize(), which is where the
     // open/create/reopen against the unusable file actually happens.
     await store.initialize();

--- a/tests/unit/learning/real-qe-reasoning-bank.benchmark.test.ts
+++ b/tests/unit/learning/real-qe-reasoning-bank.benchmark.test.ts
@@ -356,7 +356,7 @@ describe('SQLite Persistence Benchmarks', () => {
     // Store pattern with 384-dimension embedding (matching HNSW index expectations)
     // Use a simple normalized vector for testing
     const testEmbedding = new Array(384).fill(0).map((_, i) => Math.sin(i * 0.01));
-    const id = store.storePattern(pattern, testEmbedding);
+    const id = store.storePattern(pattern, testEmbedding, 'benchmark-runtime-embedding-space');
 
     // Retrieve pattern
     const retrieved = store.getPattern(id);

--- a/tests/unit/learning/rvf-pattern-store-orphan-purge.test.ts
+++ b/tests/unit/learning/rvf-pattern-store-orphan-purge.test.ts
@@ -21,6 +21,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { RvfPatternStore } from '../../../src/learning/rvf-pattern-store.js';
 import type { RvfNativeAdapter, RvfStatus } from '../../../src/integrations/ruvector/rvf-native-adapter.js';
 
+const TEST_SPACE_ID = 'rvf-orphan-purge-test-space';
+
 function makeFakeAdapter(totalVectors: number): {
   adapter: RvfNativeAdapter;
   deleteSpy: ReturnType<typeof vi.fn>;
@@ -80,6 +82,7 @@ describe('RvfPatternStore purges orphan vectors on init (#462)', () => {
     rvfPath = path.join(tmpDir, 'patterns.rvf');
     // A bare placeholder so any future fs check on the file passes.
     fs.writeFileSync(rvfPath, '');
+    fs.writeFileSync(`${rvfPath}.space.json`, JSON.stringify({ version: 1, spaceId: TEST_SPACE_ID }));
   });
 
   afterEach(() => {
@@ -105,7 +108,7 @@ describe('RvfPatternStore purges orphan vectors on init (#462)', () => {
     writeIdmap(['keep-1', 'orphan-a', 'keep-2', 'orphan-b', 'keep-3']);
 
     const { adapter, deleteSpy } = makeFakeAdapter(5);
-    const store = new RvfPatternStore(() => adapter, { rvfPath });
+    const store = new RvfPatternStore(() => adapter, { rvfPath, embeddingSpaceId: TEST_SPACE_ID });
     // Inject a fake sqlite store so the init-time auto-attach is skipped.
     store.setSqliteStore(
       makeFakeSqliteStore(3, ['keep-1', 'keep-2', 'keep-3']) as unknown as Parameters<
@@ -124,7 +127,7 @@ describe('RvfPatternStore purges orphan vectors on init (#462)', () => {
     writeIdmap(['p1', 'p2', 'p3']);
     const { adapter, deleteSpy } = makeFakeAdapter(3);
 
-    const store = new RvfPatternStore(() => adapter, { rvfPath });
+    const store = new RvfPatternStore(() => adapter, { rvfPath, embeddingSpaceId: TEST_SPACE_ID });
     store.setSqliteStore(
       makeFakeSqliteStore(3, ['p1', 'p2', 'p3']) as unknown as Parameters<
         typeof store.setSqliteStore
@@ -139,7 +142,7 @@ describe('RvfPatternStore purges orphan vectors on init (#462)', () => {
     writeIdmap(['p1']);
     const { adapter, deleteSpy } = makeFakeAdapter(1);
 
-    const store = new RvfPatternStore(() => adapter, { rvfPath });
+    const store = new RvfPatternStore(() => adapter, { rvfPath, embeddingSpaceId: TEST_SPACE_ID });
     store.setSqliteStore(
       makeFakeSqliteStore(5, ['p1', 'p2', 'p3', 'p4', 'p5']) as unknown as Parameters<
         typeof store.setSqliteStore
@@ -155,7 +158,7 @@ describe('RvfPatternStore purges orphan vectors on init (#462)', () => {
     // Purge cannot compute orphans without idmap — skip silently.
     const { adapter, deleteSpy } = makeFakeAdapter(5);
 
-    const store = new RvfPatternStore(() => adapter, { rvfPath });
+    const store = new RvfPatternStore(() => adapter, { rvfPath, embeddingSpaceId: TEST_SPACE_ID });
     store.setSqliteStore(
       makeFakeSqliteStore(3, ['p1', 'p2', 'p3']) as unknown as Parameters<
         typeof store.setSqliteStore
@@ -170,7 +173,7 @@ describe('RvfPatternStore purges orphan vectors on init (#462)', () => {
     fs.writeFileSync(`${rvfPath}.idmap.json`, '{not-valid-json');
     const { adapter, deleteSpy } = makeFakeAdapter(5);
 
-    const store = new RvfPatternStore(() => adapter, { rvfPath });
+    const store = new RvfPatternStore(() => adapter, { rvfPath, embeddingSpaceId: TEST_SPACE_ID });
     store.setSqliteStore(
       makeFakeSqliteStore(3, ['p1', 'p2', 'p3']) as unknown as Parameters<
         typeof store.setSqliteStore

--- a/tests/unit/learning/rvf-pattern-store.test.ts
+++ b/tests/unit/learning/rvf-pattern-store.test.ts
@@ -138,17 +138,17 @@ describe('RvfPatternStore', () => {
   let tmpDir: string;
 
   beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aqe-rvf-pattern-store-'));
     adapter = createMockAdapter();
     store = new RvfPatternStore(
       () => adapter,
-      { rvfPath: '/tmp/test.rvf', base: undefined as any, embeddingSpaceId: TEST_SPACE_ID },
+      { rvfPath: path.join(tmpDir, 'test.rvf'), base: undefined as any, embeddingSpaceId: TEST_SPACE_ID },
     );
     // Attach an isolated, non-unified SQLite store per test — without this,
     // RvfPatternStore.initialize() auto-attaches the ADR-046 unified
     // singleton (memory.db, shared for the whole worker process), so
     // totalPatterns/byDomain leak across tests/files now that getStats()
     // reads them from SQLite. Same pattern as sqlite-aggregate-stats.test.ts.
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aqe-rvf-pattern-store-'));
     const sqliteStore = createSQLitePatternStore({
       useUnified: false,
       dbPath: path.join(tmpDir, 'patterns.db'),
@@ -170,7 +170,11 @@ describe('RvfPatternStore', () => {
 
     it('should skip re-initialization', async () => {
       const factoryFn = vi.fn(() => adapter);
-      const s = new RvfPatternStore(factoryFn, { rvfPath: '/tmp/test.rvf', base: undefined as any });
+      const s = new RvfPatternStore(factoryFn, {
+        rvfPath: path.join(tmpDir, 'second.rvf'),
+        base: undefined as any,
+        embeddingSpaceId: TEST_SPACE_ID,
+      });
       await s.initialize();
       await s.initialize(); // second call
       expect(factoryFn).toHaveBeenCalledTimes(1);

--- a/tests/unit/learning/rvf-pattern-store.test.ts
+++ b/tests/unit/learning/rvf-pattern-store.test.ts
@@ -19,6 +19,8 @@ import {
   resetRuVectorFeatureFlags,
 } from '../../../src/integrations/ruvector/feature-flags.js';
 
+const TEST_SPACE_ID = 'test-runtime-embedding-space';
+
 // ============================================================================
 // Mock RVF Adapter
 // ============================================================================
@@ -139,7 +141,7 @@ describe('RvfPatternStore', () => {
     adapter = createMockAdapter();
     store = new RvfPatternStore(
       () => adapter,
-      { rvfPath: '/tmp/test.rvf', base: undefined as any },
+      { rvfPath: '/tmp/test.rvf', base: undefined as any, embeddingSpaceId: TEST_SPACE_ID },
     );
     // Attach an isolated, non-unified SQLite store per test — without this,
     // RvfPatternStore.initialize() auto-attaches the ADR-046 unified
@@ -212,7 +214,7 @@ describe('RvfPatternStore', () => {
       await store.store(pattern);
 
       // Search with its own embedding
-      const result = await store.search(pattern.embedding!, { limit: 5 });
+      const result = await store.search(pattern.embedding!, { limit: 5, embeddingSpaceId: TEST_SPACE_ID });
 
       expect(result.success).toBe(true);
       if (result.success) {
@@ -240,6 +242,7 @@ describe('RvfPatternStore', () => {
       const result = await store.search(p1.embedding!, {
         domain: 'test-generation',
         limit: 10,
+        embeddingSpaceId: TEST_SPACE_ID,
       });
 
       expect(result.success).toBe(true);
@@ -384,16 +387,16 @@ describe('migratePatterns', () => {
     const adapter = createMockAdapter();
     const mockSqlite = {
       getAllEmbeddings: vi.fn(() => [
-        { patternId: 'p1', embedding: Array.from({ length: 384 }, () => 0.5) },
-        { patternId: 'p2', embedding: Array.from({ length: 384 }, () => 0.3) },
-        { patternId: 'p3', embedding: Array.from({ length: 384 }, () => 0.7) },
+        { patternId: 'p1', embedding: Array.from({ length: 384 }, () => 0.5), spaceId: TEST_SPACE_ID },
+        { patternId: 'p2', embedding: Array.from({ length: 384 }, () => 0.3), spaceId: TEST_SPACE_ID },
+        { patternId: 'p3', embedding: Array.from({ length: 384 }, () => 0.7), spaceId: TEST_SPACE_ID },
       ]),
     };
 
     const result = migratePatterns(
       mockSqlite as any,
       adapter,
-      { batchSize: 2, dimension: 384 },
+      { batchSize: 2, dimension: 384, embeddingSpaceId: TEST_SPACE_ID },
     );
 
     expect(result.totalMigrated).toBe(3);
@@ -408,15 +411,15 @@ describe('migratePatterns', () => {
     const adapter = createMockAdapter();
     const mockSqlite = {
       getAllEmbeddings: vi.fn(() => [
-        { patternId: 'p1', embedding: Array.from({ length: 384 }, () => 0.5) },
-        { patternId: 'p2', embedding: Array.from({ length: 128 }, () => 0.3) }, // wrong dim
+        { patternId: 'p1', embedding: Array.from({ length: 384 }, () => 0.5), spaceId: TEST_SPACE_ID },
+        { patternId: 'p2', embedding: Array.from({ length: 128 }, () => 0.3), spaceId: TEST_SPACE_ID }, // wrong dim
       ]),
     };
 
     const result = migratePatterns(
       mockSqlite as any,
       adapter,
-      { dimension: 384 },
+      { dimension: 384, embeddingSpaceId: TEST_SPACE_ID },
     );
 
     expect(result.totalMigrated).toBe(1);

--- a/tests/unit/learning/semantic-retriever.test.ts
+++ b/tests/unit/learning/semantic-retriever.test.ts
@@ -5,7 +5,7 @@
  * a diversity-heavy policy select different examples from the same corpus.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import Database from 'better-sqlite3';
 import { createSemanticRetriever } from '../../../src/learning/qe-flywheel/coupled-anchor.js';
 import { DEFAULT_POLICY } from '../../../src/learning/qe-flywheel/policy.js';
@@ -48,19 +48,19 @@ describe('createSemanticRetriever', () => {
   const embed = async () => [1, 0, 0, 0]; // fixed query vector
 
   it('should_rank_the_most_similar_pattern_first', async () => {
-    const r = createSemanticRetriever({ db, embed, embeddingSpace: SPACE, topK: 1 });
+    const r = createSemanticRetriever({ db, embed, writeEmbed: embed, embeddingSpace: SPACE, topK: 1 });
     const top = await r('q', DEFAULT_POLICY);
     expect(top[0].id).toBe('A');
   });
 
   it('should_select_the_redundant_neighbor_when_mmrLambda_favors_relevance', async () => {
-    const r = createSemanticRetriever({ db, embed, embeddingSpace: SPACE, topK: 2 });
+    const r = createSemanticRetriever({ db, embed, writeEmbed: embed, embeddingSpace: SPACE, topK: 2 });
     const top = await r('q', { ...DEFAULT_POLICY, mmrLambda: 1.0 }); // pure relevance
     expect(top.map((e) => e.id)).toEqual(['A', 'B']);
   });
 
   it('should_select_the_diverse_pattern_when_mmrLambda_favors_diversity', async () => {
-    const r = createSemanticRetriever({ db, embed, embeddingSpace: SPACE, topK: 2 });
+    const r = createSemanticRetriever({ db, embed, writeEmbed: embed, embeddingSpace: SPACE, topK: 2 });
     const top = await r('q', { ...DEFAULT_POLICY, mmrLambda: 0.0 }); // pure diversity
     // A is still picked first (highest relevance); the second slot flips to the
     // pattern most DIVERSE from A — C, not the A-redundant B.
@@ -70,7 +70,7 @@ describe('createSemanticRetriever', () => {
   it('should_return_empty_for_an_empty_corpus', async () => {
     const empty = new Database(':memory:');
     empty.exec(SCHEMA);
-    const r = createSemanticRetriever({ db: empty, embed, embeddingSpace: SPACE, topK: 3 });
+    const r = createSemanticRetriever({ db: empty, embed, writeEmbed: embed, embeddingSpace: SPACE, topK: 3 });
     expect(await r('q', DEFAULT_POLICY)).toEqual([]);
     empty.close();
   });
@@ -93,7 +93,23 @@ describe('createSemanticRetriever', () => {
   it('classifies legacy vectors as unverified and uses only an explicit fallback', async () => {
     db.prepare('UPDATE qe_pattern_embeddings SET space_id = NULL WHERE pattern_id = ?').run('A');
     const fallback = () => [{ id: 'lexical', name: 'fallback', body: 'non-semantic' }];
-    const r = createSemanticRetriever({ db, embed, embeddingSpace: SPACE, fallback });
+    const r = createSemanticRetriever({ db, embed, writeEmbed: embed, embeddingSpace: SPACE, fallback });
     await expect(r('q', DEFAULT_POLICY)).resolves.toEqual(fallback());
+  });
+
+  it('retries a transient write/read canary failure', async () => {
+    const writeEmbed = vi.fn()
+      .mockRejectedValueOnce(new Error('temporary storage embedder outage'))
+      .mockResolvedValue([1, 0, 0, 0]);
+    const r = createSemanticRetriever({ db, embed, writeEmbed, embeddingSpace: SPACE });
+
+    await expect(r('q', DEFAULT_POLICY)).rejects.toThrow('temporary storage embedder outage');
+    await expect(r('q', DEFAULT_POLICY)).resolves.toHaveLength(3);
+    expect(writeEmbed).toHaveBeenCalledTimes(2);
+  });
+
+  it('refuses a tautological canary when the storage-side path is absent', async () => {
+    const r = createSemanticRetriever({ db, embed, embeddingSpace: SPACE });
+    await expect(r('q', DEFAULT_POLICY)).rejects.toMatchObject({ code: 'VECTOR_SPACE_UNVERIFIED' });
   });
 });

--- a/tests/unit/learning/semantic-retriever.test.ts
+++ b/tests/unit/learning/semantic-retriever.test.ts
@@ -9,11 +9,17 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import Database from 'better-sqlite3';
 import { createSemanticRetriever } from '../../../src/learning/qe-flywheel/coupled-anchor.js';
 import { DEFAULT_POLICY } from '../../../src/learning/qe-flywheel/policy.js';
+import { deriveEmbeddingSpaceIdentity } from '../../../src/learning/embedding-space.js';
 
 const SCHEMA = `
   CREATE TABLE qe_patterns (id TEXT PRIMARY KEY, name TEXT, description TEXT, deprecated_at TEXT DEFAULT NULL);
-  CREATE TABLE qe_pattern_embeddings (pattern_id TEXT PRIMARY KEY, embedding BLOB NOT NULL, dimension INTEGER NOT NULL);
+  CREATE TABLE qe_pattern_embeddings (pattern_id TEXT PRIMARY KEY, embedding BLOB NOT NULL, dimension INTEGER NOT NULL, space_id TEXT);
 `;
+
+const SPACE = deriveEmbeddingSpaceIdentity({
+  provider: 'test', model: 'same-model', dimensions: 4, normalized: true,
+  runtimeFingerprint: 'runtime-a',
+});
 
 function blob(v: number[]): Buffer {
   return Buffer.from(new Float32Array(v).buffer);
@@ -34,27 +40,27 @@ describe('createSemanticRetriever', () => {
       ['C', [0, 1, 0, 0]],
     ];
     const ins = db.prepare('INSERT INTO qe_patterns (id, name, description) VALUES (?, ?, ?)');
-    const insE = db.prepare('INSERT INTO qe_pattern_embeddings (pattern_id, embedding, dimension) VALUES (?, ?, 4)');
-    for (const [id, vec] of rows) { ins.run(id, `name-${id}`, `body-${id}`); insE.run(id, blob(vec)); }
+    const insE = db.prepare('INSERT INTO qe_pattern_embeddings (pattern_id, embedding, dimension, space_id) VALUES (?, ?, 4, ?)');
+    for (const [id, vec] of rows) { ins.run(id, `name-${id}`, `body-${id}`); insE.run(id, blob(vec), SPACE.spaceId); }
   });
   afterEach(() => db.close());
 
   const embed = async () => [1, 0, 0, 0]; // fixed query vector
 
   it('should_rank_the_most_similar_pattern_first', async () => {
-    const r = createSemanticRetriever({ db, embed, topK: 1 });
+    const r = createSemanticRetriever({ db, embed, embeddingSpace: SPACE, topK: 1 });
     const top = await r('q', DEFAULT_POLICY);
     expect(top[0].id).toBe('A');
   });
 
   it('should_select_the_redundant_neighbor_when_mmrLambda_favors_relevance', async () => {
-    const r = createSemanticRetriever({ db, embed, topK: 2 });
+    const r = createSemanticRetriever({ db, embed, embeddingSpace: SPACE, topK: 2 });
     const top = await r('q', { ...DEFAULT_POLICY, mmrLambda: 1.0 }); // pure relevance
     expect(top.map((e) => e.id)).toEqual(['A', 'B']);
   });
 
   it('should_select_the_diverse_pattern_when_mmrLambda_favors_diversity', async () => {
-    const r = createSemanticRetriever({ db, embed, topK: 2 });
+    const r = createSemanticRetriever({ db, embed, embeddingSpace: SPACE, topK: 2 });
     const top = await r('q', { ...DEFAULT_POLICY, mmrLambda: 0.0 }); // pure diversity
     // A is still picked first (highest relevance); the second slot flips to the
     // pattern most DIVERSE from A — C, not the A-redundant B.
@@ -64,8 +70,30 @@ describe('createSemanticRetriever', () => {
   it('should_return_empty_for_an_empty_corpus', async () => {
     const empty = new Database(':memory:');
     empty.exec(SCHEMA);
-    const r = createSemanticRetriever({ db: empty, embed, topK: 3 });
+    const r = createSemanticRetriever({ db: empty, embed, embeddingSpace: SPACE, topK: 3 });
     expect(await r('q', DEFAULT_POLICY)).toEqual([]);
     empty.close();
+  });
+
+  it('rejects two 4-dimensional embedders that advertise the same model', async () => {
+    const querySpace = deriveEmbeddingSpaceIdentity({
+      provider: 'test', model: 'same-model', dimensions: 4, normalized: true,
+      runtimeFingerprint: 'runtime-b',
+    });
+    const r = createSemanticRetriever({
+      db,
+      embed: async () => [0, 1, 0, 0],
+      writeEmbed: async () => [1, 0, 0, 0],
+      embeddingSpace: querySpace,
+      writeEmbeddingSpace: SPACE,
+    });
+    await expect(r('q', DEFAULT_POLICY)).rejects.toMatchObject({ code: 'VECTOR_SPACE_MISMATCH' });
+  });
+
+  it('classifies legacy vectors as unverified and uses only an explicit fallback', async () => {
+    db.prepare('UPDATE qe_pattern_embeddings SET space_id = NULL WHERE pattern_id = ?').run('A');
+    const fallback = () => [{ id: 'lexical', name: 'fallback', body: 'non-semantic' }];
+    const r = createSemanticRetriever({ db, embed, embeddingSpace: SPACE, fallback });
+    await expect(r('q', DEFAULT_POLICY)).resolves.toEqual(fallback());
   });
 });

--- a/tests/unit/learning/sqlite-embedding-backfill.test.ts
+++ b/tests/unit/learning/sqlite-embedding-backfill.test.ts
@@ -1,16 +1,18 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const embeddingMocks = vi.hoisted(() => ({
   computeBatchEmbeddings: vi.fn().mockRejectedValue(new Error('optional model unavailable')),
+  activeSpace: { spaceId: 'active-space' },
 }));
 
 vi.mock('../../../src/learning/real-embeddings.js', () => ({
   computeBatchEmbeddings: (...args: unknown[]) => embeddingMocks.computeBatchEmbeddings(...args),
   getEmbeddingDimension: () => 384,
   isUsingEndpoint: () => false,
+  getActiveEmbeddingSpaceIdentity: () => embeddingMocks.activeSpace,
 }));
 
 import { SQLitePatternStore } from '../../../src/learning/sqlite-persistence.js';
@@ -45,4 +47,47 @@ describe('SQLite pattern embedding backfill (#584)', () => {
 
     await expect(store.backfillEmbeddings()).rejects.toThrow('optional model unavailable');
   });
+
+  it('re-embeds legacy and mismatched rows under the active space', async () => {
+    embeddingMocks.computeBatchEmbeddings
+      .mockReset()
+      .mockResolvedValueOnce([new Array(384).fill(0.1)])
+      .mockResolvedValueOnce([
+        new Array(384).fill(0.2),
+        new Array(384).fill(0.3),
+      ]);
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aqe-pattern-backfill-'));
+    store = new SQLitePatternStore({
+      useUnified: false,
+      dbPath: path.join(tempDir, 'memory.db'),
+    });
+    await store.initialize();
+    for (const id of ['legacy', 'mismatched']) {
+      store.exec(`
+        INSERT INTO qe_patterns (
+          id, pattern_type, qe_domain, domain, name, description, template_json,
+          context_json, confidence, usage_count, successful_uses,
+          success_rate, quality_score, tier, created_at, updated_at
+        ) VALUES (
+          '${id}', 'unit', 'test-generation', 'test-generation', '${id}', '${id}',
+          '{}', '{}', 0.8, 0, 0, 0, 0.8, 'short-term', datetime('now'), datetime('now')
+        );
+      `);
+      store.storePatternEmbedding(id, new Array(384).fill(0), id === 'legacy' ? 'old-space' : 'other-space');
+    }
+    store.exec("UPDATE qe_pattern_embeddings SET space_id = NULL WHERE pattern_id = 'legacy'");
+
+    await expect(store.backfillEmbeddings()).resolves.toMatchObject({ processed: 2 });
+    expect(store.getEmbeddingSpaceDiagnostics('active-space')).toMatchObject({
+      status: 'healthy',
+      verifiedVectors: 2,
+      unverifiedVectors: 0,
+      mismatchedVectors: 0,
+    });
+  });
 });
+  beforeEach(() => {
+    embeddingMocks.computeBatchEmbeddings
+      .mockReset()
+      .mockRejectedValue(new Error('optional model unavailable'));
+  });

--- a/tests/unit/learning/sqlite-persistence-recent-embeddings.test.ts
+++ b/tests/unit/learning/sqlite-persistence-recent-embeddings.test.ts
@@ -64,12 +64,19 @@ describe('SQLitePatternStore.getRecentEmbeddings()', () => {
 
     for (let i = 0; i < 25; i++) {
       const p = makePattern(`p-${i}`, i);
-      store.storePattern(p, p.embedding);
+      store.storePattern(p, p.embedding, 'test-space');
     }
 
     const recent = store.getRecentEmbeddings(10);
     expect(recent).toHaveLength(10);
     expect(recent.every((r) => Array.isArray(r.embedding) && r.embedding.length === 8)).toBe(true);
+    expect(recent.every((r) => r.spaceId === 'test-space')).toBe(true);
+    expect(store.getEmbeddingSpaceDiagnostics('test-space')).toMatchObject({
+      status: 'healthy',
+      verifiedVectors: 25,
+      unverifiedVectors: 0,
+      mismatchedVectors: 0,
+    });
   });
 
   it('orders by most-recently-used first', async () => {
@@ -77,9 +84,9 @@ describe('SQLitePatternStore.getRecentEmbeddings()', () => {
     await store.initialize();
 
     // Insert in arbitrary order
-    store.storePattern(makePattern('p-2', 2), makePattern('p-2', 2).embedding);
-    store.storePattern(makePattern('p-0', 0), makePattern('p-0', 0).embedding);
-    store.storePattern(makePattern('p-1', 1), makePattern('p-1', 1).embedding);
+    store.storePattern(makePattern('p-2', 2), makePattern('p-2', 2).embedding, 'test-space');
+    store.storePattern(makePattern('p-0', 0), makePattern('p-0', 0).embedding, 'test-space');
+    store.storePattern(makePattern('p-1', 1), makePattern('p-1', 1).embedding, 'test-space');
 
     // storePattern() does not populate last_used_at (that column tracks usage,
     // not creation). Set it explicitly here so the ORDER BY has deterministic
@@ -101,7 +108,7 @@ describe('SQLitePatternStore.getRecentEmbeddings()', () => {
 
     for (let i = 0; i < 5; i++) {
       const p = makePattern(`p-${i}`, i);
-      store.storePattern(p, p.embedding);
+      store.storePattern(p, p.embedding, 'test-space');
     }
 
     // Negative / NaN should fall back to the 1000 default — i.e. return all 5.
@@ -114,5 +121,21 @@ describe('SQLitePatternStore.getRecentEmbeddings()', () => {
     await store.initialize();
 
     expect(store.getRecentEmbeddings(10)).toEqual([]);
+  });
+
+  it('reports legacy rows without space_id as unverified', async () => {
+    const store = createSQLitePatternStore({ dbPath, useUnified: false });
+    await store.initialize();
+    const pattern = makePattern('legacy', 0);
+    store.storePattern(pattern, pattern.embedding, 'test-space');
+
+    const raw = new Database(dbPath);
+    raw.prepare('UPDATE qe_pattern_embeddings SET space_id = NULL WHERE pattern_id = ?').run('legacy');
+    raw.close();
+
+    expect(store.getEmbeddingSpaceDiagnostics('test-space')).toMatchObject({
+      status: 'unverified',
+      unverifiedVectors: 1,
+    });
   });
 });

--- a/tests/unit/persistence/rvf-migration-adapter.test.ts
+++ b/tests/unit/persistence/rvf-migration-adapter.test.ts
@@ -17,6 +17,11 @@ import type { RvfStore } from '../../../src/integrations/ruvector/rvf-dual-write
 import Database from 'better-sqlite3';
 import type { Database as DatabaseType } from 'better-sqlite3';
 
+const TEST_SPACE_ID = 'rvf-migration-test-space';
+vi.mock('../../../src/learning/real-embeddings.js', () => ({
+  getActiveEmbeddingSpaceIdentity: () => ({ spaceId: TEST_SPACE_ID }),
+}));
+
 // ============================================================================
 // Test Helpers
 // ============================================================================
@@ -29,6 +34,7 @@ function createTestDb(): DatabaseType {
       embedding BLOB NOT NULL,
       dimension INTEGER NOT NULL,
       model TEXT DEFAULT 'all-MiniLM-L6-v2',
+      space_id TEXT,
       created_at TEXT DEFAULT (datetime('now'))
     )
   `);
@@ -37,12 +43,12 @@ function createTestDb(): DatabaseType {
 
 function seedEmbeddings(db: DatabaseType, count: number, dim = 384): void {
   const insert = db.prepare(
-    'INSERT OR REPLACE INTO qe_pattern_embeddings (pattern_id, embedding, dimension) VALUES (?, ?, ?)',
+    'INSERT OR REPLACE INTO qe_pattern_embeddings (pattern_id, embedding, dimension, space_id) VALUES (?, ?, ?, ?)',
   );
   for (let i = 0; i < count; i++) {
     const vec = new Float32Array(dim);
     for (let j = 0; j < dim; j++) vec[j] = Math.sin(i * 0.1 + j * 0.01);
-    insert.run(`pattern-${i}`, Buffer.from(vec.buffer), dim);
+    insert.run(`pattern-${i}`, Buffer.from(vec.buffer), dim, TEST_SPACE_ID);
   }
 }
 

--- a/tests/unit/rvf-dual-writer.test.ts
+++ b/tests/unit/rvf-dual-writer.test.ts
@@ -12,6 +12,11 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import Database from 'better-sqlite3';
+
+vi.mock('../../src/learning/real-embeddings.js', () => ({
+  getActiveEmbeddingSpaceIdentity: () => ({ spaceId: 'unrelated-global-space' }),
+}));
+
 import {
   RvfDualWriter,
   createDualWriter as createDualWriterImpl,
@@ -118,6 +123,24 @@ function insertTestPattern(db: Database.Database, id: string): void {
     VALUES (?, 'test-template', 'test-generation', 'test-generation', ?, 'Test pattern')
   `).run(id, `Pattern ${id}`);
 }
+
+it('keeps an injected writer bound to its owning embedding space', () => {
+  const db = createTestDb();
+  insertTestPattern(db, 'owned-space');
+  const writer = createDualWriter(db, {
+    rvfPath: '/tmp/not-opened.rvf',
+    mode: 'sqlite-only',
+  });
+
+  const result = writer.writePattern('owned-space', [1, 0, 0]);
+
+  expect(result.sqliteSuccess).toBe(true);
+  const row = db.prepare(
+    'SELECT space_id AS spaceId FROM qe_pattern_embeddings WHERE pattern_id = ?',
+  ).get('owned-space') as { spaceId: string };
+  expect(row.spaceId).toBe(TEST_SPACE_ID);
+  db.close();
+});
 
 function makeEmbedding(dim = 384): number[] {
   const emb = new Array(dim).fill(0);

--- a/tests/unit/rvf-dual-writer.test.ts
+++ b/tests/unit/rvf-dual-writer.test.ts
@@ -14,11 +14,23 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import Database from 'better-sqlite3';
 import {
   RvfDualWriter,
-  createDualWriter,
+  createDualWriter as createDualWriterImpl,
   type DualWriteConfig,
   type RvfStore,
   type RvfStatus,
 } from '../../src/integrations/ruvector/rvf-dual-writer.js';
+
+const TEST_SPACE_ID = 'rvf-dual-writer-test-space';
+
+function createDualWriter(
+  db: Database.Database,
+  config: DualWriteConfig,
+): RvfDualWriter {
+  return createDualWriterImpl(db, {
+    ...config,
+    embeddingSpaceId: TEST_SPACE_ID,
+  });
+}
 
 // ============================================================================
 // Helpers


### PR DESCRIPTION
## Summary

Enforces one runtime-derived embedding-space contract across SQLite, in-memory HNSW, native RVF, migration, dual-write, backfill, and semantic retrieval. Embeddings now carry durable provenance; legacy or incompatible vectors are excluded until re-embedded, ANN stores fail closed when their durable identity cannot be verified, and `aqe learning embedding-health` exposes active/stored compatibility diagnostics.

Closes #633

## Verification

- `npm run typecheck` — passed
- ESLint over every changed source file — passed
- `npm run test:unit:fast` — 8,497 passed, 6 skipped
- `npm run test:integration:fast` — 23 passed, 3 skipped
- focused embedding/provenance, schema migration, SQLite backfill, RVF migration/recovery, semantic canary, and native benchmark tests — passed
- `git diff --check` — passed
- repository-wide `npm run lint` still reports the repository's existing unrelated lint backlog; no changed source file reports an error

## Failure modes

- Same-name and same-dimension embedders that produce incompatible vectors are rejected before semantic ranking; covered by semantic retriever and embedding-space tests.
- Legacy SQLite rows without provenance, and rows from another space, are excluded from ranking and selected by the re-embedding backfill; covered by schema migration and backfill tests.
- A populated RVF index without durable provenance, or with a mismatched sidecar identity after restart, fails closed; covered by RVF pattern-store and embedding-space manifest tests.
- A transient semantic canary failure can be retried rather than poisoning the process permanently; covered by the coupled-anchor tests.
- Corrupt RVF recovery moves the embedding-space sidecar with the quarantined index and propagates configured provenance through the factory; covered by RVF corruption and recovery tests.
- This slice deliberately does not guess provenance for populated legacy ANN indexes. They must be rebuilt/re-embedded under an initialized runtime identity; the refusal path is tested.

---

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.** "Unlikely" is not an acceptable substitute. If you wrote "I don't think this can happen but...", that sentence is a failure mode and needs a test or an issue link.

### Optional context

- Linked issues: #633
- Trust tier change (if any): none
- Affects published API or CLI surface: yes — adds `aqe learning embedding-health`
- Touches the init flow / `npm-publish.yml` / `tests/fixtures/init-corpus/`: no
