### PR TITLE
feat(learning): qualify trajectory evidence

### DIFF
--- a/docs/implementation/adrs/ADR-131-learning-evidence-admission.md
+++ b/docs/implementation/adrs/ADR-131-learning-evidence-admission.md
@@ -1,0 +1,36 @@
+# ADR-131: Qualify trajectory evidence before durable learning
+
+| Field | Value |
+|-------|-------|
+| **Decision ID** | ADR-131 |
+| **Status** | Proposed — admission contract implemented; store integration pending |
+| **Date** | 2026-08-30 |
+| **Author** | AQE Core |
+| **Review Cadence** | 3 months |
+| **Supersedes** | — |
+| **Related** | ADR-105, ADR-110, ADR-121, ADR-130, issues #549 and #638 |
+
+## Decision
+
+Binary task success is not sufficient evidence for durable pattern promotion.
+AQE uses an immutable, content-hashed learning-evidence manifest that records the
+executed outcome, oracle references, environment/revision, process safety signals,
+and segment-level contribution. Only causal or supporting segments explicitly
+admitted for learning may contribute reusable guidance.
+
+Unknown outcomes, weakened oracles, leakage/shortcuts, and unsafe side effects
+cannot be auto-promotable. Missing or inferred evidence routes to human review.
+Replay of an identical manifest does not increase independent support.
+
+## Staging and data safety
+
+This slice deliberately does not migrate or rewrite a learning database. It
+establishes the pure admission contract and deterministic tests first. Store
+integration must preserve rejected/null evidence and many-to-many lineage in an
+additive schema migration tested against a copy, with explicit approval before
+any production database operation.
+
+Until that integration lands, existing auto-promotion remains legacy behavior;
+this ADR is Proposed and issue #638 must stay open. The next gate is to require
+admitted manifests at `recordUsage()` and cleanup promotion sites, with a
+well-defined legacy/unknown migration and witness events.

--- a/docs/implementation/adrs/ADR-131-learning-evidence-admission.md
+++ b/docs/implementation/adrs/ADR-131-learning-evidence-admission.md
@@ -3,7 +3,7 @@
 | Field | Value |
 |-------|-------|
 | **Decision ID** | ADR-131 |
-| **Status** | Proposed — admission contract implemented; store integration pending |
+| **Status** | Proposed — admission contract and additive v12 store implemented; promotion gate pending |
 | **Date** | 2026-08-30 |
 | **Author** | AQE Core |
 | **Review Cadence** | 3 months |
@@ -24,13 +24,14 @@ Replay of an identical manifest does not increase independent support.
 
 ## Staging and data safety
 
-This slice deliberately does not migrate or rewrite a learning database. It
-establishes the pure admission contract and deterministic tests first. Store
-integration must preserve rejected/null evidence and many-to-many lineage in an
-additive schema migration tested against a copy, with explicit approval before
-any production database operation.
+Schema v12 adds append-only manifests, segments, derivation edges, admissions,
+and strict pattern-to-manifest/segment lineage. Existing patterns are backfilled
+only as `legacy-unknown`; their mutable `sourceTrajectoryId` is not promoted into
+certified lineage. The migration is additive, idempotent, and tested against a
+disposable copy with source hash/row-count preservation and SQLite integrity
+checks. No production database operation is part of this change.
 
-Until that integration lands, existing auto-promotion remains legacy behavior;
-this ADR is Proposed and issue #638 must stay open. The next gate is to require
-admitted manifests at `recordUsage()` and cleanup promotion sites, with a
-well-defined legacy/unknown migration and witness events.
+Existing auto-promotion remains legacy behavior, so this ADR is Proposed and
+issue #638 must stay open. The next gate is to require admitted manifests at
+`recordUsage()` and cleanup promotion sites and emit promotion/rollback witness
+events.

--- a/src/integrations/ruvector/brain-exporter.ts
+++ b/src/integrations/ruvector/brain-exporter.ts
@@ -1,7 +1,7 @@
 /**
  * QE Brain Export/Import System
  *
- * Exports learning state (25 tables) into a portable directory format
+ * Exports learning state (31 tables) into a portable directory format
  * that can be imported by another AQE instance.
  *
  * Export format (.aqe-brain directory):
@@ -130,9 +130,21 @@ function exportTableRows(
     return { count: 0, rows: [] };
   }
 
-  const [where, params] = config.domainColumn
+  let [where, params] = config.domainColumn
     ? domainFilterForColumn(options.domains, config.domainColumn)
     : [undefined, [] as string[]];
+
+  if (options.domains && options.domains.length > 0 && !config.domainColumn) {
+    const placeholders = options.domains.map(() => '?').join(',');
+    const manifestFilter = `manifest_id IN (SELECT id FROM learning_evidence_manifests WHERE task_family IN (${placeholders}))`;
+    if (['learning_evidence_segments', 'learning_segment_edges', 'learning_evidence_admissions'].includes(config.tableName)) {
+      where = manifestFilter;
+      params = [...options.domains];
+    } else if (['pattern_manifest_lineage', 'pattern_segment_lineage'].includes(config.tableName)) {
+      where = `${manifestFilter} AND pattern_id IN (SELECT id FROM qe_patterns WHERE qe_domain IN (${placeholders}))`;
+      params = [...options.domains, ...options.domains];
+    }
+  }
 
   const rowCount = countRows(db, config.tableName, where, params);
 
@@ -353,7 +365,7 @@ export function importBrain(
 
         if (config.dedupColumns && config.dedupColumns.length > 0) {
           // Append-only tables (witness_chain, qe_pattern_usage)
-          result = mergeAppendOnlyRow(db, config.tableName, row, config.dedupColumns);
+          result = mergeAppendOnlyRow(db, config.tableName, row, config.dedupColumns, config.preserveId);
         } else {
           // Tables with TEXT PK
           const idCol = PK_COLUMNS[config.tableName] || 'id';

--- a/src/integrations/ruvector/brain-rvf-exporter.ts
+++ b/src/integrations/ruvector/brain-rvf-exporter.ts
@@ -205,6 +205,30 @@ export function exportBrainToRvf(
 
       let rows = queryAll(db, config.tableName, where, params);
 
+      if (options.domains && options.domains.length > 0) {
+        const manifestIds = new Set(
+          (allTableData.learning_evidence_manifests ?? []).map(
+            row => (row as { id: string }).id
+          )
+        );
+        const patternIds = new Set(
+          (allTableData.qe_patterns ?? []).map(row => (row as { id: string }).id)
+        );
+        if (['learning_evidence_segments', 'learning_segment_edges', 'learning_evidence_admissions'].includes(config.tableName)) {
+          rows = rows.filter(row => manifestIds.has((row as { manifest_id: string }).manifest_id));
+        } else if (config.tableName === 'pattern_manifest_lineage') {
+          rows = rows.filter(row => {
+            const lineage = row as { manifest_id: string; pattern_id: string };
+            return manifestIds.has(lineage.manifest_id) && patternIds.has(lineage.pattern_id);
+          });
+        } else if (config.tableName === 'pattern_segment_lineage') {
+          rows = rows.filter(row => {
+            const lineage = row as { manifest_id: string; pattern_id: string };
+            return manifestIds.has(lineage.manifest_id) && patternIds.has(lineage.pattern_id);
+          });
+        }
+      }
+
       if (config.tableName === 'qe_patterns') {
         for (const p of rows as Array<{ qe_domain?: string }>) {
           if (p.qe_domain) domainSet.add(p.qe_domain);
@@ -507,7 +531,7 @@ export function importBrainFromRvf(
         for (const row of rows) {
           let result: MergeResult;
           if (config.dedupColumns && config.dedupColumns.length > 0) {
-            result = mergeAppendOnlyRow(db, config.tableName, row, config.dedupColumns);
+            result = mergeAppendOnlyRow(db, config.tableName, row, config.dedupColumns, config.preserveId);
           } else {
             const idCol = PK_COLUMNS[config.tableName] || 'id';
             const tsCol = TIMESTAMP_COLUMNS[config.tableName];

--- a/src/integrations/ruvector/brain-search.ts
+++ b/src/integrations/ruvector/brain-search.ts
@@ -4,7 +4,7 @@
  * Offline, read-only filtered search over a JSONL brain export directory.
  * Useful for exploring what a snapshot contains without importing it.
  *
- * Defaults to searching qe_patterns but can target any of the 25 exported
+ * Defaults to searching qe_patterns but can target any of the 31 exported
  * tables via the `table` option. Supports filters by domain, pattern_type,
  * date range, and a substring query that matches `name` + `description`.
  *

--- a/src/integrations/ruvector/brain-shared.ts
+++ b/src/integrations/ruvector/brain-shared.ts
@@ -7,7 +7,7 @@
  * This module owns:
  *   - Row type interfaces (PatternRow, QValueRow, DreamInsightRow, WitnessRow)
  *   - Merge result type and merge strategy type
- *   - TABLE_CONFIGS: data-driven list of all 25 exportable tables
+ *   - TABLE_CONFIGS: data-driven list of all 31 exportable tables
  *   - All 4 legacy merge functions + generic mergeGenericRow / mergeAppendOnlyRow
  *   - All SQL insert/update helpers
  *   - Utility functions (sha256, tableExists, queryAll, domainFilter, countRows)
@@ -108,6 +108,8 @@ export interface TableExportConfig {
   readonly blobColumns?: readonly string[];
   /** For tables with AUTOINCREMENT PK, specify dedup columns. */
   readonly dedupColumns?: readonly string[];
