### PR TITLE
feat(reliability): add runtime fault diagnosis benchmark

### DIFF
--- a/docs/guides/agent-runtime-fault-diagnosis.md
+++ b/docs/guides/agent-runtime-fault-diagnosis.md
@@ -1,0 +1,46 @@
+# Agent runtime fault diagnosis benchmark
+
+AQE ships a deterministic synthetic corpus for measuring whether a detector can
+separate clean agent runs from operational faults, classify the fault, and
+localize it. The corpus is a benchmark fixture. It does not inject faults into
+real services.
+
+```ts
+import {
+  AgentFaultDiagnosis,
+} from 'agentic-qe';
+
+const corpus = AgentFaultDiagnosis.createAgentFaultDiagnosisCorpus();
+const report = AgentFaultDiagnosis.scoreAgentFaultDetector(
+  corpus,
+  AgentFaultDiagnosis.referenceAwareAqeDetector,
+);
+const qualification = AgentFaultDiagnosis.qualifyAgentFaultDetector(report);
+```
+
+The initial corpus pairs a clean trace with each of eight single-fault traces:
+tool unavailability, tool timeout, plausible output corruption, context
+truncation, delegation timeout, agent misrouting, delegation loops, and
+guardrail bypass. Tool, model/context, guardrail, and inter-agent boundaries are
+represented. Mixed faults are explicitly outside this corpus version.
+
+Detector inputs contain versioned sanitized traces and deterministic structured
+views. Spans retain timing, status, byte counts, hashes, intended and actual
+destinations, policy references, retries, recovery, and terminal outcome. They
+do not contain payloads, injection manifests, ground-truth labels, fixture
+paths, or target labels. Provenance and truth remain under each case's
+`heldOut` property and must be passed only to the scorer.
+
+The scorer reports clean precision/recall and false-positive rate, fault recall,
+type top-1/top-k, component and exact-span localization, joint type/location,
+per-fault and per-boundary slices, parse and abstention rates, latency, tokens,
+cost, and a Wilson 95% interval for recall. Per-case receipts keep injection,
+observability, detection, localization, recovery, and final task success as
+separate facts. A detector that always predicts the most common fault fails the
+qualification gate.
+
+`directSignalBaseline` recognizes only explicit runtime signals and abstains on
+plausible output changes. `referenceAwareAqeDetector` additionally compares the
+aligned clean output hash and applies the referenced policy decision. This
+prevents successful task completion or a well-formed trace from certifying
+silent corruption or a forged guardrail pass.

