### PR TITLE
feat(verification): qualify judges by fault slice

### DIFF
--- a/docs/implementation/adrs/ADR-130-fault-stratified-judge-qualification.md
+++ b/docs/implementation/adrs/ADR-130-fault-stratified-judge-qualification.md
@@ -16,13 +16,16 @@ An aggregate judge score cannot authorize automation. AQE calibration reports
 fault-type, domain, and severity slices with support, precision, recall,
 false-kill, false-keep, uncertainty, and 95% Wilson intervals. A configurable
 minimum support produces `abstain`; weak confidence-bounded recall or excessive
-false-kill produces `human-review`; only supported slices meeting policy may
-`automate`.
+false-kill, false-keep, or weak precision produces `human-review`; only
+supported slices meeting policy may `automate`. Recall and precision must clear
+their Wilson lower bounds, while false-kill and false-keep must clear their
+Wilson upper bounds, so a favorable point estimate cannot hide uncertainty.
 
-A failed critical/high severity slice makes the judge unqualified even when the
-global result is strong. Non-critical unsupported or weak slices restrict the
-judge to the explicitly automated slices. Deterministic and executed oracles
-remain higher provenance than a judge verdict.
+Critical and high severity strata are mandatory. A missing, unsupported, or
+failed critical/high slice makes the judge unqualified even when the global
+result is strong. Non-critical unsupported or weak slices restrict the judge to
+the explicitly automated slices. Deterministic and executed oracles remain
+higher provenance than a judge verdict.
 
 The existing `calibrate(labeled, options)` call remains compatible. Metadata and
 qualification policy are additive, and callers may opt into stricter thresholds

--- a/docs/implementation/adrs/ADR-130-fault-stratified-judge-qualification.md
+++ b/docs/implementation/adrs/ADR-130-fault-stratified-judge-qualification.md
@@ -1,0 +1,42 @@
+# ADR-130: Qualify LLM judges by fault slice before automation
+
+| Field | Value |
+|-------|-------|
+| **Decision ID** | ADR-130 |
+| **Status** | Proposed — P0 calibration contract implemented; corpus review pending |
+| **Date** | 2026-08-30 |
+| **Author** | AQE Core |
+| **Review Cadence** | 3 months |
+| **Supersedes** | — |
+| **Related** | ADR-113, ADR-117, ADR-119, ADR-120, ADR-121, ADR-124, issue #635 |
+
+## Decision
+
+An aggregate judge score cannot authorize automation. AQE calibration reports
+fault-type, domain, and severity slices with support, precision, recall,
+false-kill, false-keep, uncertainty, and 95% Wilson intervals. A configurable
+minimum support produces `abstain`; weak confidence-bounded recall or excessive
+false-kill produces `human-review`; only supported slices meeting policy may
+`automate`.
+
+A failed critical/high severity slice makes the judge unqualified even when the
+global result is strong. Non-critical unsupported or weak slices restrict the
+judge to the explicitly automated slices. Deterministic and executed oracles
+remain higher provenance than a judge verdict.
+
+The existing `calibrate(labeled, options)` call remains compatible. Metadata and
+qualification policy are additive, and callers may opt into stricter thresholds
+through a third argument.
+
+## Consequences and remaining gates
+
+- Positive: Simpson-style aggregate masking becomes visible and enforceable.
+- Positive: small samples fail safe instead of reporting unstable point estimates.
+- Negative: qualification coverage is limited by corpus diversity and label quality.
+- Remaining: freeze and independently review the controlled-intervention corpus;
+  persist judge/prompt/config/corpus hashes; add ranking fidelity and perturbation
+  lanes; expose CLI/JSON artifacts; establish scheduled multi-backbone evaluation.
+
+This ADR remains Proposed until the corpus and operational thresholds receive
+independent review. The P0 library output is diagnostic and must not by itself
+be wired to irreversible promotion or release decisions.

--- a/src/verification/adversarial-verify/calibrate.ts
+++ b/src/verification/adversarial-verify/calibrate.ts
@@ -7,13 +7,52 @@
  * — a deterministic stub (characterize the k-of-n aggregation) or a real LLM
  * (empirical false-kill on a labeled corpus).
  */