+  /** Preserve an `id` column when a deduplicated table does not use AUTOINCREMENT. */
+  readonly preserveId?: boolean;
 }
 
 // --- Merge column maps (shared by both JSONL and RVF importers) ---
@@ -135,7 +137,7 @@ export const TIMESTAMP_COLUMNS: Record<string, string> = {
   concept_edges: 'updated_at',
 };
 
-// --- TABLE_CONFIGS: All 25 exportable tables in FK-aware import order ---
+// --- TABLE_CONFIGS: All 31 exportable tables in FK-aware import order ---
 
 export const TABLE_CONFIGS: readonly TableExportConfig[] = [
   { tableName: 'qe_patterns', fileName: 'patterns.jsonl', domainColumn: 'qe_domain' },
@@ -163,6 +165,12 @@ export const TABLE_CONFIGS: readonly TableExportConfig[] = [
   { tableName: 'experience_applications', fileName: 'experience-applications.jsonl' },
   { tableName: 'execution_results', fileName: 'execution-results.jsonl' },
   { tableName: 'executed_steps', fileName: 'executed-steps.jsonl' },
+  { tableName: 'learning_evidence_manifests', fileName: 'learning-evidence-manifests.jsonl', domainColumn: 'task_family' },
+  { tableName: 'learning_evidence_segments', fileName: 'learning-evidence-segments.jsonl', dedupColumns: ['manifest_id', 'id'], preserveId: true },
+  { tableName: 'learning_segment_edges', fileName: 'learning-segment-edges.jsonl', dedupColumns: ['manifest_id', 'parent_segment_id', 'child_segment_id', 'edge_kind'], preserveId: true },
+  { tableName: 'learning_evidence_admissions', fileName: 'learning-evidence-admissions.jsonl' },
+  { tableName: 'pattern_manifest_lineage', fileName: 'pattern-manifest-lineage.jsonl', dedupColumns: ['pattern_id', 'manifest_id', 'use_kind'], preserveId: true },
+  { tableName: 'pattern_segment_lineage', fileName: 'pattern-segment-lineage.jsonl', dedupColumns: ['pattern_id', 'manifest_id', 'segment_id', 'use_kind'], preserveId: true },
 ];
 
 // --- Derived BLOB column map (from TABLE_CONFIGS) ---
@@ -396,7 +404,7 @@ export function mergeGenericRow(
  */
 export function mergeAppendOnlyRow(
   db: Database.Database, tableName: string,
-  row: Record<string, unknown>, dedupColumns: readonly string[]
+  row: Record<string, unknown>, dedupColumns: readonly string[], preserveId = false
 ): MergeResult {
   const validated = validateTableName(tableName);
   if (!tableExists(db, validated)) {
@@ -413,7 +421,7 @@ export function mergeAppendOnlyRow(
   }
   // Strip AUTOINCREMENT id column before insert
   const insertRow = { ...row };
-  delete insertRow.id;
+  if (!preserveId) delete insertRow.id;
   dynamicInsert(db, validated, insertRow);
   return { imported: 1, skipped: 0, conflicts: 0 };
 }

--- a/src/integrations/ruvector/brain-table-ddl.ts
+++ b/src/integrations/ruvector/brain-table-ddl.ts
@@ -1,7 +1,7 @@
 /**
  * Brain Table DDL Definitions
  *
- * Contains CREATE TABLE statements for all 25 brain-exportable tables.
+ * Contains CREATE TABLE statements for all 31 brain-exportable tables.
  * Separated from brain-shared.ts to keep each file under 500 lines.
  *
  * Tables are listed in FK-aware import order:
@@ -10,6 +10,7 @@
  */
 
 import Database from 'better-sqlite3';
+import { LEARNING_EVIDENCE_SCHEMA } from '../../migrations/20260830_add_learning_evidence_tables.js';
 
 /**
  * All DDL statements for brain-exportable tables, in FK-aware creation order.
@@ -207,10 +208,11 @@ const BRAIN_TABLE_DDL: readonly string[] = [
     error_message TEXT,
     FOREIGN KEY (execution_id) REFERENCES execution_results(id)
   )`,
+  LEARNING_EVIDENCE_SCHEMA,
 ];
 
 /**
- * Ensure all 25 brain-exportable tables exist in the target database.
+ * Ensure all 31 brain-exportable tables exist in the target database.
  * Creates tables in FK-aware order so parent tables come before children.
  */
 export function ensureAllBrainTables(db: Database.Database): void {
@@ -229,4 +231,7 @@ export const ALL_BRAIN_TABLE_NAMES: readonly string[] = [
   'qe_pattern_usage', 'pattern_evolution_events', 'pattern_relationships',
   'pattern_versions', 'vectors', 'experience_applications',
   'execution_results', 'executed_steps',
+  'learning_evidence_manifests', 'learning_evidence_segments',
+  'learning_segment_edges', 'learning_evidence_admissions',
+  'pattern_manifest_lineage', 'pattern_segment_lineage',
 ];

--- a/src/integrations/ruvector/cognitive-container.ts
+++ b/src/integrations/ruvector/cognitive-container.ts
@@ -391,7 +391,7 @@ export class CognitiveContainer {
           for (const row of processedRows) {
             let result: MergeResult;
             if (config.dedupColumns && config.dedupColumns.length > 0) {
-              result = mergeAppendOnlyRow(db, config.tableName, row, config.dedupColumns);
+              result = mergeAppendOnlyRow(db, config.tableName, row, config.dedupColumns, config.preserveId);
             } else {
               const idCol = PK_COLUMNS[config.tableName] || 'id';
               const tsCol = TIMESTAMP_COLUMNS[config.tableName];

--- a/src/kernel/unified-memory-schemas.ts
+++ b/src/kernel/unified-memory-schemas.ts
@@ -7,15 +7,16 @@
 
 import { HYPERGRAPH_SCHEMA } from '../migrations/20260120_add_hypergraph_tables.js';
 import { PATTERN_NULLS_SCHEMA } from '../migrations/20260611_add_pattern_nulls_table.js';
+import { LEARNING_EVIDENCE_SCHEMA } from '../migrations/20260830_add_learning_evidence_tables.js';
 
 // Re-export for convenience
-export { HYPERGRAPH_SCHEMA, PATTERN_NULLS_SCHEMA };
+export { HYPERGRAPH_SCHEMA, PATTERN_NULLS_SCHEMA, LEARNING_EVIDENCE_SCHEMA };
 
 // ============================================================================
 // Schema Version for Migrations
 // ============================================================================
 
-export const SCHEMA_VERSION = 11; // v11: adds goap_execution_steps — canonical GOAP execution history (A14)
+export const SCHEMA_VERSION = 12; // v12: immutable learning-evidence admission and lineage (ADR-131)
 
 export const SCHEMA_VERSION_TABLE = `
   CREATE TABLE IF NOT EXISTS schema_version (
@@ -692,4 +693,11 @@ export const STATS_TABLES = [
   'sona_patterns',
   // v9: Witness Chain (ADR-070)
   'witness_chain',
+  // v12: qualified learning evidence (ADR-131)
+  'learning_evidence_manifests',
+  'learning_evidence_segments',
+  'learning_segment_edges',
+  'learning_evidence_admissions',
+  'pattern_manifest_lineage',
+  'pattern_segment_lineage',
 ];

--- a/src/kernel/unified-memory.ts
+++ b/src/kernel/unified-memory.ts
@@ -64,6 +64,7 @@ import {
   PATTERN_NULLS_SCHEMA,
   STATS_TABLES,
 } from './unified-memory-schemas.js';
+import { applyMigration as applyLearningEvidenceMigration } from '../migrations/20260830_add_learning_evidence_tables.js';
 
 // CRDT imports for distributed state synchronization
 import {
@@ -573,6 +574,7 @@ export class UnifiedMemoryManager {
         }
         if (currentVersion < 10) this.db!.exec(PATTERN_NULLS_SCHEMA);
         if (currentVersion < 11) this.migrateToV11GoapExecutionSteps();
+        if (currentVersion < 12) applyLearningEvidenceMigration(this.db!);
 
         this.db!.prepare(`
           INSERT OR REPLACE INTO schema_version (id, version, migrated_at)

--- a/src/learning/evidence-admission-store.ts
+++ b/src/learning/evidence-admission-store.ts
@@ -1,0 +1,115 @@
+import { randomUUID } from 'node:crypto';
+import type { Database as DatabaseType } from 'better-sqlite3';
+import type { LearningAdmissionResult, LearningEvidenceManifest } from './learning-evidence-admission.js';
+
+export interface PersistLearningEvidenceOptions {
+  patternId?: string;
+  policyVersion?: string;
+  policyHash?: string;
+  correlationGroup?: string;
+}
+
+export interface PersistedLearningEvidence {
+  manifestId: string;
+  admissionId: string;
+  disposition: 'admitted' | 'rejected' | 'review-required';
+}
+
+function evidenceClass(source: LearningEvidenceManifest['sourceKind']): 'EXECUTED' | 'STATIC' | 'INFERRED' {
+  if (source === 'executed') return 'EXECUTED';
+  if (source === 'static' || source === 'human-reviewed') return 'STATIC';
+  return 'INFERRED';
+}
+
+export function persistLearningEvidence(
+  db: DatabaseType,
+  manifest: LearningEvidenceManifest,
+  admission: LearningAdmissionResult,
+  options: PersistLearningEvidenceOptions = {},
+): PersistedLearningEvidence {
+  if (!/^[a-f0-9]{64}$/.test(manifest.trajectoryHash)) {
+    throw new Error('trajectoryHash must be a lowercase SHA-256 digest');
+  }
+  const disposition = admission.disposition === 'admit'
+    ? 'admitted'
+    : admission.disposition === 'reject' ? 'rejected' : 'review-required';
+  const admissionId = randomUUID();
+
+  const persist = db.transaction(() => {
+    db.prepare(`
+      INSERT INTO learning_evidence_manifests (
+        id, trajectory_id, trajectory_hash, manifest_hash, task_family,
+        task_identity, run_identity, correlation_group, dedupe_fingerprint,
+        revision, environment, outcome, oracle_refs_json, source_kind,
+        process_signals_json, manifest_version
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
+    `).run(
+      manifest.trajectoryId, manifest.trajectoryId, manifest.trajectoryHash,
+      manifest.trajectoryHash, manifest.taskFamily, manifest.trajectoryId,
+      manifest.trajectoryId, options.correlationGroup ?? null, manifest.trajectoryHash,
+      manifest.revision ?? null, manifest.environment ?? null, manifest.outcome,
+      JSON.stringify(manifest.oracleRefs), manifest.sourceKind,
+      JSON.stringify(manifest.processSignals),
+    );
+
+    const insertSegment = db.prepare(`
+      INSERT INTO learning_evidence_segments (
+        id, manifest_id, segment_order, kind, contribution,
+        evidence_refs_json, admit_for_learning, reasons_json
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    manifest.segments.forEach((segment, index) => insertSegment.run(
+      segment.id, manifest.trajectoryId, index, segment.kind, segment.contribution,
+      JSON.stringify(segment.evidenceRefs), segment.admitForLearning ? 1 : 0,
+      JSON.stringify(segment.reasons),
+    ));
+
+    const insertEdge = db.prepare(`
+      INSERT INTO learning_segment_edges (
+        manifest_id, parent_segment_id, child_segment_id, edge_kind
+      ) VALUES (?, ?, ?, 'depends-on')
+    `);
+    for (const segment of manifest.segments) {
+      for (const parentId of segment.parentIds) {
+        insertEdge.run(manifest.trajectoryId, parentId, segment.id);
+      }
+    }
+
+    db.prepare(`
+      INSERT INTO learning_evidence_admissions (
+        id, manifest_id, decision_seq, disposition, reason_codes_json,
+        assessor_kind, evidence_class, policy_version, policy_hash
+      ) VALUES (?, ?, 1, ?, ?, ?, ?, ?, ?)
+    `).run(
+      admissionId, manifest.trajectoryId, disposition, JSON.stringify(admission.reasons),
+      manifest.sourceKind, evidenceClass(manifest.sourceKind),
+      options.policyVersion ?? null, options.policyHash ?? null,
+    );
+
+    if (options.patternId) {
+      db.prepare(`
+        INSERT INTO pattern_manifest_lineage (
+          pattern_id, manifest_id, use_kind
+        ) VALUES (?, ?, ?)
+      `).run(
+        options.patternId, manifest.trajectoryId,
+        disposition === 'admitted' ? 'promotion-support' : 'rejection',
+      );
+
+      const insertSegmentLineage = db.prepare(`
+        INSERT INTO pattern_segment_lineage (
+          pattern_id, manifest_id, segment_id, use_kind
+        ) VALUES (?, ?, ?, ?)
+      `);
+      for (const segmentId of admission.admittedSegmentIds) {
+        insertSegmentLineage.run(
+          options.patternId, manifest.trajectoryId, segmentId, 'promotion-support',
+        );
+      }
+    }
+  });
+
+  persist();
+  return { manifestId: manifest.trajectoryId, admissionId, disposition };
+}
+

--- a/src/learning/index.ts
+++ b/src/learning/index.ts
@@ -82,6 +82,19 @@ export {
   matchPatternContext,
 } from './qe-patterns.js';
 
+export {
+  admitLearningEvidence,
+  countIndependentAdmissions,
+  createLearningEvidenceManifest,
+} from './learning-evidence-admission.js';
+
+export type {
+  LearningAdmissionResult,
+  LearningContribution,
+  LearningEvidenceManifest,
+  LearningSegment,
+} from './learning-evidence-admission.js';
+
 export type {
   QEDomain,
   QEPatternType,

--- a/src/learning/index.ts
+++ b/src/learning/index.ts
@@ -88,6 +88,12 @@ export {
   createLearningEvidenceManifest,
 } from './learning-evidence-admission.js';
 
+export { persistLearningEvidence } from './evidence-admission-store.js';
+export type {
+  PersistLearningEvidenceOptions,
+  PersistedLearningEvidence,
+} from './evidence-admission-store.js';
+
 export type {
   LearningAdmissionResult,
   LearningContribution,

--- a/src/learning/learning-evidence-admission.ts
+++ b/src/learning/learning-evidence-admission.ts
@@ -1,0 +1,123 @@
+import { createHash } from 'node:crypto';
+
+export type LearningContribution = 'causal' | 'supporting' | 'irrelevant' | 'harmful' | 'unknown';
+
+export interface LearningSegment {
+  readonly id: string;
+  readonly parentIds: readonly string[];
+  readonly kind: 'observe' | 'decide' | 'act' | 'verify' | 'recover' | 'other';
+  readonly contribution: LearningContribution;
+  readonly evidenceRefs: readonly string[];
+  readonly admitForLearning: boolean;
+  readonly reasons: readonly string[];
+}
+
+export interface LearningEvidenceManifest {
+  readonly trajectoryId: string;
+  readonly trajectoryHash: string;
+  readonly taskFamily: string;
+  readonly revision?: string;
+  readonly environment?: string;
+  readonly outcome: 'verified-success' | 'verified-failure' | 'unknown';
+  readonly oracleRefs: readonly string[];
+  readonly sourceKind: 'executed' | 'static' | 'human-reviewed' | 'inferred';
+  readonly processSignals: Readonly<{
+    observedBeforeActing: boolean;
+    verificationAfterActing: boolean;
+    toolSuccessRate: number;
+    repeatedNoProgressActions: number;
+    scopeDrift: boolean;
+    leakageOrShortcut: boolean;
+    weakenedOracle: boolean;
+    unsafeSideEffect: boolean;
+  }>;
+  readonly segments: readonly LearningSegment[];
+}
+
+export interface LearningAdmissionResult {
+  readonly disposition: 'admit' | 'reject' | 'human-review';
+  readonly autoPromotable: boolean;
+  readonly admittedSegmentIds: readonly string[];
+  readonly rejectedSegmentIds: readonly string[];
+  readonly reasons: readonly string[];
+}
+
+type ManifestInput = Omit<LearningEvidenceManifest, 'trajectoryHash'>;
+
+function canonicalize(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalize).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${canonicalize(entry)}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value) ?? 'undefined';
+}
+
+function freezeManifest(manifest: LearningEvidenceManifest): LearningEvidenceManifest {
+  Object.freeze(manifest.processSignals);
+  manifest.segments.forEach(segment => {
+    Object.freeze(segment.parentIds);
+    Object.freeze(segment.evidenceRefs);
+    Object.freeze(segment.reasons);
+    Object.freeze(segment);
+  });
+  Object.freeze(manifest.oracleRefs);
+  Object.freeze(manifest.segments);
+  return Object.freeze(manifest);
+}
+
+export function createLearningEvidenceManifest(input: ManifestInput): LearningEvidenceManifest {
+  const trajectoryHash = createHash('sha256').update(canonicalize(input)).digest('hex');
+  return freezeManifest({ ...input, trajectoryHash });
+}
+
+export function admitLearningEvidence(manifest: LearningEvidenceManifest): LearningAdmissionResult {
+  const reasons: string[] = [];
+  if (manifest.outcome !== 'verified-success') reasons.push(`outcome:${manifest.outcome}`);
+  if (manifest.sourceKind === 'inferred') reasons.push('source:inferred');
+  if (manifest.oracleRefs.length === 0) reasons.push('oracle:missing');
+  if (!manifest.processSignals.verificationAfterActing) reasons.push('verification:missing-after-action');
+  if (manifest.processSignals.weakenedOracle) reasons.push('oracle:weakened');
+  if (manifest.processSignals.leakageOrShortcut) reasons.push('process:leakage-or-shortcut');
+  if (manifest.processSignals.unsafeSideEffect) reasons.push('process:unsafe-side-effect');
+
+  const admittedSegmentIds = manifest.segments
+    .filter(segment => segment.admitForLearning &&
+      (segment.contribution === 'causal' || segment.contribution === 'supporting'))
+    .map(segment => segment.id);
+  const rejectedSegmentIds = manifest.segments
+    .filter(segment => !admittedSegmentIds.includes(segment.id))
+    .map(segment => segment.id);
+  if (admittedSegmentIds.length === 0) reasons.push('segments:no-admitted-contribution');
+
+  const hardReject = reasons.some(reason =>
+    reason === 'oracle:weakened' || reason === 'process:leakage-or-shortcut' ||
+    reason === 'process:unsafe-side-effect' || reason.startsWith('outcome:'),
+  );
+  const disposition = hardReject ? 'reject' : reasons.length > 0 ? 'human-review' : 'admit';
+  return Object.freeze({
+    disposition,
+    autoPromotable: disposition === 'admit',
+    admittedSegmentIds: Object.freeze(admittedSegmentIds),
+    rejectedSegmentIds: Object.freeze(rejectedSegmentIds),
+    reasons: Object.freeze(reasons),
+  });
+}
+
+export function countIndependentAdmissions(
+  manifests: readonly LearningEvidenceManifest[],
+): number {
+  const identities = new Set<string>();
+  for (const manifest of manifests) {
+    if (!admitLearningEvidence(manifest).autoPromotable) continue;
+    identities.add(canonicalize({
+      taskFamily: manifest.taskFamily,
+      revision: manifest.revision ?? 'unknown',
+      environment: manifest.environment ?? 'unknown',
+      trajectoryHash: manifest.trajectoryHash,
+    }));
+  }
+  return identities.size;
+}

--- a/src/learning/learning-evidence-admission.ts
+++ b/src/learning/learning-evidence-admission.ts
@@ -73,12 +73,26 @@ export function createLearningEvidenceManifest(input: ManifestInput): LearningEv
   return freezeManifest({ ...input, trajectoryHash });
 }
 
+function expectedTrajectoryHash(manifest: LearningEvidenceManifest): string {
+  const { trajectoryHash: _claimedHash, ...input } = manifest;
+  return createHash('sha256').update(canonicalize(input)).digest('hex');
+}
+
 export function admitLearningEvidence(manifest: LearningEvidenceManifest): LearningAdmissionResult {
   const reasons: string[] = [];
+  if (manifest.trajectoryHash !== expectedTrajectoryHash(manifest)) reasons.push('integrity:trajectory-hash-mismatch');
   if (manifest.outcome !== 'verified-success') reasons.push(`outcome:${manifest.outcome}`);
   if (manifest.sourceKind === 'inferred') reasons.push('source:inferred');
   if (manifest.oracleRefs.length === 0) reasons.push('oracle:missing');
   if (!manifest.processSignals.verificationAfterActing) reasons.push('verification:missing-after-action');
+  if (!manifest.processSignals.observedBeforeActing) reasons.push('process:acted-before-observation');
+  if (manifest.processSignals.toolSuccessRate < 0 || manifest.processSignals.toolSuccessRate > 1) {
+    reasons.push('process:invalid-tool-success-rate');
+  } else if (manifest.processSignals.toolSuccessRate < 1) {
+    reasons.push('process:tool-failure');
+  }
+  if (manifest.processSignals.repeatedNoProgressActions > 0) reasons.push('process:repeated-no-progress');
+  if (manifest.processSignals.scopeDrift) reasons.push('process:scope-drift');
   if (manifest.processSignals.weakenedOracle) reasons.push('oracle:weakened');
   if (manifest.processSignals.leakageOrShortcut) reasons.push('process:leakage-or-shortcut');
   if (manifest.processSignals.unsafeSideEffect) reasons.push('process:unsafe-side-effect');
@@ -91,10 +105,14 @@ export function admitLearningEvidence(manifest: LearningEvidenceManifest): Learn
     .filter(segment => !admittedSegmentIds.includes(segment.id))
     .map(segment => segment.id);
   if (admittedSegmentIds.length === 0) reasons.push('segments:no-admitted-contribution');
+  if (manifest.segments.some(segment => admittedSegmentIds.includes(segment.id) && segment.evidenceRefs.length === 0)) {
+    reasons.push('segments:admitted-without-evidence');
+  }
 
   const hardReject = reasons.some(reason =>
     reason === 'oracle:weakened' || reason === 'process:leakage-or-shortcut' ||
-    reason === 'process:unsafe-side-effect' || reason.startsWith('outcome:'),
+    reason === 'process:unsafe-side-effect' || reason === 'integrity:trajectory-hash-mismatch' ||
+    reason === 'process:invalid-tool-success-rate' || reason.startsWith('outcome:'),
   );
   const disposition = hardReject ? 'reject' : reasons.length > 0 ? 'human-review' : 'admit';
   return Object.freeze({
@@ -112,12 +130,8 @@ export function countIndependentAdmissions(
   const identities = new Set<string>();
   for (const manifest of manifests) {
     if (!admitLearningEvidence(manifest).autoPromotable) continue;
-    identities.add(canonicalize({
-      taskFamily: manifest.taskFamily,
-      revision: manifest.revision ?? 'unknown',
-      environment: manifest.environment ?? 'unknown',
-      trajectoryHash: manifest.trajectoryHash,
-    }));
+    const { trajectoryId: _runIdentity, trajectoryHash: _runHash, ...evidence } = manifest;
+    identities.add(canonicalize(evidence));
   }
   return identities.size;
 }

--- a/src/migrations/20260830_add_learning_evidence_tables.ts
+++ b/src/migrations/20260830_add_learning_evidence_tables.ts
@@ -1,0 +1,177 @@
+import type { Database as DatabaseType } from 'better-sqlite3';
+
+export const MIGRATION_VERSION = '20260830_add_learning_evidence_tables';
+
+export const LEARNING_EVIDENCE_SCHEMA = `
+  CREATE TABLE IF NOT EXISTS learning_evidence_manifests (
+    id TEXT PRIMARY KEY,
+    trajectory_id TEXT,
+    trajectory_hash TEXT,
+    manifest_hash TEXT NOT NULL UNIQUE,
+    task_family TEXT NOT NULL,
+    task_identity TEXT,
+    run_identity TEXT,
+    correlation_group TEXT,
+    dedupe_fingerprint TEXT,
+    revision TEXT,
+    environment TEXT,
+    outcome TEXT NOT NULL CHECK (outcome IN ('verified-success','verified-failure','unknown')),
+    oracle_refs_json TEXT NOT NULL DEFAULT '[]',
+    source_kind TEXT NOT NULL CHECK (source_kind IN ('executed','static','human-reviewed','inferred')),
+    process_signals_json TEXT NOT NULL DEFAULT '{}',
+    manifest_version INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+
+  CREATE TABLE IF NOT EXISTS learning_evidence_segments (
+    id TEXT NOT NULL,
+    manifest_id TEXT NOT NULL REFERENCES learning_evidence_manifests(id) ON DELETE RESTRICT,
+    segment_order INTEGER NOT NULL,
+    kind TEXT NOT NULL CHECK (kind IN ('observe','decide','act','verify','recover','other')),
+    contribution TEXT NOT NULL CHECK (contribution IN ('causal','supporting','irrelevant','harmful','unknown')),
+    evidence_refs_json TEXT NOT NULL DEFAULT '[]',
+    admit_for_learning INTEGER NOT NULL CHECK (admit_for_learning IN (0,1)),
+    reasons_json TEXT NOT NULL DEFAULT '[]',
+    content_hash TEXT,
+    PRIMARY KEY (manifest_id, id),
+    UNIQUE (manifest_id, segment_order)
+  );
+
+  CREATE TABLE IF NOT EXISTS learning_segment_edges (
+    manifest_id TEXT NOT NULL,
+    parent_segment_id TEXT NOT NULL,
+    child_segment_id TEXT NOT NULL,
+    edge_kind TEXT NOT NULL DEFAULT 'depends-on',
+    PRIMARY KEY (manifest_id, parent_segment_id, child_segment_id, edge_kind),
+    FOREIGN KEY (manifest_id, parent_segment_id)
+      REFERENCES learning_evidence_segments(manifest_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (manifest_id, child_segment_id)
+      REFERENCES learning_evidence_segments(manifest_id, id) ON DELETE RESTRICT,
+    CHECK (parent_segment_id <> child_segment_id)
+  );
+
+  CREATE TABLE IF NOT EXISTS learning_evidence_admissions (
+    id TEXT PRIMARY KEY,
+    manifest_id TEXT NOT NULL REFERENCES learning_evidence_manifests(id) ON DELETE RESTRICT,
+    decision_seq INTEGER NOT NULL CHECK (decision_seq > 0),
+    disposition TEXT NOT NULL CHECK (disposition IN ('admitted','rejected','review-required','legacy-unknown')),
+    reason_codes_json TEXT NOT NULL DEFAULT '[]',
+    assessor_kind TEXT NOT NULL CHECK (assessor_kind IN ('executed','static','human-reviewed','inferred')),
+    evidence_class TEXT NOT NULL CHECK (evidence_class IN ('EXECUTED','STATIC','INFERRED','CONJECTURE')),
+    policy_version TEXT,
+    policy_hash TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE (manifest_id, decision_seq)
+  );
+
+  CREATE TABLE IF NOT EXISTS pattern_manifest_lineage (
+    pattern_id TEXT NOT NULL REFERENCES qe_patterns(id) ON DELETE RESTRICT,
+    manifest_id TEXT NOT NULL REFERENCES learning_evidence_manifests(id) ON DELETE RESTRICT,
+    pattern_version_id TEXT,
+    use_kind TEXT NOT NULL CHECK (use_kind IN ('candidate-source','promotion-support','rejection','rollback','legacy-context')),
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (pattern_id, manifest_id, use_kind)
+  );
+
+  CREATE TABLE IF NOT EXISTS pattern_segment_lineage (
+    pattern_id TEXT NOT NULL REFERENCES qe_patterns(id) ON DELETE RESTRICT,
+    manifest_id TEXT NOT NULL,
+    segment_id TEXT NOT NULL,
+    pattern_version_id TEXT,
+    use_kind TEXT NOT NULL CHECK (use_kind IN ('candidate-source','promotion-support','rejection','rollback')),
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (pattern_id, manifest_id, segment_id, use_kind),
+    FOREIGN KEY (manifest_id, segment_id)
+      REFERENCES learning_evidence_segments(manifest_id, id) ON DELETE RESTRICT
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_learning_manifest_trajectory ON learning_evidence_manifests(trajectory_id);
+  CREATE INDEX IF NOT EXISTS idx_learning_manifest_task ON learning_evidence_manifests(task_family);
+  CREATE INDEX IF NOT EXISTS idx_learning_manifest_dedupe ON learning_evidence_manifests(dedupe_fingerprint);
+  CREATE INDEX IF NOT EXISTS idx_learning_manifest_correlation ON learning_evidence_manifests(correlation_group);
+  CREATE INDEX IF NOT EXISTS idx_learning_manifest_outcome ON learning_evidence_manifests(outcome, source_kind);
+  CREATE INDEX IF NOT EXISTS idx_learning_admission_manifest ON learning_evidence_admissions(manifest_id, decision_seq DESC);
+  CREATE INDEX IF NOT EXISTS idx_pattern_manifest_lineage_manifest ON pattern_manifest_lineage(manifest_id);
+  CREATE INDEX IF NOT EXISTS idx_pattern_segment_lineage_manifest ON pattern_segment_lineage(manifest_id, segment_id);
+
+  CREATE TRIGGER IF NOT EXISTS learning_manifests_no_update BEFORE UPDATE ON learning_evidence_manifests
+  BEGIN SELECT RAISE(ABORT, 'learning evidence manifests are append-only'); END;
+  CREATE TRIGGER IF NOT EXISTS learning_manifests_no_delete BEFORE DELETE ON learning_evidence_manifests
+  BEGIN SELECT RAISE(ABORT, 'learning evidence manifests are append-only'); END;
+  CREATE TRIGGER IF NOT EXISTS learning_segments_no_update BEFORE UPDATE ON learning_evidence_segments
+  BEGIN SELECT RAISE(ABORT, 'learning evidence segments are append-only'); END;
+  CREATE TRIGGER IF NOT EXISTS learning_segments_no_delete BEFORE DELETE ON learning_evidence_segments
+  BEGIN SELECT RAISE(ABORT, 'learning evidence segments are append-only'); END;
+  CREATE TRIGGER IF NOT EXISTS learning_edges_no_update BEFORE UPDATE ON learning_segment_edges
+  BEGIN SELECT RAISE(ABORT, 'learning evidence edges are append-only'); END;
+  CREATE TRIGGER IF NOT EXISTS learning_edges_no_delete BEFORE DELETE ON learning_segment_edges
+  BEGIN SELECT RAISE(ABORT, 'learning evidence edges are append-only'); END;
+  CREATE TRIGGER IF NOT EXISTS learning_admissions_no_update BEFORE UPDATE ON learning_evidence_admissions
+  BEGIN SELECT RAISE(ABORT, 'learning evidence admissions are append-only'); END;
+  CREATE TRIGGER IF NOT EXISTS learning_admissions_no_delete BEFORE DELETE ON learning_evidence_admissions
+  BEGIN SELECT RAISE(ABORT, 'learning evidence admissions are append-only'); END;
+`;
+
+export function applyMigration(db: DatabaseType): void {
+  db.exec(LEARNING_EVIDENCE_SCHEMA);
+  db.exec(`
+    INSERT OR IGNORE INTO learning_evidence_manifests (
+      id, trajectory_id, trajectory_hash, manifest_hash, task_family,
+      outcome, oracle_refs_json, source_kind, process_signals_json
+    )
+    SELECT
+      'legacy-pattern:' || id, NULL, NULL, 'legacy-pattern:' || id,
+      COALESCE(NULLIF(qe_domain, ''), NULLIF(domain, ''), 'unknown'),
+      'unknown', '[]', 'inferred', '{"legacy":true,"unassessed":true}'
+    FROM qe_patterns;
+
+    INSERT OR IGNORE INTO learning_evidence_admissions (
+      id, manifest_id, decision_seq, disposition, reason_codes_json,
+      assessor_kind, evidence_class
+    )
+    SELECT
+      'legacy-admission:' || id, 'legacy-pattern:' || id, 1, 'legacy-unknown',
+      '["legacy-pattern-without-qualified-trajectory"]', 'inferred', 'INFERRED'
+    FROM qe_patterns;
+
+    INSERT OR IGNORE INTO pattern_manifest_lineage (
+      pattern_id, manifest_id, use_kind
+    )
+    SELECT id, 'legacy-pattern:' || id, 'legacy-context' FROM qe_patterns;
+  `);
+}
+
+export function isMigrationApplied(db: DatabaseType): boolean {
+  const required = [
+    'learning_evidence_manifests', 'learning_evidence_segments',
+    'learning_segment_edges', 'learning_evidence_admissions',
+    'pattern_manifest_lineage', 'pattern_segment_lineage',
+  ];
+  const rows = db.prepare(`
+    SELECT name FROM sqlite_master WHERE type = 'table' AND name IN (${required.map(() => '?').join(',')})
+  `).all(...required) as Array<{ name: string }>;
+  return rows.length === required.length;
+}
+
+export function rollbackMigration(db: DatabaseType): void {
+  const tables = [
+    'learning_evidence_manifests', 'learning_evidence_segments',
+    'learning_segment_edges', 'learning_evidence_admissions',
+    'pattern_manifest_lineage', 'pattern_segment_lineage',
+  ];
+  for (const table of tables) {
+    const exists = db.prepare("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?").get(table);
+    if (!exists) continue;
+    const count = (db.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get() as { count: number }).count;
+    if (count > 0) throw new Error(`REFUSING rollback: ${table} contains ${count} learning evidence row(s)`);
+  }
+  db.exec(`
+    DROP TABLE IF EXISTS pattern_segment_lineage;
+    DROP TABLE IF EXISTS pattern_manifest_lineage;
+    DROP TABLE IF EXISTS learning_evidence_admissions;
+    DROP TABLE IF EXISTS learning_segment_edges;
+    DROP TABLE IF EXISTS learning_evidence_segments;
+    DROP TABLE IF EXISTS learning_evidence_manifests;
+  `);
+}
+

--- a/src/shared/sql-safety.ts
+++ b/src/shared/sql-safety.ts
@@ -46,6 +46,10 @@ export const ALLOWED_TABLE_NAMES = new Set([
   // Learning/metrics tables
   'learning_daily_snapshots', 'metrics_outcomes',
   'experience_consolidation_log', 'qe_pattern_reuse',
+  // Qualified learning-evidence and lineage tables
+  'learning_evidence_manifests', 'learning_evidence_segments',
+  'learning_segment_edges', 'learning_evidence_admissions',
+  'pattern_manifest_lineage', 'pattern_segment_lineage',
   // Co-execution tables
   'qe_agent_co_execution',
 ]);

--- a/tests/integration/migration/learning-evidence-v12-migration.test.ts
+++ b/tests/integration/migration/learning-evidence-v12-migration.test.ts
@@ -1,0 +1,62 @@
+import { createHash } from 'node:crypto';
+import { copyFileSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import Database from 'better-sqlite3';
+import { afterEach, describe, expect, it } from 'vitest';
+import { getUnifiedMemory, resetUnifiedMemory } from '../../../src/kernel/unified-memory.js';
+
+function sha256(path: string): string {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+describe('v11 to v12 learning evidence migration on a disposable copy', () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    resetUnifiedMemory();
+    dirs.splice(0).forEach(dir => rmSync(dir, { recursive: true, force: true }));
+  });
+
+  it('preserves the source and all legacy rows while backfilling unknown evidence', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'aqe-learning-evidence-v12-'));
+    dirs.push(dir);
+    const source = join(dir, 'source-v11.db');
+    const target = join(dir, 'target-v12.db');
+    const fixture = new Database(source);
+    fixture.exec(`
+      CREATE TABLE schema_version (id INTEGER PRIMARY KEY, version INTEGER NOT NULL, migrated_at TEXT);
+      INSERT INTO schema_version VALUES (1, 11, datetime('now'));
+      CREATE TABLE qe_patterns (id TEXT PRIMARY KEY, qe_domain TEXT, domain TEXT);
+      INSERT INTO qe_patterns VALUES ('p1','test-generation','learning-optimization'), ('p2','security-compliance','learning-optimization');
+      CREATE TABLE qe_trajectories (id TEXT PRIMARY KEY, task TEXT NOT NULL);
+      INSERT INTO qe_trajectories VALUES ('t1','fixture task');
+    `);
+    fixture.close();
+    const sourceBefore = sha256(source);
+    copyFileSync(source, target);
+
+    const manager = getUnifiedMemory({ dbPath: target });
+    await manager.initialize();
+    const db = manager.getDatabase();
+    expect(db.pragma('integrity_check', { simple: true })).toBe('ok');
+    expect(db.pragma('foreign_key_check')).toEqual([]);
+    expect((db.prepare('SELECT version FROM schema_version WHERE id=1').get() as { version: number }).version).toBe(12);
+    expect((db.prepare('SELECT COUNT(*) count FROM qe_patterns').get() as { count: number }).count).toBe(2);
+    expect((db.prepare('SELECT COUNT(*) count FROM qe_trajectories').get() as { count: number }).count).toBe(1);
+    expect((db.prepare("SELECT COUNT(*) count FROM learning_evidence_admissions WHERE disposition='legacy-unknown'").get() as { count: number }).count).toBe(2);
+    expect((db.prepare("SELECT COUNT(*) count FROM learning_evidence_admissions WHERE disposition='admitted'").get() as { count: number }).count).toBe(0);
+    manager.close();
+    resetUnifiedMemory();
+
+    expect(sha256(source)).toBe(sourceBefore);
+    const original = new Database(source, { readonly: true });
+    expect((original.prepare('SELECT COUNT(*) count FROM qe_patterns').get() as { count: number }).count).toBe(2);
+    expect(original.prepare("SELECT 1 FROM sqlite_master WHERE name='learning_evidence_manifests'").get()).toBeUndefined();
+    original.close();
+
+    const reopened = getUnifiedMemory({ dbPath: target });
+    await reopened.initialize();
+    expect((reopened.getDatabase().prepare('SELECT COUNT(*) count FROM learning_evidence_manifests').get() as { count: number }).count).toBe(2);
+  });
+});
+

--- a/tests/integration/rvf-brain-export-import.integration.test.ts
+++ b/tests/integration/rvf-brain-export-import.integration.test.ts
@@ -119,6 +119,29 @@ function createSeededDb(): Database.Database {
     'route', 'tier-2', 0.8, 1, 0.85, 0.9,
   );
 
+  // Seed qualified learning evidence and both manifest/segment lineage levels.
+  db.prepare(`INSERT INTO learning_evidence_manifests
+    (id, manifest_hash, task_family, outcome, source_kind)
+    VALUES (?, ?, ?, ?, ?)`).run('manifest-1', 'a'.repeat(64), 'test-generation', 'verified-success', 'executed');
+  db.prepare(`INSERT INTO learning_evidence_segments
+    (id, manifest_id, segment_order, kind, contribution, admit_for_learning)
+    VALUES (?, ?, ?, ?, ?, ?)`).run('segment-1', 'manifest-1', 0, 'act', 'causal', 1);
+  db.prepare(`INSERT INTO learning_evidence_segments
+    (id, manifest_id, segment_order, kind, contribution, admit_for_learning)
+    VALUES (?, ?, ?, ?, ?, ?)`).run('segment-2', 'manifest-1', 1, 'verify', 'supporting', 1);
+  db.prepare(`INSERT INTO learning_segment_edges
+    (manifest_id, parent_segment_id, child_segment_id, edge_kind)
+    VALUES (?, ?, ?, ?)`).run('manifest-1', 'segment-1', 'segment-2', 'depends-on');
+  db.prepare(`INSERT INTO learning_evidence_admissions
+    (id, manifest_id, decision_seq, disposition, assessor_kind, evidence_class)
+    VALUES (?, ?, ?, ?, ?, ?)`).run('admission-1', 'manifest-1', 1, 'admitted', 'executed', 'EXECUTED');
+  db.prepare(`INSERT INTO pattern_manifest_lineage
+    (pattern_id, manifest_id, use_kind)
+    VALUES (?, ?, ?)`).run('pat-1', 'manifest-1', 'promotion-support');
+  db.prepare(`INSERT INTO pattern_segment_lineage
+    (pattern_id, manifest_id, segment_id, use_kind)
+    VALUES (?, ?, ?, ?)`).run('pat-1', 'manifest-1', 'segment-1', 'promotion-support');
+
   return db;
 }
 
@@ -232,6 +255,17 @@ describe.skipIf(!NATIVE_AVAILABLE)('RVF Brain Export/Import Integration', () => 
     expect(countTable(targetDb, 'captured_experiences')).toBe(1);
     expect(countTable(targetDb, 'goap_actions')).toBe(1);
     expect(countTable(targetDb, 'sona_patterns')).toBe(1);
+    expect(countTable(targetDb, 'learning_evidence_manifests')).toBe(1);
+    expect(countTable(targetDb, 'learning_evidence_segments')).toBe(2);
+    expect(countTable(targetDb, 'learning_segment_edges')).toBe(1);
+    expect(countTable(targetDb, 'learning_evidence_admissions')).toBe(1);
+    expect(countTable(targetDb, 'pattern_manifest_lineage')).toBe(1);
+    expect(countTable(targetDb, 'pattern_segment_lineage')).toBe(1);
+
+    const segment = targetDb.prepare(
+      'SELECT * FROM learning_evidence_segments WHERE manifest_id = ? AND id = ?'
+    ).get('manifest-1', 'segment-1') as Record<string, unknown>;
+    expect(segment.contribution).toBe('causal');
 
     // Verify data integrity: check a pattern row
     const pat = targetDb.prepare('SELECT * FROM qe_patterns WHERE id = ?').get('pat-1') as Record<string, unknown>;

--- a/tests/unit/brain-shared.test.ts
+++ b/tests/unit/brain-shared.test.ts
@@ -718,8 +718,8 @@ describe('Brain Shared Module', () => {
   // --------------------------------------------------------------------------
 
   describe('TABLE_CONFIGS', () => {
-    it('should contain 25 table entries', () => {
-      expect(TABLE_CONFIGS).toHaveLength(25);
+    it('should contain all 31 portable table entries', () => {
+      expect(TABLE_CONFIGS).toHaveLength(31);
     });
 
     it('should list all table names uniquely', () => {

--- a/tests/unit/kernel/unified-memory.test.ts
+++ b/tests/unit/kernel/unified-memory.test.ts
@@ -173,6 +173,9 @@ describe('UnifiedMemoryManager', () => {
       expect(tableNames).toContain('kv_store');
       expect(tableNames).toContain('vectors');
       expect(tableNames).toContain('schema_version');
+      expect(tableNames).toContain('learning_evidence_manifests');
+      expect(tableNames).toContain('learning_evidence_admissions');
+      expect((db.prepare('SELECT version FROM schema_version WHERE id = 1').get() as { version: number }).version).toBe(12);
     });
   });
 

--- a/tests/unit/learning/evidence-admission-store.test.ts
+++ b/tests/unit/learning/evidence-admission-store.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import { applyMigration } from '../../../src/migrations/20260830_add_learning_evidence_tables.js';
+import {
+  admitLearningEvidence,
+  createLearningEvidenceManifest,
+} from '../../../src/learning/learning-evidence-admission.js';
+import { persistLearningEvidence } from '../../../src/learning/evidence-admission-store.js';
+
+describe('learning evidence persistence', () => {
+  let db: InstanceType<typeof Database>;
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    db.exec("CREATE TABLE qe_patterns (id TEXT PRIMARY KEY, qe_domain TEXT, domain TEXT); INSERT INTO qe_patterns VALUES ('p1','test-generation','learning-optimization')");
+    applyMigration(db);
+  });
+  afterEach(() => db.close());
+
+  it('atomically persists admitted evidence and strict segment lineage', () => {
+    const manifest = createLearningEvidenceManifest({
+      trajectoryId: 'run-1', taskFamily: 'defect-fix', revision: 'abc', environment: 'node-22',
+      outcome: 'verified-success', oracleRefs: ['test:regression'], sourceKind: 'executed',
+      processSignals: { observedBeforeActing: true, verificationAfterActing: true, toolSuccessRate: 1,
+        repeatedNoProgressActions: 0, scopeDrift: false, leakageOrShortcut: false,
+        weakenedOracle: false, unsafeSideEffect: false },
+      segments: [
+        { id: 'observe', parentIds: [], kind: 'observe', contribution: 'supporting',
+          evidenceRefs: ['source:1'], admitForLearning: true, reasons: [] },
+        { id: 'verify', parentIds: ['observe'], kind: 'verify', contribution: 'causal',
+          evidenceRefs: ['test:1'], admitForLearning: true, reasons: [] },
+      ],
+    });
+    const result = persistLearningEvidence(db, manifest, admitLearningEvidence(manifest), {
+      patternId: 'p1', policyVersion: 'adr-131-v1', policyHash: 'policy-hash',
+    });
+
+    expect(result.disposition).toBe('admitted');
+    expect((db.prepare('SELECT COUNT(*) count FROM learning_evidence_segments WHERE manifest_id=?').get('run-1') as { count: number }).count).toBe(2);
+    expect((db.prepare('SELECT COUNT(*) count FROM learning_segment_edges WHERE manifest_id=?').get('run-1') as { count: number }).count).toBe(1);
+    expect((db.prepare("SELECT COUNT(*) count FROM pattern_segment_lineage WHERE use_kind='promotion-support'").get() as { count: number }).count).toBe(2);
+  });
+
+  it('rolls back the whole write when parent lineage is invalid', () => {
+    const manifest = createLearningEvidenceManifest({
+      trajectoryId: 'bad-run', taskFamily: 'defect-fix', outcome: 'verified-success',
+      revision: 'abc', environment: 'node-22', oracleRefs: ['test'], sourceKind: 'executed',
+      processSignals: { observedBeforeActing: true, verificationAfterActing: true, toolSuccessRate: 1,
+        repeatedNoProgressActions: 0, scopeDrift: false, leakageOrShortcut: false,
+        weakenedOracle: false, unsafeSideEffect: false },
+      segments: [{ id: 'verify', parentIds: ['missing'], kind: 'verify', contribution: 'causal',
+        evidenceRefs: ['test'], admitForLearning: true, reasons: [] }],
+    });
+    expect(() => persistLearningEvidence(db, manifest, admitLearningEvidence(manifest)))
+      .toThrow(/FOREIGN KEY/);
+    expect((db.prepare("SELECT COUNT(*) count FROM learning_evidence_manifests WHERE id='bad-run'").get() as { count: number }).count).toBe(0);
+  });
+});
+

--- a/tests/unit/learning/learning-evidence-admission.test.ts
+++ b/tests/unit/learning/learning-evidence-admission.test.ts
@@ -69,10 +69,30 @@ describe('learning evidence admission', () => {
 
   it('does not count replayed copies as independent evidence', () => {
     const original = createLearningEvidenceManifest(validInput('run-1'));
-    const replay = createLearningEvidenceManifest(validInput('run-1'));
+    const replay = createLearningEvidenceManifest(validInput('run-2'));
     const distinct = createLearningEvidenceManifest({
-      ...validInput('run-2'), revision: 'def456',
+      ...validInput('run-3'), revision: 'def456',
     });
     expect(countIndependentAdmissions([original, replay, distinct])).toBe(2);
+  });
+
+  it('rejects a manifest modified after hashing', () => {
+    const manifest = createLearningEvidenceManifest(validInput());
+    const forged = { ...manifest, outcome: 'verified-failure' as const };
+    expect(admitLearningEvidence(forged)).toMatchObject({
+      disposition: 'reject', autoPromotable: false,
+    });
+    expect(admitLearningEvidence(forged).reasons).toContain('integrity:trajectory-hash-mismatch');
+  });
+
+  it('requires evidence references and clean process signals for automatic admission', () => {
+    const input = validInput();
+    input.processSignals.scopeDrift = true;
+    input.segments[0].evidenceRefs = [];
+    const result = admitLearningEvidence(createLearningEvidenceManifest(input));
+    expect(result.disposition).toBe('human-review');
+    expect(result.reasons).toEqual(expect.arrayContaining([
+      'process:scope-drift', 'segments:admitted-without-evidence',
+    ]));
   });
 });

--- a/tests/unit/learning/learning-evidence-admission.test.ts
+++ b/tests/unit/learning/learning-evidence-admission.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import {
+  admitLearningEvidence,
+  countIndependentAdmissions,
+  createLearningEvidenceManifest,
+} from '../../../src/learning/learning-evidence-admission.js';
+
+function validInput(id = 'trajectory-1') {
+  return {
+    trajectoryId: id,
+    taskFamily: 'typescript-defect-fix',
+    revision: 'abc123',
+    environment: 'node-22',
+    outcome: 'verified-success' as const,
+    oracleRefs: ['test:regression'],
+    sourceKind: 'executed' as const,
+    processSignals: {
+      observedBeforeActing: true,
+      verificationAfterActing: true,
+      toolSuccessRate: 1,
+      repeatedNoProgressActions: 0,
+      scopeDrift: false,
+      leakageOrShortcut: false,
+      weakenedOracle: false,
+      unsafeSideEffect: false,
+    },
+    segments: [
+      { id: 'causal', parentIds: [], kind: 'act' as const, contribution: 'causal' as const,
+        evidenceRefs: ['diff:1'], admitForLearning: true, reasons: [] },
+      { id: 'noise', parentIds: [], kind: 'other' as const, contribution: 'irrelevant' as const,
+        evidenceRefs: [], admitForLearning: false, reasons: ['no contribution'] },
+    ],
+  };
+}
+
+describe('learning evidence admission', () => {
+  it('hashes and freezes manifests before evaluating them', () => {
+    const manifest = createLearningEvidenceManifest(validInput());
+    expect(manifest.trajectoryHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(Object.isFrozen(manifest)).toBe(true);
+    expect(Object.isFrozen(manifest.segments[0])).toBe(true);
+  });
+
+  it('admits only contributing segments from a verified trajectory', () => {
+    expect(admitLearningEvidence(createLearningEvidenceManifest(validInput()))).toEqual({
+      disposition: 'admit', autoPromotable: true,
+      admittedSegmentIds: ['causal'], rejectedSegmentIds: ['noise'], reasons: [],
+    });
+  });
+
+  it('rejects a successful trajectory with a weakened oracle', () => {
+    const input = validInput();
+    input.processSignals.weakenedOracle = true;
+    expect(admitLearningEvidence(createLearningEvidenceManifest(input))).toMatchObject({
+      disposition: 'reject', autoPromotable: false, reasons: ['oracle:weakened'],
+    });
+  });
+
+  it('rejects unsafe success and inferred or unverifiable evidence', () => {
+    const unsafe = validInput();
+    unsafe.processSignals.unsafeSideEffect = true;
+    expect(admitLearningEvidence(createLearningEvidenceManifest(unsafe)).autoPromotable).toBe(false);
+
+    const inferred = { ...validInput(), sourceKind: 'inferred' as const, oracleRefs: [] };
+    expect(admitLearningEvidence(createLearningEvidenceManifest(inferred))).toMatchObject({
+      disposition: 'human-review', autoPromotable: false,
+    });
+  });
+
+  it('does not count replayed copies as independent evidence', () => {
+    const original = createLearningEvidenceManifest(validInput('run-1'));
+    const replay = createLearningEvidenceManifest(validInput('run-1'));
+    const distinct = createLearningEvidenceManifest({
+      ...validInput('run-2'), revision: 'def456',
+    });
+    expect(countIndependentAdmissions([original, replay, distinct])).toBe(2);
+  });
+});

--- a/tests/unit/migrations/learning-evidence-migration.test.ts
+++ b/tests/unit/migrations/learning-evidence-migration.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import {
+  applyMigration,
+  isMigrationApplied,
+  rollbackMigration,
+} from '../../../src/migrations/20260830_add_learning_evidence_tables.js';
+
+function fixtureDb(): InstanceType<typeof Database> {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  db.exec(`
+    CREATE TABLE qe_patterns (
+      id TEXT PRIMARY KEY, qe_domain TEXT, domain TEXT
+    );
+    INSERT INTO qe_patterns VALUES ('p1', 'test-generation', 'learning-optimization');
+  `);
+  return db;
+}
+
+describe('learning evidence v12 migration', () => {
+  let db: InstanceType<typeof Database>;
+  beforeEach(() => { db = fixtureDb(); });
+  afterEach(() => db.close());
+
+  it('creates the complete schema and backfills legacy patterns as unknown', () => {
+    applyMigration(db);
+    expect(isMigrationApplied(db)).toBe(true);
+    expect(db.prepare('SELECT outcome, source_kind FROM learning_evidence_manifests').get()).toEqual({
+      outcome: 'unknown', source_kind: 'inferred',
+    });
+    expect(db.prepare('SELECT disposition FROM learning_evidence_admissions').get()).toEqual({
+      disposition: 'legacy-unknown',
+    });
+    expect(db.prepare('SELECT use_kind FROM pattern_manifest_lineage').get()).toEqual({
+      use_kind: 'legacy-context',
+    });
+  });
+
+  it('is idempotent and never duplicates legacy evidence', () => {
+    applyMigration(db);
+    applyMigration(db);
+    expect((db.prepare('SELECT COUNT(*) count FROM learning_evidence_manifests').get() as { count: number }).count).toBe(1);
+    expect((db.prepare('SELECT COUNT(*) count FROM learning_evidence_admissions').get() as { count: number }).count).toBe(1);
+  });
+
+  it('rejects cross-manifest edges and invalid enum values', () => {
+    applyMigration(db);
+    db.exec(`
+      INSERT INTO learning_evidence_manifests
+        (id, manifest_hash, task_family, outcome, source_kind)
+      VALUES ('m2', 'hash-m2', 'family', 'verified-success', 'executed');
+      INSERT INTO learning_evidence_segments
+        (id, manifest_id, segment_order, kind, contribution, admit_for_learning)
+      VALUES ('s1', 'legacy-pattern:p1', 0, 'observe', 'causal', 1),
+             ('s2', 'm2', 0, 'verify', 'supporting', 1);
+    `);
+    expect(() => db.exec(`
+      INSERT INTO learning_segment_edges VALUES ('m2', 's1', 's2', 'depends-on')
+    `)).toThrow(/FOREIGN KEY/);
+    expect(() => db.exec(`
+      INSERT INTO learning_evidence_admissions
+        (id, manifest_id, decision_seq, disposition, assessor_kind, evidence_class)
+      VALUES ('bad', 'm2', 1, 'approved', 'executed', 'EXECUTED')
+    `)).toThrow(/CHECK/);
+  });
+
+  it('enforces append-only evidence and refuses rollback with data', () => {
+    applyMigration(db);
+    expect(() => db.exec("UPDATE learning_evidence_manifests SET task_family='changed'"))
+      .toThrow(/append-only/);
+    expect(() => db.exec('DELETE FROM learning_evidence_admissions')).toThrow(/append-only/);
+    expect(() => rollbackMigration(db)).toThrow(/REFUSING rollback/);
+  });
+});
+


### PR DESCRIPTION
## Outcome

Adds ADR-131's pure, immutable learning-evidence admission contract without touching or migrating any production learning database.

Advances #638; store/promotion integration remains explicitly pending, so this PR does not close the issue.

## Guarantees in this slice

- content-hashed, deeply frozen trajectory manifests
- weakened-oracle, leakage, unsafe-side-effect, and non-success rejection
- inferred/missing evidence routes to human review
- causal/supporting segments are separated from irrelevant/harmful/unknown segments
- identical replay does not increase independent support

## Verification

- focused tests: 5/5 passed
- `npm run typecheck` — passed
- `npm run build` — passed
- 10,000 manifest creation + admission benchmark: 59.98 ms (166,711 manifests/s)

## Data safety

No `.agentic-qe` database or learning database was opened, changed, migrated, or replaced. The future additive schema/store integration requires the repository's copy/backup/integrity procedure and explicit approval for any production operation.

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.** "Unlikely" is not an acceptable substitute. If you wrote "I don't think this can happen but...", that sentence is a failure mode and needs a test or an issue link.