### PR TITLE
fix(security): disclose local embedding advisories

### DIFF
--- a/docs/implementation/adrs/ADR-115-dependency-security-system.md
+++ b/docs/implementation/adrs/ADR-115-dependency-security-system.md
@@ -155,3 +155,19 @@ relying on the transitive install get a precise error telling them what to insta
 `npm install @huggingface/transformers` themselves, accepting the advisory
 knowingly. Everyone using an embedding endpoint (the default) no longer carries a
 HIGH CVE they never asked for.
+
+## Amendment (2026-08-30) — endpoint-first disclosure (issue #615)
+
+An exact packed-consumer test installed `agentic-qe@3.13.12` and then the
+documented compatible local provider, `@huggingface/transformers@4.2.0`. A
+production-only `npm audit` reported four HIGH findings across the provider and
+its `onnxruntime-node`, `adm-zip`, and `sharp` dependency paths. Installing safe
+top-level `adm-zip` and `sharp` versions did not remove the incompatible nested
+copies. The unresolved advisories are GHSA-xcpc-8h2w-3j85 and
+GHSA-f88m-g3jw-g9cj.
+
+Therefore all missing-provider guidance recommends `AQE_EMBEDDER_ENDPOINT`
+first. The local provider remains available only as an explicit security opt-in,
+and its error and MCP degradation messages disclose both advisories. We do not
+claim the vulnerable code paths are unexploitable without direct evidence, and
+we do not represent root overrides as consumer protection.

--- a/src/integrations/embeddings/base/EmbeddingGenerator.ts
+++ b/src/integrations/embeddings/base/EmbeddingGenerator.ts
@@ -141,9 +141,11 @@ export class EmbeddingGenerator {
       } catch (err) {
         throw new Error(
           'Local (in-process) embeddings require the optional dependency ' +
-          '"@huggingface/transformers", which is not installed. Either run ' +
-          '`npm install @huggingface/transformers`, or configure an embedding ' +
+          '"@huggingface/transformers", which is not installed. Configure an embedding ' +
           'endpoint (e.g. Cognitum /v1/embeddings) so the local backend is not needed. ' +
+          'Installing @huggingface/transformers@4.2.0 is an explicit security opt-in: ' +
+          'its compatible dependency chain currently has unresolved HIGH advisories ' +
+          'GHSA-xcpc-8h2w-3j85 and GHSA-f88m-g3jw-g9cj. ' +
           `Underlying import error: ${err instanceof Error ? err.message : String(err)}`
         );
       }

--- a/src/learning/real-embeddings.ts
+++ b/src/learning/real-embeddings.ts
@@ -226,9 +226,11 @@ async function initializeModel(config: Partial<EmbeddingConfig> = {}): Promise<v
       } catch {
         throw new Error(
           'In-process embeddings require the optional package "@huggingface/transformers", ' +
-          'which is not installed. Either run `npm install @huggingface/transformers`, or ' +
-          'configure an embedding endpoint (EmbeddingConfig.endpoint / AQE_EMBEDDER_ENDPOINT) ' +
-          'so no local model is loaded.'
+          'which is not installed. Configure an embedding endpoint ' +
+          '(EmbeddingConfig.endpoint / AQE_EMBEDDER_ENDPOINT) so no local model is loaded. ' +
+          'Installing @huggingface/transformers@4.2.0 is an explicit security opt-in: ' +
+          'its compatible dependency chain currently has unresolved HIGH advisories ' +
+          'GHSA-xcpc-8h2w-3j85 and GHSA-f88m-g3jw-g9cj.'
         );
       }
       pipeline = transformers.pipeline;

--- a/src/mcp/handlers/memory-handlers.ts
+++ b/src/mcp/handlers/memory-handlers.ts
@@ -111,14 +111,19 @@ export async function handleMemoryStore(
       vectorIndex = { status: 'indexed' };
     } catch {
       // Non-critical — KV store succeeded, vector indexing is best-effort
+      const vectorUnavailableMessage =
+        'Semantic vector indexing is unavailable for this entry. Configure AQE_EMBEDDER_ENDPOINT ' +
+        'for the recommended remote backend. The compatible local @huggingface/transformers@4.2.0 ' +
+        'dependency chain currently has unresolved HIGH advisories ' +
+        'GHSA-xcpc-8h2w-3j85 and GHSA-f88m-g3jw-g9cj.';
       console.warn(
-        '[MemoryHandler] VECTOR_INDEX_UNAVAILABLE: Semantic vector indexing is unavailable for this entry.'
+        `[MemoryHandler] VECTOR_INDEX_UNAVAILABLE: ${vectorUnavailableMessage}`
       );
       vectorIndex = {
         status: 'failed',
         error: {
           code: 'VECTOR_INDEX_UNAVAILABLE',
-          message: 'Semantic vector indexing is unavailable for this entry.',
+          message: vectorUnavailableMessage,
         },
       };
     }