-import type { AdversarialVerifyOptions, Finding } from './types.js';
+import type { AdversarialVerifyOptions, Finding, FindingSeverity, FindingOutcome } from './types.js';
 import { adversarialVerify } from './verify.js';
 
 export interface LabeledFinding {
   finding: Finding;
   /** Ground truth: is this a genuine, actionable problem? */
   isReal: boolean;
+  failureType?: string;
+  domain?: string;
+  expectedSeverity?: FindingSeverity;
+  source?: 'human' | 'oracle' | 'controlled-intervention';
+}
+
+export interface ConfidenceInterval { low: number; high: number; level: 0.95 }
+export type QualificationDisposition = 'automate' | 'human-review' | 'abstain';
+
+export interface QualificationSlice {
+  key: string;
+  support: number;
+  precision: number;
+  recall: number;
+  falseKillRate: number;
+  falseKeepRate: number;
+  uncertainRate: number;
+  intervals: {
+    precision: ConfidenceInterval;
+    recall: ConfidenceInterval;
+    falseKillRate: ConfidenceInterval;
+    falseKeepRate: ConfidenceInterval;
+  };
+  disposition: QualificationDisposition;
+}
+
+export interface QualificationOptions {
+  minSupport?: number;
+  minRecall?: number;
+  maxFalseKillRate?: number;
+  criticalSeverities?: FindingSeverity[];
+}
+
+export interface JudgeQualification {
+  status: 'qualified' | 'restricted' | 'unqualified';
+  automatedSlices: string[];
+  humanReviewSlices: string[];
+  abstainSlices: string[];
+  reasons: string[];
 }
 
 export interface CalibrationReport {
@@ -29,18 +68,100 @@ export interface CalibrationReport {
   correctConfirm: number; // real & upheld
   correctKill: number; // false & refuted
   uncertain: number; // no votes cast
+  slices: QualificationSlice[];
+  qualification: JudgeQualification;
+}
+
+const DEFAULT_QUALIFICATION: Required<QualificationOptions> = {
+  minSupport: 10,
+  minRecall: 0.8,
+  maxFalseKillRate: 0.1,
+  criticalSeverities: ['critical', 'high'],
+};
+
+function wilson(successes: number, total: number): ConfidenceInterval {
+  if (total === 0) return { low: 0, high: 1, level: 0.95 };
+  const z = 1.959963984540054;
+  const p = successes / total;
+  const z2 = z * z;
+  const denominator = 1 + z2 / total;
+  const centre = (p + z2 / (2 * total)) / denominator;
+  const margin = z * Math.sqrt((p * (1 - p) + z2 / (4 * total)) / total) / denominator;
+  return { low: Math.max(0, centre - margin), high: Math.min(1, centre + margin), level: 0.95 };
+}
+
+function buildSlice(
+  key: string,
+  entries: Array<{ label: LabeledFinding; verdict: FindingOutcome }>,
+  policy: Required<QualificationOptions>,
+): QualificationSlice {
+  const real = entries.filter(entry => entry.label.isReal);
+  const falseEntries = entries.filter(entry => !entry.label.isReal);
+  const upheldReal = real.filter(entry => entry.verdict === 'upheld').length;
+  const upheldFalse = falseEntries.filter(entry => entry.verdict === 'upheld').length;
+  const falseKill = real.filter(entry => entry.verdict === 'refuted').length;
+  const falseKeep = upheldFalse;
+  const uncertain = entries.filter(entry => entry.verdict === 'uncertain').length;
+  const upheld = upheldReal + upheldFalse;
+  const precision = upheld ? upheldReal / upheld : 0;
+  const recall = real.length ? upheldReal / real.length : 0;
+  const falseKillRate = real.length ? falseKill / real.length : 0;
+  const falseKeepRate = falseEntries.length ? falseKeep / falseEntries.length : 0;
+  let disposition: QualificationDisposition = 'automate';
+  if (entries.length < policy.minSupport || real.length === 0) disposition = 'abstain';
+  else if (wilson(upheldReal, real.length).low < policy.minRecall || falseKillRate > policy.maxFalseKillRate) {
+    disposition = 'human-review';
+  }
+  return {
+    key, support: entries.length, precision, recall, falseKillRate, falseKeepRate,
+    uncertainRate: entries.length ? uncertain / entries.length : 0,
+    intervals: {
+      precision: wilson(upheldReal, upheld),
+      recall: wilson(upheldReal, real.length),
+      falseKillRate: wilson(falseKill, real.length),
+      falseKeepRate: wilson(falseKeep, falseEntries.length),
+    },
+    disposition,
+  };
+}
+
+export function qualifyJudge(
+  slices: QualificationSlice[],
+  criticalSliceKeys: string[] = [],
+): JudgeQualification {
+  const automatedSlices = slices.filter(s => s.disposition === 'automate').map(s => s.key);
+  const humanReviewSlices = slices.filter(s => s.disposition === 'human-review').map(s => s.key);
+  const abstainSlices = slices.filter(s => s.disposition === 'abstain').map(s => s.key);
+  const criticalFailures = slices.filter(
+    s => criticalSliceKeys.includes(s.key) && s.disposition !== 'automate',
+  );
+  const status = criticalFailures.length > 0
+    ? 'unqualified'
+    : humanReviewSlices.length > 0 || abstainSlices.length > 0
+      ? 'restricted'
+      : 'qualified';
+  return {
+    status, automatedSlices, humanReviewSlices, abstainSlices,
+    reasons: criticalFailures.map(s => `Critical slice ${s.key} is ${s.disposition}`),
+  };
 }
 
 /** Run the verifier over a labeled set and report the confusion vs ground truth. */
 export async function calibrate(
   labeled: LabeledFinding[],
   opts: AdversarialVerifyOptions,
+  qualificationOptions: QualificationOptions = {},
 ): Promise<CalibrationReport> {
   const verdicts = await adversarialVerify(labeled.map((l) => l.finding), opts);
+  const policy = { ...DEFAULT_QUALIFICATION, ...qualificationOptions };
   const r: CalibrationReport = {
     total: labeled.length, realCount: 0, falseCount: 0,
     falseKill: 0, falseKillRate: 0, falseKeep: 0, falseKeepRate: 0,
-    correctConfirm: 0, correctKill: 0, uncertain: 0,
+    correctConfirm: 0, correctKill: 0, uncertain: 0, slices: [],
+    qualification: {
+      status: 'restricted', automatedSlices: [], humanReviewSlices: [],
+      abstainSlices: [], reasons: [],
+    },
   };
   labeled.forEach((l, i) => {
     const v = verdicts[i].verdict;
@@ -57,5 +178,22 @@ export async function calibrate(
   });
   r.falseKillRate = r.realCount ? r.falseKill / r.realCount : 0;
   r.falseKeepRate = r.falseCount ? r.falseKeep / r.falseCount : 0;
+  const entries = labeled.map((label, index) => ({ label, verdict: verdicts[index].verdict }));
+  const groups = new Map<string, typeof entries>();
+  const add = (key: string, entry: typeof entries[number]) => {
+    const group = groups.get(key) ?? [];
+    group.push(entry);
+    groups.set(key, group);
+  };
+  entries.forEach(entry => {
+    add('overall', entry);
+    if (entry.label.failureType) add(`failureType:${entry.label.failureType}`, entry);
+    if (entry.label.domain) add(`domain:${entry.label.domain}`, entry);
+    const severity = entry.label.expectedSeverity ?? entry.label.finding.severity;
+    add(`severity:${severity}`, entry);
+  });
+  r.slices = [...groups.entries()].map(([key, group]) => buildSlice(key, group, policy));
+  const criticalKeys = policy.criticalSeverities.map(severity => `severity:${severity}`);
+  r.qualification = qualifyJudge(r.slices, criticalKeys);
   return r;
 }

--- a/src/verification/adversarial-verify/calibrate.ts
+++ b/src/verification/adversarial-verify/calibrate.ts
@@ -43,7 +43,9 @@ export interface QualificationSlice {
 export interface QualificationOptions {
   minSupport?: number;
   minRecall?: number;
+  minPrecision?: number;
   maxFalseKillRate?: number;
+  maxFalseKeepRate?: number;
   criticalSeverities?: FindingSeverity[];
 }
 
@@ -75,7 +77,9 @@ export interface CalibrationReport {
 const DEFAULT_QUALIFICATION: Required<QualificationOptions> = {
   minSupport: 10,
   minRecall: 0.8,
+  minPrecision: 0.8,
   maxFalseKillRate: 0.1,
+  maxFalseKeepRate: 0.1,
   criticalSeverities: ['critical', 'high'],
 };
 
@@ -107,20 +111,26 @@ function buildSlice(
   const recall = real.length ? upheldReal / real.length : 0;
   const falseKillRate = real.length ? falseKill / real.length : 0;
   const falseKeepRate = falseEntries.length ? falseKeep / falseEntries.length : 0;
+  const intervals = {
+    precision: wilson(upheldReal, upheld),
+    recall: wilson(upheldReal, real.length),
+    falseKillRate: wilson(falseKill, real.length),
+    falseKeepRate: wilson(falseKeep, falseEntries.length),
+  };
   let disposition: QualificationDisposition = 'automate';
   if (entries.length < policy.minSupport || real.length === 0) disposition = 'abstain';
-  else if (wilson(upheldReal, real.length).low < policy.minRecall || falseKillRate > policy.maxFalseKillRate) {
+  else if (
+    intervals.recall.low < policy.minRecall
+    || intervals.precision.low < policy.minPrecision
+    || intervals.falseKillRate.high > policy.maxFalseKillRate
+    || intervals.falseKeepRate.high > policy.maxFalseKeepRate
+  ) {
     disposition = 'human-review';
   }
   return {
     key, support: entries.length, precision, recall, falseKillRate, falseKeepRate,
     uncertainRate: entries.length ? uncertain / entries.length : 0,
-    intervals: {
-      precision: wilson(upheldReal, upheld),
-      recall: wilson(upheldReal, real.length),
-      falseKillRate: wilson(falseKill, real.length),
-      falseKeepRate: wilson(falseKeep, falseEntries.length),
-    },
+    intervals,
     disposition,
   };
 }
@@ -132,17 +142,22 @@ export function qualifyJudge(
   const automatedSlices = slices.filter(s => s.disposition === 'automate').map(s => s.key);
   const humanReviewSlices = slices.filter(s => s.disposition === 'human-review').map(s => s.key);
   const abstainSlices = slices.filter(s => s.disposition === 'abstain').map(s => s.key);
+  const presentKeys = new Set(slices.map(s => s.key));
+  const missingCriticalKeys = criticalSliceKeys.filter(key => !presentKeys.has(key));
   const criticalFailures = slices.filter(
     s => criticalSliceKeys.includes(s.key) && s.disposition !== 'automate',
   );
-  const status = criticalFailures.length > 0
+  const status = criticalFailures.length > 0 || missingCriticalKeys.length > 0
     ? 'unqualified'
     : humanReviewSlices.length > 0 || abstainSlices.length > 0
       ? 'restricted'
       : 'qualified';
   return {
     status, automatedSlices, humanReviewSlices, abstainSlices,
-    reasons: criticalFailures.map(s => `Critical slice ${s.key} is ${s.disposition}`),
+    reasons: [
+      ...criticalFailures.map(s => `Critical slice ${s.key} is ${s.disposition}`),
+      ...missingCriticalKeys.map(key => `Critical slice ${key} is missing`),
+    ],
   };
 }
 
@@ -192,8 +207,11 @@ export async function calibrate(
     const severity = entry.label.expectedSeverity ?? entry.label.finding.severity;
     add(`severity:${severity}`, entry);
   });
-  r.slices = [...groups.entries()].map(([key, group]) => buildSlice(key, group, policy));
   const criticalKeys = policy.criticalSeverities.map(severity => `severity:${severity}`);
+  for (const key of criticalKeys) {
+    if (!groups.has(key)) groups.set(key, []);
+  }
+  r.slices = [...groups.entries()].map(([key, group]) => buildSlice(key, group, policy));
   r.qualification = qualifyJudge(r.slices, criticalKeys);
   return r;
 }

--- a/src/verification/adversarial-verify/index.ts
+++ b/src/verification/adversarial-verify/index.ts
@@ -23,5 +23,15 @@ export type {
 export { adversarialVerify, partitionVerdicts } from './verify.js';
 export { synthesizeVerdict, majorityKill, isFindingVerdict } from './synthesize.js';
 export { refuterPrompt, DEFAULT_LENSES } from './prompts.js';
-export { calibrate, type LabeledFinding, type CalibrationReport } from './calibrate.js';
+export {
+  calibrate,
+  qualifyJudge,
+  type CalibrationReport,
+  type ConfidenceInterval,
+  type JudgeQualification,
+  type LabeledFinding,
+  type QualificationDisposition,
+  type QualificationOptions,
+  type QualificationSlice,
+} from './calibrate.js';
 export { verifyGate, type VerifyGateOptions, type VerifyGateResult } from './gate.js';

--- a/tests/unit/verification/adversarial-verify/calibrate.test.ts
+++ b/tests/unit/verification/adversarial-verify/calibrate.test.ts
@@ -92,9 +92,100 @@ describe('calibrate — k-of-n aggregation reduces refuter noise', () => {
   it('abstains when a slice lacks minimum support', async () => {
     const report = await calibrate(labeled.slice(0, 4), {
       judge: noisyJudge(1, 1), refuters: 1,
-    }, { minSupport: 5 });
+    }, { minSupport: 5, criticalSeverities: [] });
     expect(report.slices.find(s => s.key === 'overall')?.disposition).toBe('abstain');
     expect(report.qualification.status).toBe('restricted');
+  });
+
+  it('does not qualify when mandatory critical severity strata are absent', async () => {
+    const report = await calibrate(labeled, {
+      judge: noisyJudge(1, 1), refuters: 1,
+    }, { minSupport: 2 });
+
+    expect(report.slices.find(s => s.key === 'severity:critical')).toMatchObject({
+      support: 0,
+      disposition: 'abstain',
+    });
+    expect(report.slices.find(s => s.key === 'severity:high')).toMatchObject({
+      support: 0,
+      disposition: 'abstain',
+    });
+    expect(report.qualification.status).toBe('unqualified');
+    expect(report.qualification.reasons).toEqual(expect.arrayContaining([
+      'Critical slice severity:critical is abstain',
+      'Critical slice severity:high is abstain',
+    ]));
+  });
+
+  it('requires confidence-bounded precision and false-keep policy', async () => {
+    const corpus: LabeledFinding[] = Array.from({ length: 40 }, (_, i) => ({
+      isReal: i < 20,
+      expectedSeverity: 'medium',
+      finding: {
+        id: `precision-${i}`,
+        title: i < 20 ? `KEEP real ${i}` : `KEEP false ${i}`,
+        file: `src/precision-${i}.ts`,
+        severity: 'medium', confidence: 0.9, evidence: [`fixture:${i}`],
+      },
+    }));
+    const judge: Judge = async () => ({ refuted: false, reasoning: 'uphold all' });
+
+    const precisionReport = await calibrate(corpus, { judge, refuters: 1 }, {
+      minSupport: 10,
+      minRecall: 0.5,
+      minPrecision: 0.8,
+      maxFalseKillRate: 1,
+      maxFalseKeepRate: 1,
+      criticalSeverities: [],
+    });
+    const falseKeepReport = await calibrate(corpus, { judge, refuters: 1 }, {
+      minSupport: 10,
+      minRecall: 0.5,
+      minPrecision: 0,
+      maxFalseKillRate: 1,
+      maxFalseKeepRate: 0.2,
+      criticalSeverities: [],
+    });
+
+    expect(precisionReport.slices.find(s => s.key === 'overall')).toMatchObject({
+      precision: 0.5,
+      falseKeepRate: 1,
+      disposition: 'human-review',
+    });
+    expect(falseKeepReport.slices.find(s => s.key === 'overall')?.disposition).toBe('human-review');
+    expect(precisionReport.qualification.status).toBe('restricted');
+    expect(falseKeepReport.qualification.status).toBe('restricted');
+  });
+
+  it('uses the false-kill Wilson upper bound instead of a passing point estimate', async () => {
+    const corpus: LabeledFinding[] = Array.from({ length: 20 }, (_, i) => ({
+      isReal: true,
+      expectedSeverity: 'medium',
+      finding: {
+        id: `false-kill-bound-${i}`,
+        title: i === 0 ? 'KILL one real finding' : `KEEP real finding ${i}`,
+        file: `src/false-kill-${i}.ts`,
+        severity: 'medium', confidence: 0.9, evidence: [`fixture:${i}`],
+      },
+    }));
+    const judge: Judge = async prompt => ({
+      refuted: /KILL one real finding/.test(prompt),
+      reasoning: 'one deterministic false kill',
+    });
+
+    const report = await calibrate(corpus, { judge, refuters: 1 }, {
+      minSupport: 10,
+      minRecall: 0.5,
+      minPrecision: 0.5,
+      maxFalseKillRate: 0.1,
+      maxFalseKeepRate: 1,
+      criticalSeverities: [],
+    });
+    const overall = report.slices.find(s => s.key === 'overall');
+
+    expect(overall?.falseKillRate).toBe(0.05);
+    expect(overall?.intervals.falseKillRate.high).toBeGreaterThan(0.1);
+    expect(overall?.disposition).toBe('human-review');
   });
 
   it('should make majority-of-3 no worse — and typically better — than a single refuter', async () => {

--- a/tests/unit/verification/adversarial-verify/calibrate.test.ts
+++ b/tests/unit/verification/adversarial-verify/calibrate.test.ts
@@ -52,6 +52,51 @@ describe('calibrate — k-of-n aggregation reduces refuter noise', () => {
     expect(report.correctKill).toBe(10);
   });
 
+  it('does not let aggregate accuracy mask a failed critical evidence slice', async () => {
+    const corpus: LabeledFinding[] = Array.from({ length: 20 }, (_, i) => ({
+      isReal: true,
+      failureType: i < 2 ? 'evidence-corruption' : 'general',
+      expectedSeverity: i < 2 ? 'high' : 'medium',
+      source: 'controlled-intervention',
+      finding: {
+        id: `slice-${i}`,
+        title: i < 2 ? `MISS evidence ${i}` : `KEEP general ${i}`,
+        severity: i < 2 ? 'high' : 'medium',
+        confidence: 0.9,
+        evidence: [`fixture:${i}`],
+      },
+    }));
+    const judge: Judge = async prompt => ({
+      refuted: /MISS evidence/.test(prompt),
+      reasoning: 'deterministic controlled intervention',
+    });
+
+    const report = await calibrate(corpus, { judge, refuters: 1 }, {
+      minSupport: 2,
+      minRecall: 0.5,
+      maxFalseKillRate: 0.2,
+    });
+
+    expect(report.correctConfirm).toBe(18);
+    expect(report.slices.find(s => s.key === 'failureType:evidence-corruption')).toMatchObject({
+      support: 2,
+      recall: 0,
+      falseKillRate: 1,
+      disposition: 'human-review',
+    });
+    expect(report.slices.find(s => s.key === 'severity:high')?.intervals.recall.level).toBe(0.95);
+    expect(report.qualification.status).toBe('unqualified');
+    expect(report.qualification.reasons).toContain('Critical slice severity:high is human-review');
+  });
+
+  it('abstains when a slice lacks minimum support', async () => {
+    const report = await calibrate(labeled.slice(0, 4), {
+      judge: noisyJudge(1, 1), refuters: 1,
+    }, { minSupport: 5 });
+    expect(report.slices.find(s => s.key === 'overall')?.disposition).toBe('abstain');
+    expect(report.qualification.status).toBe('restricted');
+  });
+
   it('should make majority-of-3 no worse — and typically better — than a single refuter', async () => {
     const ACC = 0.75; // each refuter is 75% accurate
     const single = await calibrate(labeled, { judge: noisyJudge(ACC, 42), refuters: 1 });


### PR DESCRIPTION
## Outcome

Adds the P0 judge-qualification contract from ADR-130: fault/domain/severity slices, 95% Wilson intervals, support-aware abstention, and critical-slice vetoes.

Advances #635; it does not close the controlled-corpus, ranking, perturbation, or CLI follow-up scope.

## Compatibility

Existing two-argument `calibrate(labeled, options)` callers remain valid. Labels and the third qualification-policy argument are additive.

## Adversarial evidence

A controlled corpus with 90% aggregate correctness but 0% evidence-corruption recall is marked `unqualified`; the failed high-severity slice cannot be masked by the aggregate.

## Verification

- complete adversarial-verify unit area: 33/33 passed
- `npm run typecheck` — passed
- `npm run build` — passed
- deterministic 10,000-finding / 35-slice benchmark: 44.62 ms (224,135 findings/s)

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.** "Unlikely" is not an acceptable substitute. If you wrote "I don't think this can happen but...", that sentence is a failure mode and needs a test or an issue link.