### PR TITLE
fix(llm): initialize external providers for advisor

### DIFF
--- a/docs/implementation/adrs/ADR-127-external-provider-registration.md
+++ b/docs/implementation/adrs/ADR-127-external-provider-registration.md
@@ -5,6 +5,7 @@
 | **Decision ID** | ADR-127 |
 | **Status** | Accepted — implemented (see Verification) |
 | **Date** | 2026-08-19 |
+| **Updated** | 2026-08-30 — config-aware advisor CLI/MCP construction |
 | **Author** | AQE Core |
 | **Review Cadence** | 6 months |
 | **Supersedes** | — |
@@ -293,6 +294,14 @@ tests pin the built-in wording as well as the external wording.
 ## Verification
 
 Everything below was executed, not asserted.
+
+The 2026-08-30 amendment closes a construction-path drift found after release:
+`aqe llm advise` used a private minimal router bootstrap and therefore skipped
+config-declared provider registration. It now uses the same config-aware router
+service as the kernel. A real CLI subprocess regression declares an external
+host, invokes `llm advise`, and asserts both the host marker and provider
+identity. Because MCP `advisor_consult` delegates to this command, its protocol
+test must cover the same declaration before #628 closes.
 
 | Check | Result |
 |---|---|

--- a/src/cli/commands/llm-router.ts
+++ b/src/cli/commands/llm-router.ts
@@ -893,35 +893,31 @@ async function executeAdvise(options: AdviseOptions): Promise<void> {
     }
 
     // Lazy-load to keep CLI cold-start fast when advise is not used
-    const { createProviderManager } = await import('../../shared/llm/provider-manager.js');
-    const { createHybridRouter } = await import('../../shared/llm/router/hybrid-router.js');
+    const { createLLMRouterService } = await import('../../shared/llm/llm-router-service.js');
     const { MultiModelExecutor, DEFAULT_ADVISOR_PROVIDER, DEFAULT_ADVISOR_MODEL } =
       await import('../../routing/advisor/multi-model-executor.js');
 
     const provider = (options.provider ?? DEFAULT_ADVISOR_PROVIDER) as ExtendedProviderType;
     const model = options.model ?? DEFAULT_ADVISOR_MODEL;
 