--- a/tests/unit/learning/real-embeddings-guidance.test.ts
+++ b/tests/unit/learning/real-embeddings-guidance.test.ts
@@ -10,14 +10,16 @@ describe('real embeddings configuration guidance', () => {
     delete process.env.AQE_EMBEDDER_ENDPOINT;
   });
 
-  it('should name the environment variable read by the endpoint configuration', async () => {
+  it('should recommend the endpoint and disclose local provider advisories', async () => {
     const { computeRealEmbedding, resetInitialization } = await import(
       '../../../src/learning/real-embeddings.js'
     );
     resetInitialization();
 
-    await expect(
-      computeRealEmbedding('semantic test input', { enableCache: false })
-    ).rejects.toThrow('AQE_EMBEDDER_ENDPOINT');
+    const result = computeRealEmbedding('semantic test input', { enableCache: false });
+    await expect(result).rejects.toThrow('AQE_EMBEDDER_ENDPOINT');
+    await expect(result).rejects.toThrow('unresolved HIGH advisories');
+    await expect(result).rejects.toThrow('GHSA-xcpc-8h2w-3j85');
+    await expect(result).rejects.toThrow('GHSA-f88m-g3jw-g9cj');
   });
 });

--- a/tests/unit/mcp/handlers/memory-handlers.test.ts
+++ b/tests/unit/mcp/handlers/memory-handlers.test.ts
@@ -89,13 +89,14 @@ describe('Memory Handlers', { timeout: 30000 }, () => {
         status: 'failed',
         error: {
           code: 'VECTOR_INDEX_UNAVAILABLE',
-          message: 'Semantic vector indexing is unavailable for this entry.',
+          message: expect.stringContaining('AQE_EMBEDDER_ENDPOINT'),
         },
       });
+      expect(result.data!.vectorIndex?.error?.message).toContain('unresolved HIGH advisories');
+      expect(result.data!.vectorIndex?.error?.message).toContain('GHSA-xcpc-8h2w-3j85');
+      expect(result.data!.vectorIndex?.error?.message).toContain('GHSA-f88m-g3jw-g9cj');
       expect(JSON.stringify(result)).not.toContain('/private/model-cache');
-      expect(warning).toHaveBeenCalledWith(
-        '[MemoryHandler] VECTOR_INDEX_UNAVAILABLE: Semantic vector indexing is unavailable for this entry.'
-      );
+      expect(warning).toHaveBeenCalledWith(expect.stringContaining('AQE_EMBEDDER_ENDPOINT'));
       expect(JSON.stringify(warning.mock.calls)).not.toContain('/private/model-cache');
     });
 


### PR DESCRIPTION
## Outcome

Makes the remote embedding endpoint the explicit recommended path and discloses the unresolved HIGH advisories in the compatible local `@huggingface/transformers@4.2.0` dependency chain.

Closes #615

## Evidence

An exact packed consumer install of `agentic-qe@3.13.12` plus `@huggingface/transformers@4.2.0` reported four HIGH findings across `transformers`, `onnxruntime-node`, `adm-zip`, and `sharp`. Adding safe top-level `adm-zip` and `sharp` versions did not remove the vulnerable nested copies.

## Verification

- `npm test -- --run tests/unit/learning/real-embeddings-guidance.test.ts tests/unit/mcp/handlers/memory-handlers.test.ts tests/unit/cli/commands/memory-vector-warning.test.ts` — 53 passed
- `npm run typecheck` — passed
- `npm run build` — passed
- Exact packed consumer `npm audit --omit=dev --json` — reproduced four HIGH findings (the limitation this PR now discloses)

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.** "Unlikely" is not an acceptable substitute. If you wrote "I don't think this can happen but...", that sentence is a failure mode and needs a test or an issue link.