--- a/src/domains/chaos-resilience/diagnosis/corpus.ts
+++ b/src/domains/chaos-resilience/diagnosis/corpus.ts
@@ -1,0 +1,194 @@
+import { createHash } from 'node:crypto';
+import {
+  AGENT_FAULT_CORPUS_SCHEMA_VERSION,
+  AGENT_FAULT_TRACE_SCHEMA_VERSION,
+  type AgentFaultCorpus,
+  type AgentFaultCorpusCase,
+  type AgentFaultGroundTruth,
+  type AgentRuntimeBoundary,
+  type AgentRuntimeFaultType,
+  type SanitizedExecutionTrace,
+  type SanitizedTraceSpan,
+  type StructuredTraceView,
+} from './types.js';
+
+const SOURCE_REVISION = 'fixture-source-v1';
+const HARNESS_REVISION = 'agent-runtime-diagnosis-v1';
+const ENVIRONMENT_DIGEST = sha256('synthetic-node-runtime-v1');
+
+interface FaultFixture {
+  readonly faultType: Exclude<AgentRuntimeFaultType, 'none'>;
+  readonly boundary: Exclude<AgentRuntimeBoundary, 'control'>;
+  readonly componentId: string;
+  readonly spanId: string;
+  readonly signal: string;
+  readonly mutate: (span: SanitizedTraceSpan) => SanitizedTraceSpan;
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function stable(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stable).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, item]) => `${JSON.stringify(key)}:${stable(item)}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function span(
+  spanId: string,
+  componentId: string,
+  kind: SanitizedTraceSpan['kind'],
+  parentSpanId?: string,
+): SanitizedTraceSpan {
+  const input = `input:${componentId}`;
+  const output = `output:${componentId}`;
+  return {
+    spanId,
+    ...(parentSpanId ? { parentSpanId } : {}),
+    componentId,
+    kind,
+    startOffsetMs: kind === 'run' ? 0 : 10,
+    durationMs: kind === 'run' ? 100 : 20,
+    status: 'ok',
+    inputBytes: Buffer.byteLength(input),
+    outputBytes: Buffer.byteLength(output),
+    inputHash: sha256(input),
+    outputHash: sha256(output),
+    recovered: false,
+  };
+}
+
+function baseSpans(): SanitizedTraceSpan[] {
+  return [
+    span('run', 'workflow', 'run'),
+    span('agent-primary', 'planner', 'agent', 'run'),
+    { ...span('tool-weather', 'weather-tool', 'tool', 'agent-primary'), intendedDestination: 'weather-tool', actualDestination: 'weather-tool' },
+    span('model-answer', 'reasoning-model', 'model', 'agent-primary'),
+    { ...span('policy-check', 'safety-policy', 'guardrail', 'agent-primary'), policyRef: 'policy://safety/v1', expectedDecision: 'deny', actualDecision: 'deny' },
+    { ...span('delegate-review', 'reviewer-agent', 'delegation', 'agent-primary'), intendedDestination: 'reviewer-agent', actualDestination: 'reviewer-agent' },
+  ];
+}
+
+const FIXTURES: readonly FaultFixture[] = [
+  { faultType: 'tool-unavailable', boundary: 'tool', componentId: 'weather-tool', spanId: 'tool-weather', signal: 'tool unavailable', mutate: (s) => ({ ...s, status: 'error', signalCode: 'TOOL_UNAVAILABLE', outputBytes: 0, outputHash: sha256('') }) },
+  { faultType: 'tool-timeout', boundary: 'tool', componentId: 'weather-tool', spanId: 'tool-weather', signal: 'tool deadline exceeded', mutate: (s) => ({ ...s, status: 'timeout', signalCode: 'DEADLINE_EXCEEDED', durationMs: 5_000 }) },
+  { faultType: 'corrupted-tool-output', boundary: 'tool', componentId: 'weather-tool', spanId: 'tool-weather', signal: 'output differs from aligned clean reference', mutate: (s) => ({ ...s, outputHash: sha256('plausible-but-wrong'), outputBytes: 19 }) },
+  { faultType: 'context-truncation', boundary: 'model-context', componentId: 'reasoning-model', spanId: 'model-answer', signal: 'context truncated', mutate: (s) => ({ ...s, status: 'error', signalCode: 'CONTEXT_TRUNCATED', inputBytes: 131_072 }) },
+  { faultType: 'delegation-timeout', boundary: 'inter-agent', componentId: 'reviewer-agent', spanId: 'delegate-review', signal: 'delegation deadline exceeded', mutate: (s) => ({ ...s, status: 'timeout', signalCode: 'DELEGATION_TIMEOUT', durationMs: 5_000 }) },
+  { faultType: 'agent-misroute', boundary: 'inter-agent', componentId: 'reviewer-agent', spanId: 'delegate-review', signal: 'actual agent differs from intended agent', mutate: (s) => ({ ...s, actualDestination: 'billing-agent' }) },
+  { faultType: 'delegation-loop', boundary: 'inter-agent', componentId: 'reviewer-agent', spanId: 'delegate-review', signal: 'delegation edge repeats', mutate: (s) => ({ ...s, retry: 4, signalCode: 'DELEGATION_REPEATED' }) },
+  { faultType: 'guardrail-bypass', boundary: 'guardrail', componentId: 'safety-policy', spanId: 'policy-check', signal: 'policy oracle denies but runtime allows', mutate: (s) => ({ ...s, actualDecision: 'allow' }) },
+];
+
+function trace(runId: string, taskId: string, spans: readonly SanitizedTraceSpan[]): SanitizedExecutionTrace {
+  return {
+    schemaVersion: AGENT_FAULT_TRACE_SCHEMA_VERSION,
+    runId,
+    taskId,
+    harnessRevision: HARNESS_REVISION,
+    terminalOutcome: 'completed',
+    spans,
+  };
+}
+
+function structured(raw: SanitizedExecutionTrace): StructuredTraceView {
+  return {
+    schemaVersion: raw.schemaVersion,
+    runId: raw.runId,
+    taskId: raw.taskId,
+    terminalOutcome: raw.terminalOutcome,
+    spans: [...raw.spans].sort((a, b) => a.startOffsetMs - b.startOffsetMs || a.spanId.localeCompare(b.spanId)),
+  };
+}
+
+function makeCase(
+  caseId: string,
+  runId: string,
+  taskId: string,
+  truth: AgentFaultGroundTruth,
+  spans: readonly SanitizedTraceSpan[],
+  cleanReference?: StructuredTraceView,
+  cleanReferenceId?: string,
+  expectedObservableSignal = 'no fault signal',
+): AgentFaultCorpusCase {
+  const raw = trace(runId, taskId, spans);
+  return {
+    caseId,
+    ...(cleanReferenceId ? { cleanReferenceId } : {}),
+    detectorInput: { trace: raw, structured: structured(raw), ...(cleanReference ? { cleanReference } : {}) },
+    heldOut: {
+      truth,
+      manifest: {
+        schemaVersion: AGENT_FAULT_CORPUS_SCHEMA_VERSION,
+        caseId,
+        runId,
+        taskId,
+        sourceRevision: SOURCE_REVISION,
+        environmentDigest: ENVIRONMENT_DIGEST,
+        seed: 649,
+        target: { boundary: truth.boundary, componentId: truth.componentId, spanId: truth.spanId },
+        parameters: { synthetic: true },
+        expectedObservableSignal,
+        cleanup: { required: false, state: 'not-required', witness: 'synthetic fixture; no side effects' },
+      },
+    },
+  };
+}
+
+/** Frozen, synthetic corpus. Ground truth is never embedded in detectorInput. */
+export function createAgentFaultDiagnosisCorpus(): AgentFaultCorpus {
+  const cases: AgentFaultCorpusCase[] = [];
+  FIXTURES.forEach((fixture, index) => {
+    const ordinal = String(index + 1).padStart(3, '0');
+    const taskId = `task-${ordinal}`;
+    const cleanCaseId = `case-${ordinal}-a`;
+    const cleanSpans = baseSpans();
+    const cleanRaw = trace(`run-${ordinal}-a`, taskId, cleanSpans);
+    const cleanView = structured(cleanRaw);
+    const cleanTruth: AgentFaultGroundTruth = { faultType: 'none', boundary: 'control', componentId: 'workflow', spanId: 'run' };
+    cases.push(makeCase(cleanCaseId, `run-${ordinal}-a`, taskId, cleanTruth, cleanSpans));
+
+    const faultySpans = cleanSpans.map((item) => item.spanId === fixture.spanId ? fixture.mutate(item) : item);
+    const truth: AgentFaultGroundTruth = {
+      faultType: fixture.faultType,
+      boundary: fixture.boundary,
+      componentId: fixture.componentId,
+      spanId: fixture.spanId,
+    };
+    cases.push(makeCase(
+      `case-${ordinal}-b`,
+      `run-${ordinal}-b`,
+      taskId,
+      truth,
+      faultySpans,
+      cleanView,
+      cleanCaseId,
+      fixture.signal,
+    ));
+  });
+  const casesDigest = sha256(stable(cases.map(({ caseId, cleanReferenceId, detectorInput, heldOut }) => ({
+    caseId, cleanReferenceId, detectorInput, heldOut,
+  }))));
+  return {
+    manifest: {
+      schemaVersion: AGENT_FAULT_CORPUS_SCHEMA_VERSION,
+      corpusId: `aqe-agent-faults-${casesDigest.slice(0, 16)}`,
+      sourceRevision: SOURCE_REVISION,
+      harnessRevision: HARNESS_REVISION,
+      caseCount: cases.length,
+      casesDigest,
+      mixedFaults: 'out-of-scope',
+      detectorInputExcludes: ['injection manifest', 'ground-truth fault type', 'ground-truth location', 'fixture path'],
+    },
+    cases,
+  };
+}
+
+export function serializeDetectorInput(input: AgentFaultCorpusCase['detectorInput']): string {
+  return stable(input);
+}

--- a/src/domains/chaos-resilience/diagnosis/detectors.ts
+++ b/src/domains/chaos-resilience/diagnosis/detectors.ts
@@ -1,0 +1,123 @@
+import type {
+  AgentFaultDetector,
+  AgentFaultDiagnosis,
+  AgentRuntimeBoundary,
+  AgentRuntimeFaultType,
+  RankedFaultCandidate,
+  SanitizedTraceSpan,
+} from './types.js';
+
+interface RuleMatch {
+  readonly faultType: Exclude<AgentRuntimeFaultType, 'none'>;
+  readonly boundary: Exclude<AgentRuntimeBoundary, 'control'>;
+  readonly confidence: number;
+}
+
+function directSignal(span: SanitizedTraceSpan): RuleMatch | undefined {
+  if (span.signalCode === 'TOOL_UNAVAILABLE') return { faultType: 'tool-unavailable', boundary: 'tool', confidence: 1 };
+  if (span.kind === 'tool' && span.status === 'timeout') return { faultType: 'tool-timeout', boundary: 'tool', confidence: 1 };
+  if (span.signalCode === 'CONTEXT_TRUNCATED') return { faultType: 'context-truncation', boundary: 'model-context', confidence: 1 };
+  if (span.kind === 'delegation' && span.status === 'timeout') return { faultType: 'delegation-timeout', boundary: 'inter-agent', confidence: 1 };
+  if (span.kind === 'delegation' && span.intendedDestination !== span.actualDestination) {
+    return { faultType: 'agent-misroute', boundary: 'inter-agent', confidence: 1 };
+  }
+  if (span.kind === 'delegation' && (span.retry ?? 0) >= 3) {
+    return { faultType: 'delegation-loop', boundary: 'inter-agent', confidence: 0.95 };
+  }
+  return undefined;
+}
+
+function candidate(span: SanitizedTraceSpan, match: RuleMatch): RankedFaultCandidate {
+  return {
+    ...match,
+    componentId: span.componentId,
+    spanId: span.spanId,
+  };
+}
+
+/** A transparent baseline limited to explicit runtime signals. */
+export const directSignalBaseline: AgentFaultDetector = {
+  id: 'direct-signal-v1',
+  diagnose(caseId, input) {
+    const candidates = input.structured.spans.flatMap((span) => {
+      const match = directSignal(span);
+      return match ? [candidate(span, match)] : [];
+    });
+    if (candidates.length > 0) return diagnosed(caseId, candidates);
+    if (input.cleanReference && input.structured.spans.some((span) => {
+      const clean = input.cleanReference?.spans.find((item) => item.spanId === span.spanId);
+      return clean?.outputHash !== span.outputHash;
+    })) return abstained(caseId, 'Output differs from reference but has no direct failure signal');
+    if (input.structured.spans.every(isHealthy)) return healthy(caseId);
+    return abstained(caseId, 'No qualified direct signal');
+  },
+};
+
+/**
+ * AQE reference-aware diagnosis. It adds paired-output comparison and a policy
+ * oracle to the direct-signal baseline; neither source is a hidden fault label.
+ */
+export const referenceAwareAqeDetector: AgentFaultDetector = {
+  id: 'aqe-reference-aware-v1',
+  diagnose(caseId, input) {
+    const direct = directSignalBaseline.diagnose(caseId, input);
+    if (direct.status === 'diagnosed') return direct;
+
+    for (const span of input.structured.spans) {
+      if (span.kind === 'guardrail' && span.policyRef && span.expectedDecision && span.actualDecision
+        && span.expectedDecision !== span.actualDecision) {
+        return diagnosed(caseId, [candidate(span, {
+          faultType: 'guardrail-bypass', boundary: 'guardrail', confidence: 1,
+        })]);
+      }
+      if (span.kind === 'tool' && input.cleanReference) {
+        const clean = input.cleanReference.spans.find((item) => item.spanId === span.spanId);
+        if (clean && clean.outputHash !== span.outputHash) {
+          return diagnosed(caseId, [candidate(span, {
+            faultType: 'corrupted-tool-output', boundary: 'tool', confidence: 0.9,
+          })]);
+        }
+      }
+    }
+    return direct;
+  },
+};
+
+/** Negative-control detector used to prove majority-class guessing cannot pass. */
+export const majorityFaultDetector: AgentFaultDetector = {
+  id: 'always-tool-unavailable',
+  diagnose(caseId, input) {
+    const span = input.structured.spans.find((item) => item.kind === 'tool') ?? input.structured.spans[0];
+    if (!span) return { ...abstained(caseId, 'Empty trace'), status: 'parse-error' };
+    return diagnosed(caseId, [candidate(span, {
+      faultType: 'tool-unavailable', boundary: 'tool', confidence: 1,
+    })]);
+  },
+};
+
+function isHealthy(span: SanitizedTraceSpan): boolean {
+  return span.status === 'ok'
+    && span.intendedDestination === span.actualDestination
+    && (!(span.expectedDecision && span.actualDecision) || span.expectedDecision === span.actualDecision)
+    && (span.retry ?? 0) < 3;
+}
+
+function diagnosed(caseId: string, candidates: readonly RankedFaultCandidate[]): AgentFaultDiagnosis {
+  return { caseId, status: 'diagnosed', candidates, signalObserved: true, latencyMs: 0 };
+}
+
+function healthy(caseId: string): AgentFaultDiagnosis {
+  return {
+    caseId,
+    status: 'diagnosed',
+    candidates: [{
+      faultType: 'none', boundary: 'control', componentId: 'workflow', spanId: 'run', confidence: 1,
+    }],
+    signalObserved: false,
+    latencyMs: 0,
+  };
+}
+
+function abstained(caseId: string, reason: string): AgentFaultDiagnosis {
+  return { caseId, status: 'abstained', candidates: [], signalObserved: false, latencyMs: 0, reason };
+}

--- a/src/domains/chaos-resilience/diagnosis/index.ts
+++ b/src/domains/chaos-resilience/diagnosis/index.ts
@@ -1,0 +1,4 @@
+export * from './types.js';
+export * from './corpus.js';
+export * from './detectors.js';
+export * from './scorer.js';

--- a/src/domains/chaos-resilience/diagnosis/scorer.ts
+++ b/src/domains/chaos-resilience/diagnosis/scorer.ts
@@ -1,0 +1,154 @@
+import type {
+  AgentFaultCaseScore,
+  AgentFaultCorpus,
+  AgentFaultDiagnosis,
+  AgentFaultDetector,
+  AgentFaultScoreReport,
+  AgentFaultSliceScore,
+} from './types.js';
+
+const ratio = (numerator: number, denominator: number): number => denominator === 0 ? 0 : numerator / denominator;
+
+function wilson95(successes: number, total: number): readonly [number, number] {
+  if (total === 0) return [0, 0];
+  const z = 1.96;
+  const p = successes / total;
+  const denominator = 1 + (z * z) / total;
+  const center = (p + (z * z) / (2 * total)) / denominator;
+  const margin = (z / denominator) * Math.sqrt((p * (1 - p) / total) + (z * z) / (4 * total * total));
+  return [Math.max(0, center - margin), Math.min(1, center + margin)];
+}
+
+export function scoreAgentFaultDetector(
+  corpus: AgentFaultCorpus,
+  detector: AgentFaultDetector,
+  topK = 3,
+): AgentFaultScoreReport {
+  const diagnoses = new Map<string, AgentFaultDiagnosis>();
+  for (const item of corpus.cases) diagnoses.set(item.caseId, runDetector(detector, item.caseId, item.detectorInput));
+
+  const cases: AgentFaultCaseScore[] = corpus.cases.map((item) => {
+    const diagnosis = diagnoses.get(item.caseId)!;
+    const truth = item.heldOut.truth;
+    const top = diagnosis.candidates[0];
+    const injected = truth.faultType !== 'none';
+    const predictedFault = Boolean(top && top.faultType !== 'none');
+    return {
+      caseId: item.caseId,
+      faultType: truth.faultType,
+      boundary: truth.boundary,
+      faultInjected: injected,
+      signalObserved: diagnosis.signalObserved,
+      detected: injected ? predictedFault : !predictedFault,
+      typeCorrect: top?.faultType === truth.faultType,
+      componentLocalized: top?.componentId === truth.componentId,
+      spanLocalized: top?.spanId === truth.spanId,
+      jointCorrect: top?.faultType === truth.faultType && top?.componentId === truth.componentId,
+      recovered: item.detectorInput.structured.spans.some((span) => span.recovered),
+      taskSucceeded: item.detectorInput.structured.terminalOutcome === 'completed',
+      abstained: diagnosis.status === 'abstained',
+    };
+  });
+
+  const faulty = corpus.cases.filter((item) => item.heldOut.truth.faultType !== 'none');
+  const clean = corpus.cases.filter((item) => item.heldOut.truth.faultType === 'none');
+  const faultyScores = cases.filter((item) => item.faultInjected);
+  const cleanScores = cases.filter((item) => !item.faultInjected);
+  const predictedClean = corpus.cases.filter((item) => diagnoses.get(item.caseId)?.candidates[0]?.faultType === 'none');
+  const trueCleanPredictions = predictedClean.filter((item) => item.heldOut.truth.faultType === 'none');
+  const typeTopKCorrect = faulty.filter((item) => diagnoses.get(item.caseId)?.candidates
+    .slice(0, topK).some((candidate) => candidate.faultType === item.heldOut.truth.faultType)).length;
+  const parsed = [...diagnoses.values()].filter((item) => item.status !== 'parse-error').length;
+  const abstained = [...diagnoses.values()].filter((item) => item.status === 'abstained').length;
+
+  return {
+    detectorId: detector.id,
+    corpusId: corpus.manifest.corpusId,
+    support: cases.length,
+    noFault: {
+      precision: ratio(trueCleanPredictions.length, predictedClean.length),
+      recall: ratio(cleanScores.filter((item) => item.typeCorrect).length, clean.length),
+      falsePositiveRate: ratio(cleanScores.filter((item) => !item.typeCorrect).length, clean.length),
+    },
+    faultRecall: ratio(faultyScores.filter((item) => item.detected).length, faulty.length),
+    typeTop1: ratio(faultyScores.filter((item) => item.typeCorrect).length, faulty.length),
+    typeTopK: ratio(typeTopKCorrect, faulty.length),
+    componentTop1: ratio(faultyScores.filter((item) => item.componentLocalized).length, faulty.length),
+    exactSpanTop1: ratio(faultyScores.filter((item) => item.spanLocalized).length, faulty.length),
+    jointTop1: ratio(faultyScores.filter((item) => item.jointCorrect).length, faulty.length),
+    parseRate: ratio(parsed, cases.length),
+    abstentionRate: ratio(abstained, cases.length),
+    meanLatencyMs: ratio([...diagnoses.values()].reduce((sum, item) => sum + item.latencyMs, 0), cases.length),
+    totalTokens: [...diagnoses.values()].reduce((sum, item) => sum + (item.tokens ?? 0), 0),
+    totalCost: [...diagnoses.values()].reduce((sum, item) => sum + (item.cost ?? 0), 0),
+    uncertainty: { method: 'wilson-95', faultRecall: wilson95(faultyScores.filter((item) => item.detected).length, faulty.length) },
+    byFault: slice(corpus, cases, (index) => corpus.cases[index]!.heldOut.truth.faultType),
+    byBoundary: slice(corpus, cases, (index) => corpus.cases[index]!.heldOut.truth.boundary),
+    cases,
+  };
+}
+
+function slice(
+  corpus: AgentFaultCorpus,
+  scores: readonly AgentFaultCaseScore[],
+  key: (index: number) => string,
+): Readonly<Record<string, AgentFaultSliceScore>> {
+  const groups = new Map<string, AgentFaultCaseScore[]>();
+  scores.forEach((score, index) => groups.set(key(index), [...(groups.get(key(index)) ?? []), score]));
+  return Object.fromEntries([...groups.entries()].map(([name, items]) => [name, {
+    support: items.length,
+    detected: items.filter((item) => item.detected).length,
+    typeTop1: items.filter((item) => item.typeCorrect).length,
+    componentTop1: items.filter((item) => item.componentLocalized).length,
+    jointTop1: items.filter((item) => item.jointCorrect).length,
+    abstentions: items.filter((item) => item.abstained).length,
+  }]));
+}
+
+export interface AgentFaultQualification {
+  readonly passed: boolean;
+  readonly failures: readonly string[];
+}
+
+export function qualifyAgentFaultDetector(report: AgentFaultScoreReport): AgentFaultQualification {
+  const failures: string[] = [];
+  if (report.noFault.falsePositiveRate > 0.1) failures.push('no-fault false-positive rate exceeds 10%');
+  if (report.typeTop1 < 0.5) failures.push('fault-type top-1 accuracy is below 50%');
+  if (report.jointTop1 < 0.5) failures.push('joint type/location accuracy is below 50%');
+  if (report.parseRate < 1) failures.push('detector did not parse every frozen case');
+  for (const critical of ['corrupted-tool-output', 'guardrail-bypass']) {
+    const score = report.cases.find((item) => item.faultType === critical);
+    if (score && !score.typeCorrect && !score.abstained) {
+      failures.push(`${critical} must be diagnosed correctly or explicitly abstained`);
+    }
+  }
+  return { passed: failures.length === 0, failures };
+}
+
+function runDetector(
+  detector: AgentFaultDetector,
+  caseId: string,
+  input: Parameters<AgentFaultDetector['diagnose']>[1],
+): AgentFaultDiagnosis {
+  try {
+    const result = detector.diagnose(caseId, input);
+    const validStatus = ['diagnosed', 'abstained', 'parse-error'].includes(result.status);
+    const validCandidates = Array.isArray(result.candidates)
+      && result.candidates.every((item) => Number.isFinite(item.confidence)
+        && item.confidence >= 0 && item.confidence <= 1);
+    if (result.caseId !== caseId || !validStatus || !validCandidates
+      || !Number.isFinite(result.latencyMs) || result.latencyMs < 0) {
+      throw new Error('Detector returned an invalid diagnosis envelope');
+    }
+    return result;
+  } catch (error) {
+    return {
+      caseId,
+      status: 'parse-error',
+      candidates: [],
+      signalObserved: false,
+      latencyMs: 0,
+      reason: error instanceof Error ? error.message : 'Detector failed',
+    };
+  }
+}

--- a/src/domains/chaos-resilience/diagnosis/types.ts
+++ b/src/domains/chaos-resilience/diagnosis/types.ts
@@ -1,0 +1,190 @@
+export const AGENT_FAULT_TRACE_SCHEMA_VERSION = '1.0.0' as const;
+export const AGENT_FAULT_CORPUS_SCHEMA_VERSION = '1.0.0' as const;
+
+export type AgentRuntimeBoundary = 'tool' | 'model-context' | 'guardrail' | 'inter-agent' | 'control';
+
+export type AgentRuntimeFaultType =
+  | 'none'
+  | 'tool-unavailable'
+  | 'tool-timeout'
+  | 'corrupted-tool-output'
+  | 'context-truncation'
+  | 'delegation-timeout'
+  | 'agent-misroute'
+  | 'delegation-loop'
+  | 'guardrail-bypass';
+
+export type TraceSpanKind = 'run' | 'agent' | 'delegation' | 'tool' | 'model' | 'guardrail';
+export type TraceSpanStatus = 'ok' | 'error' | 'timeout' | 'cancelled';
+
+export interface SanitizedTraceSpan {
+  readonly spanId: string;
+  readonly parentSpanId?: string;
+  readonly componentId: string;
+  readonly kind: TraceSpanKind;
+  readonly startOffsetMs: number;
+  readonly durationMs: number;
+  readonly status: TraceSpanStatus;
+  readonly signalCode?: string;
+  readonly inputBytes: number;
+  readonly outputBytes: number;
+  readonly inputHash: string;
+  readonly outputHash: string;
+  readonly intendedDestination?: string;
+  readonly actualDestination?: string;
+  readonly policyRef?: string;
+  readonly expectedDecision?: 'allow' | 'deny';
+  readonly actualDecision?: 'allow' | 'deny';
+  readonly retry?: number;
+  readonly recovered?: boolean;
+}
+
+export interface SanitizedExecutionTrace {
+  readonly schemaVersion: typeof AGENT_FAULT_TRACE_SCHEMA_VERSION;
+  readonly runId: string;
+  readonly taskId: string;
+  readonly harnessRevision: string;
+  readonly terminalOutcome: 'completed' | 'failed' | 'cancelled';
+  readonly spans: readonly SanitizedTraceSpan[];
+}
+
+export interface StructuredTraceView {
+  readonly schemaVersion: typeof AGENT_FAULT_TRACE_SCHEMA_VERSION;
+  readonly runId: string;
+  readonly taskId: string;
+  readonly terminalOutcome: SanitizedExecutionTrace['terminalOutcome'];
+  readonly spans: readonly SanitizedTraceSpan[];
+}
+
+export interface AgentFaultDetectorInput {
+  readonly trace: SanitizedExecutionTrace;
+  readonly structured: StructuredTraceView;
+  readonly cleanReference?: StructuredTraceView;
+}
+
+export interface AgentFaultInjectionManifest {
+  readonly schemaVersion: typeof AGENT_FAULT_CORPUS_SCHEMA_VERSION;
+  readonly caseId: string;
+  readonly runId: string;
+  readonly taskId: string;
+  readonly sourceRevision: string;
+  readonly environmentDigest: string;
+  readonly seed: number;
+  readonly target: {
+    readonly boundary: AgentRuntimeBoundary;
+    readonly componentId: string;
+    readonly spanId: string;
+  };
+  readonly parameters: Readonly<Record<string, string | number | boolean>>;
+  readonly expectedObservableSignal: string;
+  readonly cleanup: {
+    readonly required: boolean;
+    readonly state: 'not-required' | 'verified';
+    readonly witness: string;
+  };
+}
+
+export interface AgentFaultGroundTruth {
+  readonly faultType: AgentRuntimeFaultType;
+  readonly boundary: AgentRuntimeBoundary;
+  readonly componentId: string;
+  readonly spanId: string;
+}
+
+export interface AgentFaultCorpusCase {
+  readonly caseId: string;
+  readonly cleanReferenceId?: string;
+  readonly detectorInput: AgentFaultDetectorInput;
+  /** Held outside detectorInput. Callers must not pass this object to detectors. */
+  readonly heldOut: {
+    readonly manifest: AgentFaultInjectionManifest;
+    readonly truth: AgentFaultGroundTruth;
+  };
+}
+
+export interface AgentFaultCorpusManifest {
+  readonly schemaVersion: typeof AGENT_FAULT_CORPUS_SCHEMA_VERSION;
+  readonly corpusId: string;
+  readonly sourceRevision: string;
+  readonly harnessRevision: string;
+  readonly caseCount: number;
+  readonly casesDigest: string;
+  readonly mixedFaults: 'out-of-scope';
+  readonly detectorInputExcludes: readonly string[];
+}
+
+export interface AgentFaultCorpus {
+  readonly manifest: AgentFaultCorpusManifest;
+  readonly cases: readonly AgentFaultCorpusCase[];
+}
+
+export interface RankedFaultCandidate {
+  readonly faultType: AgentRuntimeFaultType;
+  readonly boundary: AgentRuntimeBoundary;
+  readonly componentId: string;
+  readonly spanId: string;
+  readonly confidence: number;
+}
+
+export interface AgentFaultDiagnosis {
+  readonly caseId: string;
+  readonly status: 'diagnosed' | 'abstained' | 'parse-error';
+  readonly candidates: readonly RankedFaultCandidate[];
+  readonly signalObserved: boolean;
+  readonly latencyMs: number;
+  readonly tokens?: number;
+  readonly cost?: number;
+  readonly reason?: string;
+}
+
+export interface AgentFaultDetector {
+  readonly id: string;
+  diagnose(caseId: string, input: AgentFaultDetectorInput): AgentFaultDiagnosis;
+}
+
+export interface AgentFaultCaseScore {
+  readonly caseId: string;
+  readonly faultType: AgentRuntimeFaultType;
+  readonly boundary: AgentRuntimeBoundary;
+  readonly faultInjected: boolean;
+  readonly signalObserved: boolean;
+  readonly detected: boolean;
+  readonly typeCorrect: boolean;
+  readonly componentLocalized: boolean;
+  readonly spanLocalized: boolean;
+  readonly jointCorrect: boolean;
+  readonly recovered: boolean;
+  readonly taskSucceeded: boolean;
+  readonly abstained: boolean;
+}
+
+export interface AgentFaultSliceScore {
+  readonly support: number;
+  readonly detected: number;
+  readonly typeTop1: number;
+  readonly componentTop1: number;
+  readonly jointTop1: number;
+  readonly abstentions: number;
+}
+
+export interface AgentFaultScoreReport {
+  readonly detectorId: string;
+  readonly corpusId: string;
+  readonly support: number;
+  readonly noFault: { readonly precision: number; readonly recall: number; readonly falsePositiveRate: number };
+  readonly faultRecall: number;
+  readonly typeTop1: number;
+  readonly typeTopK: number;
+  readonly componentTop1: number;
+  readonly exactSpanTop1: number;
+  readonly jointTop1: number;
+  readonly parseRate: number;
+  readonly abstentionRate: number;
+  readonly meanLatencyMs: number;
+  readonly totalTokens: number;
+  readonly totalCost: number;
+  readonly uncertainty: { readonly method: 'wilson-95'; readonly faultRecall: readonly [number, number] };
+  readonly byFault: Readonly<Record<string, AgentFaultSliceScore>>;
+  readonly byBoundary: Readonly<Record<string, AgentFaultSliceScore>>;
+  readonly cases: readonly AgentFaultCaseScore[];
+}

--- a/src/domains/chaos-resilience/index.ts
+++ b/src/domains/chaos-resilience/index.ts
@@ -141,3 +141,5 @@ export type {
   LoadTestCompletedEvent,
   ResilienceIssueDetectedEvent,
 } from './interfaces';
+
+export * from './diagnosis/index.js';

--- a/src/domains/index.ts
+++ b/src/domains/index.ts
@@ -20,5 +20,6 @@ export * as SecurityCompliance from './security-compliance/interfaces';
 export * as ContractTesting from './contract-testing/interfaces';
 export * as VisualAccessibility from './visual-accessibility/interfaces';
 export * as ChaosResilience from './chaos-resilience/interfaces';
+export * as AgentFaultDiagnosis from './chaos-resilience/diagnosis/index';
 export * as LearningOptimization from './learning-optimization/interfaces';
 export * as EnterpriseIntegration from './enterprise-integration/interfaces';

--- a/tests/unit/domains/chaos-resilience/agent-fault-diagnosis.test.ts
+++ b/tests/unit/domains/chaos-resilience/agent-fault-diagnosis.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createAgentFaultDiagnosisCorpus,
+  directSignalBaseline,
+  majorityFaultDetector,
+  qualifyAgentFaultDetector,
+  referenceAwareAqeDetector,
+  scoreAgentFaultDetector,
+  serializeDetectorInput,
+} from '../../../../src/domains/chaos-resilience/diagnosis/index.js';
+
+describe('agent runtime fault diagnosis corpus', () => {
+  it('freezes paired clean/fault traces across every required boundary and fault', () => {
+    const corpus = createAgentFaultDiagnosisCorpus();
+    const faults = corpus.cases.filter((item) => item.heldOut.truth.faultType !== 'none');
+
+    expect(corpus.manifest.caseCount).toBe(16);
+    expect(new Set(faults.map((item) => item.heldOut.truth.boundary))).toEqual(
+      new Set(['tool', 'model-context', 'guardrail', 'inter-agent']),
+    );
+    expect(new Set(faults.map((item) => item.heldOut.truth.faultType))).toEqual(new Set([
+      'tool-unavailable', 'tool-timeout', 'corrupted-tool-output', 'context-truncation',
+      'delegation-timeout', 'agent-misroute', 'delegation-loop', 'guardrail-bypass',
+    ]));
+    for (const item of faults) {
+      const clean = corpus.cases.find((candidate) => candidate.caseId === item.cleanReferenceId);
+      expect(clean).toBeDefined();
+      expect(clean?.detectorInput.trace.taskId).toBe(item.detectorInput.trace.taskId);
+      expect(item.heldOut.manifest.cleanup).toEqual({
+        required: false, state: 'not-required', witness: 'synthetic fixture; no side effects',
+      });
+    }
+    expect(createAgentFaultDiagnosisCorpus().manifest).toEqual(corpus.manifest);
+  });
+
+  it('keeps provenance and ground truth outside sanitized detector inputs', () => {
+    const corpus = createAgentFaultDiagnosisCorpus();
+    const forbiddenKeys = [
+      'heldOut', 'manifest', 'truth', 'faultType', 'boundary', 'expectedObservableSignal',
+      'sourceRevision', 'environmentDigest', 'parameters', 'seed', 'caseId',
+    ];
+
+    for (const item of corpus.cases) {
+      const serialized = serializeDetectorInput(item.detectorInput);
+      for (const key of forbiddenKeys) expect(serialized).not.toContain(`"${key}"`);
+      expect(serialized).not.toContain(item.caseId);
+      expect(item.caseId).toMatch(/^case-\d{3}-[ab]$/);
+      for (const span of item.detectorInput.trace.spans) {
+        expect(span.inputHash).toMatch(/^[a-f0-9]{64}$/);
+        expect(span.outputHash).toMatch(/^[a-f0-9]{64}$/);
+        expect(span).not.toHaveProperty('input');
+        expect(span).not.toHaveProperty('output');
+      }
+    }
+  });
+
+  it('reports the full metric surface and separates runtime outcomes', () => {
+    const corpus = createAgentFaultDiagnosisCorpus();
+    const report = scoreAgentFaultDetector(corpus, referenceAwareAqeDetector);
+
+    expect(report.noFault).toEqual({ precision: 1, recall: 1, falsePositiveRate: 0 });
+    expect(report.faultRecall).toBe(1);
+    expect(report.typeTop1).toBe(1);
+    expect(report.typeTopK).toBe(1);
+    expect(report.componentTop1).toBe(1);
+    expect(report.exactSpanTop1).toBe(1);
+    expect(report.jointTop1).toBe(1);
+    expect(report.parseRate).toBe(1);
+    expect(report.byFault['guardrail-bypass']?.support).toBe(1);
+    expect(report.byBoundary.tool?.support).toBe(3);
+    expect(report.byBoundary.control?.support).toBe(8);
+    expect(report.uncertainty.method).toBe('wilson-95');
+    const corruption = corpus.cases.find((item) => item.heldOut.truth.faultType === 'corrupted-tool-output')!;
+    expect(report.cases.find((item) => item.caseId === corruption.caseId)).toMatchObject({
+      faultInjected: true, signalObserved: true, detected: true, recovered: false, taskSucceeded: true,
+    });
+    expect(qualifyAgentFaultDetector(report)).toEqual({ passed: true, failures: [] });
+  });
+
+  it('abstains on silent corruption without a qualified reference interpretation', () => {
+    const corpus = createAgentFaultDiagnosisCorpus();
+    const item = corpus.cases.find(
+      (candidate) => candidate.heldOut.truth.faultType === 'corrupted-tool-output',
+    )!;
+    expect(directSignalBaseline.diagnose(item.caseId, item.detectorInput)).toMatchObject({
+      status: 'abstained', candidates: [],
+    });
+  });
+
+  it('rejects an always-majority fault detector', () => {
+    const report = scoreAgentFaultDetector(createAgentFaultDiagnosisCorpus(), majorityFaultDetector);
+    const qualification = qualifyAgentFaultDetector(report);
+
+    expect(qualification.passed).toBe(false);
+    expect(report.noFault.falsePositiveRate).toBe(1);
+    expect(report.typeTop1).toBeLessThan(0.5);
+    expect(qualification.failures).toContain('no-fault false-positive rate exceeds 10%');
+  });
+
+  it('retains throwing detectors as parse failures instead of dropping cases', () => {
+    const report = scoreAgentFaultDetector(createAgentFaultDiagnosisCorpus(), {
+      id: 'throwing-detector',
+      diagnose: () => { throw new Error('malformed output'); },
+    });
+
+    expect(report.support).toBe(16);
+    expect(report.parseRate).toBe(0);
+    expect(report.cases).toHaveLength(16);
+    expect(qualifyAgentFaultDetector(report).failures).toContain(
+      'detector did not parse every frozen case',
+    );
+  });
+});


### PR DESCRIPTION
AQE had infrastructure chaos experiments but no reproducible way to measure whether a detector can distinguish clean agent runs from runtime faults, classify them, and localize the affected component. This adds a versioned, synthetic diagnosis corpus and scorer exposed through the package-root `AgentFaultDiagnosis` namespace.

The frozen corpus contains eight same-input clean/fault pairs across tool, model/context, guardrail, and inter-agent boundaries. It covers tool unavailability, timeout, plausible output corruption, context truncation, delegation timeout, agent misrouting, loops, and guardrail bypass. Detector-visible IDs are opaque; manifests and truth remain held out; traces contain hashes and byte counts rather than payloads.

The scorer reports clean behavior, top-1/top-k type accuracy, component and exact-span localization, joint accuracy, per-fault/per-boundary slices, parse/abstention rates, cost/performance fields, and Wilson uncertainty. It retains malformed detector results as parse errors and proves that an always-majority predictor cannot qualify.

Closes #649

## Verification

- `npm run typecheck`
- targeted ESLint over `src/domains/chaos-resilience/diagnosis/*.ts`
- `npx vitest run tests/unit/domains/chaos-resilience` — 6 files and 162 tests passed
- `npm run build`
- package-root ESM smoke test — 16 cases, reference-aware detector qualified
- `git diff --check`

## Failure modes

- Truth leakage through trace metadata and descriptive case IDs is covered by negative assertions over every detector input.
- Silent corruption without a reference is covered by an explicit abstention test.
- Throwing detector implementations are covered and retained as parse failures.
- Majority-class prediction is covered by a detector that fails the qualification thresholds.
- Mixed/multiple faults remain explicitly out of scope in the versioned corpus manifest, as required by #649.

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.**