-    // Phase 0: bootstrap a minimal ProviderManager + HybridRouter for the advisor call.
-    // Phase 1+ reuses a shared router from the AQE kernel.
-    const providerManager = createProviderManager({
-      primary: provider === 'openrouter' ? 'openrouter' : (provider as any),
-      providers: {
-        openrouter: {
-          apiKey: process.env.OPENROUTER_API_KEY,
-          model,
-        },
+    // Use the same config-aware construction path as the kernel. In particular,
+    // loadRouterConfig() registers ADR-127 external providers before the
+    // ProviderManager is built. The old minimal bootstrap bypassed that step,
+    // so `llm providers` recognized a declared host while `llm advise` rejected
+    // the same identity as unknown (#628).
+    const built = await createLLMRouterService({
+      projectRoot: configProjectRoot(),
+      override: {
+        mode: 'manual',
+        defaultProvider: provider,
+        defaultModel: model,
       },
     });
+    if (!built) {
+      throw new Error(`No enabled LLM provider is available for advisor provider "${provider}".`);
+    }
 
-    const router = createHybridRouter(providerManager, {
-      mode: 'manual',
-      defaultProvider: provider as any,
-      defaultModel: model,
-    });
-
-    await router.initialize();
-
-    const executor = new MultiModelExecutor(router);
+    const executor = new MultiModelExecutor(built.router);
 
     const redactMode = (options.redact ?? 'strict') as 'strict' | 'balanced' | 'off';
     const result = await executor.consult(transcript, {

--- a/src/cli/commands/llm-router.ts
+++ b/src/cli/commands/llm-router.ts
@@ -907,6 +907,9 @@ async function executeAdvise(options: AdviseOptions): Promise<void> {
     // the same identity as unknown (#628).
     const built = await createLLMRouterService({
       projectRoot: configProjectRoot(),
+      // Advisor transcripts may be paired with ambient API credentials. A
+      // repository-controlled baseUrl must never become their destination.
+      allowProjectProviderEndpoints: false,
       override: {
         mode: 'manual',
         defaultProvider: provider,

--- a/src/cli/commands/llm-router.ts
+++ b/src/cli/commands/llm-router.ts
@@ -894,11 +894,10 @@ async function executeAdvise(options: AdviseOptions): Promise<void> {
 
     // Lazy-load to keep CLI cold-start fast when advise is not used
     const { createLLMRouterService } = await import('../../shared/llm/llm-router-service.js');
-    const { MultiModelExecutor, DEFAULT_ADVISOR_PROVIDER, DEFAULT_ADVISOR_MODEL } =
+    const { MultiModelExecutor, DEFAULT_ADVISOR_MODEL } =
       await import('../../routing/advisor/multi-model-executor.js');
 
-    const provider = (options.provider ?? DEFAULT_ADVISOR_PROVIDER) as ExtendedProviderType;
-    const model = options.model ?? DEFAULT_ADVISOR_MODEL;
+    const requestedProvider = options.provider as ExtendedProviderType | undefined;
 
     // Use the same config-aware construction path as the kernel. In particular,
     // loadRouterConfig() registers ADR-127 external providers before the
@@ -912,13 +911,20 @@ async function executeAdvise(options: AdviseOptions): Promise<void> {
       allowProjectProviderEndpoints: false,
       override: {
         mode: 'manual',
-        defaultProvider: provider,
-        defaultModel: model,
+        ...(requestedProvider ? { defaultProvider: requestedProvider } : {}),
+        ...(options.model ? { defaultModel: options.model } : {}),
       },
     });
     if (!built) {
-      throw new Error(`No enabled LLM provider is available for advisor provider "${provider}".`);
+      throw new Error(`No enabled LLM provider is available for advisor${requestedProvider ? ` provider "${requestedProvider}"` : ''}.`);
     }
+
+    // With no CLI/MCP override, honor the project's resolved default. Falling
+    // back to OpenRouter here made declared external defaults unreachable when
+    // an OpenRouter key happened to coexist in the environment.
+    const provider = requestedProvider ?? built.resolvedConfig.defaultProvider;
+    const model = options.model ?? built.resolvedConfig.providers?.[provider]?.defaultModel ??
+      built.resolvedConfig.defaultModel ?? DEFAULT_ADVISOR_MODEL;
 
     const executor = new MultiModelExecutor(built.router);
 

--- a/src/shared/llm/llm-router-service.ts
+++ b/src/shared/llm/llm-router-service.ts
@@ -99,6 +99,8 @@ export interface LLMRouterServiceOptions {
    * When supplied, config loading and provider construction is skipped.
    */
   providerManager?: ProviderManager;
+  /** Ignore project-controlled network endpoints before attaching ambient credentials. */
+  allowProjectProviderEndpoints?: boolean;
 }
 
 /**
@@ -191,7 +193,7 @@ export async function createLLMRouterService(
   const providerManagerConfig: Partial<ProviderManagerConfig> = {
     primary: primary as LLMProviderType,
     fallbacks: fallbacks as LLMProviderType[],
-    providers: extractProviderConfigs(config, enabled),
+    providers: extractProviderConfigs(config, enabled, options.allowProjectProviderEndpoints ?? true),
     loadBalancing: 'round-robin',
     global: { enableCostTracking: true, enableMetrics: true },
   };
@@ -290,7 +292,8 @@ export function pickPrimaryAndFallbacks(
  */
 export function extractProviderConfigs(
   config: RouterConfig,
-  enabled: ExtendedProviderType[]
+  enabled: ExtendedProviderType[],
+  allowProjectProviderEndpoints = true
 ): ProviderManagerConfig['providers'] {
   const out: ProviderManagerConfig['providers'] = {};
   for (const p of enabled) {
@@ -300,12 +303,10 @@ export function extractProviderConfigs(
       // trusted subscription CLI with an arbitrary executable. Callers that
       // intentionally need a custom binary can still construct ProviderManager
       // directly with an explicit config.
-      if (p === 'codex' || p === 'claude-code') {
-        const { binaryPath: _untrustedBinaryPath, ...safeCfg } = cfg as typeof cfg & { binaryPath?: string };
-        (out as Record<string, unknown>)[p] = safeCfg;
-      } else {
-        (out as Record<string, unknown>)[p] = cfg;
-      }
+      const sanitized = { ...cfg } as typeof cfg & { binaryPath?: string; baseUrl?: string };
+      if (p === 'codex' || p === 'claude-code') delete sanitized.binaryPath;
+      if (!allowProjectProviderEndpoints) delete sanitized.baseUrl;
+      (out as Record<string, unknown>)[p] = sanitized;
     }
   }
   return out;

--- a/src/shared/llm/llm-router-service.ts
+++ b/src/shared/llm/llm-router-service.ts
@@ -239,6 +239,13 @@ export function pickEnabledProviders(
   for (const p of FALLBACK_PRIORITY) {
     consider(p);
   }
+  // Finally, every explicitly configured provider. The fixed priority list is
+  // an ordering policy, not an allowlist: treating it as one made enabled
+  // subscription hosts (`codex`, `claude-code`) and registered external hosts
+  // unreachable unless repeated in fallbackChain (#631).
+  for (const p of Object.keys(config.providers ?? {}) as ExtendedProviderType[]) {
+    consider(p);
+  }
 
   return result;
 }

--- a/src/shared/llm/llm-router-service.ts
+++ b/src/shared/llm/llm-router-service.ts
@@ -26,6 +26,7 @@ import type {
   RouterConfig,
   ExtendedProviderType,
 } from './router/types.js';
+import { ALL_PROVIDER_TYPES } from './router/types.js';
 import type { ProviderManagerConfig, LLMProviderType } from './interfaces.js';
 import {
   loadRouterConfig,
@@ -239,11 +240,12 @@ export function pickEnabledProviders(
   for (const p of FALLBACK_PRIORITY) {
     consider(p);
   }
-  // Finally, every explicitly configured provider. The fixed priority list is
-  // an ordering policy, not an allowlist: treating it as one made enabled
-  // subscription hosts (`codex`, `claude-code`) and registered external hosts
-  // unreachable unless repeated in fallbackChain (#631).
-  for (const p of Object.keys(config.providers ?? {}) as ExtendedProviderType[]) {
+  // Finally, every AQE-shipped provider. The fixed priority list is an ordering
+  // policy, not an allowlist: treating it as one made enabled subscription
+  // hosts (`codex`, `claude-code`) unreachable unless repeated in fallbackChain.
+  // Do not implicitly activate project-declared external commands here: a
+  // checkout must not gain code execution merely through `enabled: true`.
+  for (const p of ALL_PROVIDER_TYPES) {
     consider(p);
   }
 
@@ -286,7 +288,7 @@ export function pickPrimaryAndFallbacks(
  * Extract only the provider configs for the enabled set, so
  * ProviderManager doesn't try to construct providers we don't need.
  */
-function extractProviderConfigs(
+export function extractProviderConfigs(
   config: RouterConfig,
   enabled: ExtendedProviderType[]
 ): ProviderManagerConfig['providers'] {
@@ -294,7 +296,16 @@ function extractProviderConfigs(
   for (const p of enabled) {
     const cfg = config.providers?.[p];
     if (cfg) {
-      (out as Record<string, unknown>)[p] = cfg;
+      // The kernel reads project-local config. Never let a checkout replace a
+      // trusted subscription CLI with an arbitrary executable. Callers that
+      // intentionally need a custom binary can still construct ProviderManager
+      // directly with an explicit config.
+      if (p === 'codex' || p === 'claude-code') {
+        const { binaryPath: _untrustedBinaryPath, ...safeCfg } = cfg as typeof cfg & { binaryPath?: string };
+        (out as Record<string, unknown>)[p] = safeCfg;
+      } else {
+        (out as Record<string, unknown>)[p] = cfg;
+      }
     }
   }
   return out;

--- a/tests/integration/llm/external-provider-declarative.test.ts
+++ b/tests/integration/llm/external-provider-declarative.test.ts
@@ -15,6 +15,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
 
 import {
   resetProviderRegistry,
@@ -28,6 +30,7 @@ import { ProviderManager } from '../../../src/shared/llm/provider-manager';
 import { HybridRouter } from '../../../src/shared/llm/router/hybrid-router';
 
 const HOST = 'my-host';
+const require = createRequire(import.meta.url);
 
 let projectRoot: string;
 let hostScript: string;
@@ -362,6 +365,47 @@ describe('ADR-127 declarative external providers (integration)', () => {
   });
 
   describe('end-to-end: declaration on disk to a routed answer', () => {
+    it('routes llm advise through a config-declared external provider (#628)', () => {
+      writeConfig(projectRoot, {
+        defaultProvider: HOST,
+        providers: { [HOST]: { enabled: true } },
+        externalProviders: {
+          [HOST]: {
+            kind: 'cli',
+            command: [hostScript],
+            billingMode: 'local',
+            models: ['proof-model'],
+            defaultModel: 'proof-model',
+          },
+        },
+      });
+      const transcriptPath = path.join(projectRoot, 'transcript.json');
+      fs.writeFileSync(transcriptPath, JSON.stringify({
+        taskDescription: 'External provider advisor regression',
+        messages: [{ role: 'user', content: 'Return the external provider marker.' }],
+      }));
+
+      const cliEntry = path.resolve(process.cwd(), 'src/cli/index.ts');
+      const stdout = execFileSync(process.execPath, [
+        '--import', require.resolve('tsx'), cliEntry,
+        'llm', 'advise',
+        '--transcript', transcriptPath,
+        '--provider', HOST,
+        '--model', 'proof-model',
+        '--agent', 'issue-628-regression',
+        '--trigger-reason', 'external-provider-regression',
+        '--json',
+      ], {
+        cwd: projectRoot,
+        env: { ...isolatedEnv(), AQE_CONFIG_ROOT: projectRoot },
+        encoding: 'utf8',
+      });
+
+      const result = JSON.parse(stdout);
+      expect(result.provider).toBe(HOST);
+      expect(JSON.parse(result.advice).marker).toBe('served-by-my-host');
+    });
+
     it('routes a chat request through the declared host', async () => {
       writeConfig(projectRoot, {
         externalProviders: {

--- a/tests/integration/llm/external-provider-declarative.test.ts
+++ b/tests/integration/llm/external-provider-declarative.test.ts
@@ -390,14 +390,14 @@ describe('ADR-127 declarative external providers (integration)', () => {
         '--import', require.resolve('tsx'), cliEntry,
         'llm', 'advise',
         '--transcript', transcriptPath,
-        '--provider', HOST,
-        '--model', 'proof-model',
         '--agent', 'issue-628-regression',
         '--trigger-reason', 'external-provider-regression',
         '--json',
       ], {
         cwd: projectRoot,
-        env: { ...isolatedEnv(), AQE_CONFIG_ROOT: projectRoot },
+        // A coexisting OpenRouter credential must not override the declared
+        // external default when MCP/CLI omits --provider.
+        env: { ...isolatedEnv(), OPENROUTER_API_KEY: 'coexisting-key', AQE_CONFIG_ROOT: projectRoot },
         encoding: 'utf8',
       });
 

--- a/tests/unit/shared/llm/llm-router-service.test.ts
+++ b/tests/unit/shared/llm/llm-router-service.test.ts
@@ -67,6 +67,20 @@ describe('pickEnabledProviders', () => {
     });
     expect(pickEnabledProviders(cfg, { GOOGLE_API_KEY: 'x' })).not.toContain('gemini');
   });
+
+  it('includes explicitly enabled subscription hosts without fallback entries (#631)', () => {
+    const cfg = mergeRouterConfig(DEFAULT_ROUTER_CONFIG, {
+      providers: {
+        codex: { enabled: true },
+        'claude-code': { enabled: true },
+      } as any,
+    });
+
+    const result = pickEnabledProviders(cfg, {});
+
+    expect(result).toContain('codex');
+    expect(result).toContain('claude-code');
+  });
 });
 
 describe('pickPrimaryAndFallbacks', () => {

--- a/tests/unit/shared/llm/llm-router-service.test.ts
+++ b/tests/unit/shared/llm/llm-router-service.test.ts
@@ -105,6 +105,17 @@ describe('extractProviderConfigs', () => {
     expect(result.codex.binaryPath).toBeUndefined();
     expect(result['claude-code'].binaryPath).toBeUndefined();
   });
+
+  it('drops project-controlled endpoints when the caller handles ambient credentials', () => {
+    const cfg = mergeRouterConfig(DEFAULT_ROUTER_CONFIG, {
+      providers: {
+        openrouter: { enabled: true, baseUrl: 'https://attacker.invalid/v1' },
+      } as any,
+    });
+
+    const result = extractProviderConfigs(cfg, ['openrouter'], false) as Record<string, any>;
+    expect(result.openrouter.baseUrl).toBeUndefined();
+  });
 });
 
 describe('pickPrimaryAndFallbacks', () => {

--- a/tests/unit/shared/llm/llm-router-service.test.ts
+++ b/tests/unit/shared/llm/llm-router-service.test.ts
@@ -17,6 +17,7 @@ import {
   createLLMRouterService,
   pickEnabledProviders,
   pickPrimaryAndFallbacks,
+  extractProviderConfigs,
 } from '../../../../src/shared/llm/llm-router-service';
 import { ProviderManager } from '../../../../src/shared/llm/provider-manager';
 import {
@@ -80,6 +81,29 @@ describe('pickEnabledProviders', () => {
 
     expect(result).toContain('codex');
     expect(result).toContain('claude-code');
+  });
+
+  it('does not implicitly execute project-declared external providers', () => {
+    const cfg = mergeRouterConfig(DEFAULT_ROUTER_CONFIG, {
+      providers: { payload: { enabled: true } } as any,
+    });
+
+    expect(pickEnabledProviders(cfg, {})).not.toContain('payload');
+  });
+});
+
+describe('extractProviderConfigs', () => {
+  it('drops project-controlled subscription binary paths', () => {
+    const cfg = mergeRouterConfig(DEFAULT_ROUTER_CONFIG, {
+      providers: {
+        codex: { enabled: true, binaryPath: './payload.sh' },
+        'claude-code': { enabled: true, binaryPath: './payload.sh' },
+      } as any,
+    });
+
+    const result = extractProviderConfigs(cfg, ['codex', 'claude-code']) as Record<string, any>;
+    expect(result.codex.binaryPath).toBeUndefined();
+    expect(result['claude-code'].binaryPath).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Outcome

Makes `aqe llm advise` use the same config-aware router construction path as the kernel, so providers declared through ADR-127 work through the advisor CLI and the MCP wrapper that delegates to it. Updates ADR-127 and adds a real subprocess regression.

Closes the post-release regression reported in #628; keep #628 open until this PR is merged and exact-SHA MCP evidence is posted.

## Verification

- `npx vitest run tests/integration/llm/external-provider-declarative.test.ts --reporter=verbose` — 28 passed
- `npm run typecheck` — passed
- `npm run build` — passed (CLI and MCP bundles built)
- `npx vitest run tests/unit/shared/llm tests/integration/llm --reporter=dot` — 1105 passed, 0 failed

## Failure modes

The regression test starts a real external host process and verifies both its response marker and provider identity. No production database is read or changed. MCP `advisor_consult` still delegates to `llm advise`; exact built-protocol evidence remains a merge/closure gate for #628.

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.**