### PR TITLE
feat(verification): add failure-mode reach gates

### DIFF
--- a/docs/v3/README.md
+++ b/docs/v3/README.md
@@ -18,6 +18,7 @@ Welcome to Agentic QE v3 - a complete architectural reimagining with Domain-Driv
 ### Getting Started
 - [Quick Start Guide](guides/getting-started.md)
 - [Quick Reference](guides/quick-reference.md)
+- [Verification Reach Manifests](guides/verification-reach.md)
 - [Migration from v2](migration/v2-to-v3-migration.md)
 
 ### Architecture

--- a/docs/v3/guides/verification-reach.md
+++ b/docs/v3/guides/verification-reach.md
@@ -1,0 +1,80 @@
+# Verification Reach Manifests
+
+AQE quality gates separate two questions:
+
+1. Did the artifact satisfy the mechanical and specification checks?
+2. Could the supplied evidence directly observe every material failure mode?
+
+An overall `pass` requires both `qualityVerdict: "pass"` and
+`coverageVerdict: "pass"`. Requests made without a reach manifest remain
+supported during migration, but return `verification.kind: "legacy-unknown"`,
+`coverageVerdict: "inconclusive"`, and cannot produce an overall pass.
+
+## Create a manifest
+
+Use the exported helpers so the artifact bytes and manifest content are hashed
+canonically:
+
+```ts
+import {
+  computeVerificationArtifactDigest,
+  createVerificationReachManifest,
+} from 'agentic-qe';
+
+const artifact = await readArtifact();
+const target = {
+  revision: process.env.GITHUB_SHA!,
+  digest: computeVerificationArtifactDigest(artifact),
+  environment: 'github-actions/ubuntu-24.04',
+};
+
+const manifest = createVerificationReachManifest({
+  id: 'release-reach-v1',
+  systemUnderTest: 'my-service',
+  artifact: target,
+  generatedAt: new Date().toISOString(),
+  risks: [{
+    riskId: 'service-does-not-start',
+    failureMode: 'the service cannot accept requests after deployment',
+    severity: 'critical',
+    requiredOracle: 'health-response-oracle-v1',
+    requiredObservations: ['runtime'],
+    dispositionWhenUncovered: 'fail',
+    checks: [{
+      checkId: 'boot-probe',
+      channel: 'runtime',
+      reach: 'direct',
+      evidenceClass: 'EXECUTED',
+      executionStatus: 'passed',
+      target,
+      oracleRef: 'health-response-oracle-v1',
+      observedAt: new Date().toISOString(),
+      limitations: ['does not exercise concurrent writes'],
+    }],
+  }],
+});
+```
+
+Pass the serialized manifest to the CLI with
+`--verification-manifest reach.json`, or provide the same object as
+`verificationManifest` to the `qe/quality/gate` MCP tool.
+
+## Reach rules
+
+- Only fresh `EXECUTED` evidence with `reach: "direct"`, a passing execution,
+  the exact target, the required observation channel, and the required oracle
+  can cover a failure mode.
+- `partial` and `none` reach remain visible in results but do not count as
+  direct coverage.
+- Static evidence cannot establish runtime behavior. Browser evidence cannot
+  establish API, telemetry, concurrency, or hardware behavior unless those
+  channels have their own directly applicable checks.
+- Failed checks fail the affected risk. Missing, stale, future-dated,
+  unavailable, wrong-target, or inferred evidence follows the risk's configured
+  `fail`, `inconclusive`, or `human-review` disposition.
+- The manifest hash binds the target, risks, checks, timestamps, limitations,
+  and costs. Changing any bound field invalidates the manifest.
+
+Text output lists direct checks, partial checks, and uncovered channels for each
+risk. JSON output retains the complete manifest evaluation for automation and
+audit.

--- a/src/cli/commands/quality-gate.ts
+++ b/src/cli/commands/quality-gate.ts
@@ -21,12 +21,14 @@ import {
   runQualityGate,
   listChecklistIds,
   type QualityGateRequest,
+  type QualityGateVerificationCoverage,
 } from '../../validation/quality-gate-runner.js';
 import {
   createRouterFrontierJudge,
   createUnavailableJudge,
 } from '../../validation/frontier-judge.js';
 import type { Judge } from '../../validation/quality-verdict.js';
+import type { VerificationReachManifest } from '../../validation/verification-reach.js';
 
 export function createQualityGateCommand(
   _context: CLIContext,
@@ -34,7 +36,7 @@ export function createQualityGateCommand(
   _ensureInitialized: () => Promise<boolean>,
 ): Command {
   return new Command('quality-gate')
-    .description('Two-gate, three-valued quality verdict against a pinned ADR-117 checklist (ADR-119)')
+    .description('Fail-closed quality and verification-reach verdict against a pinned checklist')
     .option('-c, --checklist <id>', 'Pinned anchor checklist id (e.g. A1-inRange)')
     .option('-a, --artifact-file <path>', 'File containing the artifact under judgement')
     .option('--artifact <text>', 'Inline artifact text (alternative to --artifact-file)')
@@ -42,6 +44,7 @@ export function createQualityGateCommand(
     .option('--baseline-passed', 'Tests executed against the reference implementation')
     .option('--oracle-file <path>', 'JSON file with { passed, baselinePassed } from the ADR-113 oracle')
     .option('--anchor <path>', 'Override the frozen anchor path (ADR-117)')
+    .option('--verification-manifest <path>', 'Revision-bound failure-mode reach manifest (#651)')
     .option('--model <id>', 'Frontier judge model id (ADR-111: always frontier-tier)')
     .option('--list', 'List the available pinned checklist ids and exit')
     .option('-F, --format <format>', 'Output format (text|json)', 'text')
@@ -82,13 +85,23 @@ export function createQualityGateCommand(
           checklistId: options.checklist,
           judge,
           anchorPath: options.anchor,
+          verificationManifest: resolveVerificationManifest(options.verificationManifest),
         };
         const result = await runQualityGate(request);
 
         if (format === 'json') {
           writeOutput(toJSON(result), options.output);
         } else {
-          printVerdict(result.verdict, result.mechanical, result.specCoverage, result.unmet, result.reason);
+          printVerdict(
+            result.verdict,
+            result.qualityVerdict,
+            result.coverageVerdict,
+            result.mechanical,
+            result.specCoverage,
+            result.unmet,
+            result.reason,
+            result.verification,
+          );
         }
 
         // Exit codes: 0 pass, 1 fail, 3 inconclusive (distinct so CI can branch).
@@ -99,6 +112,11 @@ export function createQualityGateCommand(
         await cleanupAndExit(1);
       }
     });
+}
+
+function resolveVerificationManifest(path?: string): VerificationReachManifest | undefined {
+  if (!path) return undefined;
+  return JSON.parse(fs.readFileSync(path, 'utf8')) as VerificationReachManifest;
 }
 
 function resolveArtifact(options: { artifactFile?: string; artifact?: string }): string | null {
@@ -145,20 +163,37 @@ export async function buildJudge(model?: string): Promise<Judge> {
 
 function printVerdict(
   verdict: string,
+  qualityVerdict: string,
+  coverageVerdict: string,
   mechanical: string,
   specCoverage: number | null,
   unmet: string[],
   reason: string,
+  verification: QualityGateVerificationCoverage,
 ): void {
   const icon = verdict === 'pass' ? chalk.green('✓ PASS')
     : verdict === 'fail' ? chalk.red('✗ FAIL')
     : chalk.yellow('? INCONCLUSIVE');
   console.log(`\n  Quality Gate: ${icon}`);
+  console.log(`  Quality verdict: ${qualityVerdict}`);
+  console.log(`  Coverage verdict: ${coverageVerdict}`);
   console.log(`  Mechanical gate: ${mechanical === 'pass' ? chalk.green('pass') : chalk.red('fail')}`);
   if (specCoverage != null) console.log(`  Spec coverage:   ${chalk.cyan((specCoverage * 100).toFixed(0) + '%')}`);
   if (unmet.length > 0) {
     console.log(chalk.cyan('  Unmet requirements:'));
     for (const u of unmet) console.log(chalk.gray(`    - ${u}`));
+  }
+  if (verification.kind === 'legacy-unknown') {
+    console.log(chalk.yellow(`  Verification reach: ${verification.reason}`));
+  } else {
+    console.log(chalk.cyan('  Verification reach:'));
+    for (const risk of verification.risks) {
+      const direct = risk.directCheckIds.join(', ') || 'none';
+      const partial = risk.partialCheckIds.join(', ') || 'none';
+      const uncovered = risk.uncoveredObservations.join(', ') || 'none';
+      console.log(`    ${risk.riskId}: ${risk.verdict}`);
+      console.log(chalk.gray(`      direct=${direct}; partial=${partial}; uncovered=${uncovered}`));
+    }
   }
   console.log(chalk.gray(`  ${reason}\n`));
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -313,6 +313,13 @@ export {
   createVersionComparator,
 } from './validation';
 
+export {
+  computeVerificationArtifactDigest,
+  computeVerificationReachManifestHash,
+  createVerificationReachManifest,
+  evaluateVerificationReach,
+} from './validation/verification-reach';
+
 export type {
   // Configuration types
   SwarmValidationConfig,
@@ -340,6 +347,25 @@ export type {
   ComparisonStats,
   TestCaseComparison,
 } from './validation';
+
+export type {
+  FailureModeRequirement,
+  FailureModeReachResult,
+  FailureModeSeverity,
+  UncoveredDisposition,
+  VerificationChannel,
+  VerificationCost,
+  VerificationCoverageVerdict,
+  VerificationEvidenceClass,
+  VerificationExecutionStatus,
+  VerificationReach,
+  VerificationReachEvaluationOptions,
+  VerificationReachLevel,
+  VerificationReachManifest,
+  VerificationReachManifestInput,
+  VerificationReachResult,
+  VerificationTarget,
+} from './validation/verification-reach';
 
 // Version info - read from package.json
 export const VERSION: string = pkg.version;

--- a/src/mcp/tools/quality-assessment/gate.ts
+++ b/src/mcp/tools/quality-assessment/gate.ts
@@ -1,8 +1,8 @@
 /**
  * Agentic QE v3 - Quality Gate MCP Tool (ADR-119)
  *
- * qe/quality/gate - two-gate, three-valued quality verdict against a pinned
- * ADR-117 checklist. Calls the SAME `runQualityGate` orchestrator as the
+ * qe/quality/gate - fail-closed quality and verification-reach verdict against
+ * a pinned ADR-117 checklist. Calls the SAME `runQualityGate` orchestrator as the
  * `aqe quality-gate` CLI subcommand so CLI and MCP stay in exact parity.
  *
  * The frontier judge is built from the forwarded HybridRouter
@@ -14,12 +14,15 @@ import { MCPToolBase, MCPToolConfig, MCPToolContext, MCPToolSchema } from '../ba
 import { ToolResult } from '../../types';
 import { toErrorMessage } from '../../../shared/error-utils.js';
 import { getLLMRouter } from '../base.js';
-import { runQualityGate } from '../../../validation/quality-gate-runner.js';
+import {
+  runQualityGate,
+  type ReachAwareQualityGateResult,
+} from '../../../validation/quality-gate-runner.js';
 import {
   createRouterFrontierJudge,
   createUnavailableJudge,
 } from '../../../validation/frontier-judge.js';
-import type { QualityVerdictResult } from '../../../validation/quality-verdict.js';
+import type { VerificationReachManifest } from '../../../validation/verification-reach.js';
 
 export interface QualityGateParams {
   /** Pinned anchor checklist id (e.g. "A1-inRange"). */
@@ -33,17 +36,19 @@ export interface QualityGateParams {
   oracle?: { passed: boolean; baselinePassed: boolean } | null;
   /** Override the frozen anchor path (ADR-117). */
   anchorPath?: string;
+  /** Revision-bound evidence proving which failure modes the checks can observe. */
+  verificationManifest?: VerificationReachManifest;
   /** Frontier judge model id (ADR-111: always frontier-tier). */
   model?: string;
   [key: string]: unknown;
 }
 
-export class QualityGateTool extends MCPToolBase<QualityGateParams, QualityVerdictResult> {
+export class QualityGateTool extends MCPToolBase<QualityGateParams, ReachAwareQualityGateResult> {
   readonly config: MCPToolConfig = {
     name: 'qe/quality/gate',
     description:
       'Two-gate, three-valued quality verdict (ADR-119): mechanical oracle gate plus a frontier '
-      + 'judge grading the artifact against a pinned ADR-117 checklist. Returns pass|fail|inconclusive.',
+      + 'judge grading plus failure-mode verification reach. Returns pass|fail|inconclusive.',
     domain: 'quality-assessment',
     schema: QUALITY_GATE_SCHEMA,
     streaming: false,
@@ -53,7 +58,7 @@ export class QualityGateTool extends MCPToolBase<QualityGateParams, QualityVerdi
   async execute(
     params: QualityGateParams,
     context: MCPToolContext,
-  ): Promise<ToolResult<QualityVerdictResult>> {
+  ): Promise<ToolResult<ReachAwareQualityGateResult>> {
     try {
       if (!params.checklistId) {
         return { success: false, error: 'checklistId is required' };
@@ -79,6 +84,7 @@ export class QualityGateTool extends MCPToolBase<QualityGateParams, QualityVerdi
         checklistId: params.checklistId,
         judge,
         anchorPath: params.anchorPath,
+        verificationManifest: params.verificationManifest,
       });
 
       return { success: true, data: result };
@@ -110,6 +116,10 @@ const QUALITY_GATE_SCHEMA: MCPToolSchema = {
     anchorPath: {
       type: 'string',
       description: 'Override the frozen anchor path (ADR-117)',
+    },
+    verificationManifest: {
+      type: 'object',
+      description: 'Hashed, revision-bound failure-mode verification reach manifest (#651)',
     },
     model: {
       type: 'string',

--- a/src/validation/quality-gate-runner.ts
+++ b/src/validation/quality-gate-runner.ts
@@ -8,8 +8,10 @@
  *   1. loads the pinned, hash-checked ADR-117 anchor via `loadAnchorSet` (which
  *      throws on drift — the frozen checklist can't be silently edited),
  *   2. selects the constant-denominator checklist for `checklistId`,
- *   3. runs the two-gate, three-valued `computeQualityVerdict` with the injected
- *      frontier judge.
+ *   3. evaluates the revision-bound failure-mode reach manifest before any
+ *      judge call (missing legacy manifests remain explicitly inconclusive),
+ *   4. runs the two-gate, three-valued `computeQualityVerdict` with the injected
+ *      frontier judge and combines the independent verdicts fail-closed.
  *
  * The oracle result and the judge are injected — this module owns no LLM and no
  * mutation runner, so it is deterministic and unit-testable with a fake judge.
@@ -25,6 +27,13 @@ import {
 } from './quality-verdict.js';
 import type { OracleResult } from './oracle-eval.js';
 import { findProjectRoot } from '../kernel/unified-memory.js';
+import {
+  computeVerificationArtifactDigest,
+  evaluateVerificationReach,
+  type VerificationCoverageVerdict,
+  type VerificationReachManifest,
+  type VerificationReachResult,
+} from './verification-reach.js';
 
 /** Default frozen anchor location, relative to the project root (ADR-117). */
 export const DEFAULT_ANCHOR_RELATIVE_PATH = 'verification/anchors/qe-anchor-v1.json';
@@ -43,21 +52,78 @@ export interface QualityGateRequest {
   judge: Judge;
   /** Override the frozen anchor path (absolute, or relative to project root). */
   anchorPath?: string;
+  /** Revision-bound failure-mode reach evidence. Omit only for legacy migration. */
+  verificationManifest?: VerificationReachManifest;
+}
+
+export interface LegacyUnknownVerificationCoverage {
+  kind: 'legacy-unknown';
+  coverageVerdict: 'inconclusive';
+  reason: string;
+}
+
+export interface VerifiedVerificationCoverage extends VerificationReachResult {
+  kind: 'verified';
+}
+
+export type QualityGateVerificationCoverage =
+  | LegacyUnknownVerificationCoverage
+  | VerifiedVerificationCoverage;
+
+export interface ReachAwareQualityGateResult extends QualityVerdictResult {
+  /** Threshold/oracle/judge verdict before verification-reach preflight. */
+  qualityVerdict: QualityVerdictResult['verdict'];
+  /** Independent verdict for required failure-mode observation coverage. */
+  coverageVerdict: VerificationCoverageVerdict;
+  /** Overall fail-closed verdict. A pass requires both independent gates to pass. */
+  verdict: QualityVerdictResult['verdict'];
+  verification: QualityGateVerificationCoverage;
 }
 
 /**
  * Run the two-gate quality gate for one artifact against one pinned checklist.
  * Throws only for caller error (unknown checklist id, unloadable/drifted anchor);
- * every judgement outcome is returned as a three-valued `QualityVerdictResult`.
+ * every judgement outcome is returned as a three-valued reach-aware result.
  */
-export async function runQualityGate(req: QualityGateRequest): Promise<QualityVerdictResult> {
+export async function runQualityGate(req: QualityGateRequest): Promise<ReachAwareQualityGateResult> {
   const checklist = loadChecklist(req.checklistId, req.anchorPath);
-  return computeQualityVerdict({
+  if (
+    req.verificationManifest
+    && req.verificationManifest.artifact.digest !== computeVerificationArtifactDigest(req.artifact)
+  ) {
+    throw new Error('Verification reach manifest artifact digest does not match the judged artifact');
+  }
+  const verification: QualityGateVerificationCoverage = req.verificationManifest
+    ? { kind: 'verified', ...evaluateVerificationReach(req.verificationManifest) }
+    : {
+        kind: 'legacy-unknown',
+        coverageVerdict: 'inconclusive',
+        reason: 'legacy quality-gate request has no verification reach manifest',
+      };
+  const coverageVerdict = verification.coverageVerdict;
+  const quality = await computeQualityVerdict({
     oracle: req.oracleResult,
     artifact: req.artifact,
     checklist,
     judge: req.judge,
   });
+
+  return {
+    ...quality,
+    qualityVerdict: quality.verdict,
+    coverageVerdict,
+    verdict: combineVerdicts(quality.verdict, coverageVerdict),
+    verification,
+  };
+}
+
+function combineVerdicts(
+  quality: QualityVerdictResult['verdict'],
+  coverage: VerificationCoverageVerdict,
+): QualityVerdictResult['verdict'] {
+  if (quality === 'fail' || coverage === 'fail') return 'fail';
+  if (quality === 'pass' && coverage === 'pass') return 'pass';
+  return 'inconclusive';
 }
 
 /**

--- a/src/validation/verification-reach.ts
+++ b/src/validation/verification-reach.ts
@@ -1,0 +1,305 @@
+/**
+ * Failure-mode verification reach contracts (#651).
+ *
+ * Quality evidence is useful only within the boundary it actually observed.
+ * This module keeps that boundary revision-bound and fail-closed: direct,
+ * executed, fresh evidence with the required oracle can cover a risk; partial,
+ * inferred, stale, unavailable, and wrong-target evidence remains visible but
+ * cannot silently produce a passing coverage verdict.
+ */
+
+import { createHash } from 'node:crypto';
+
+export type FailureModeSeverity = 'critical' | 'high' | 'medium' | 'low';
+export type VerificationChannel =
+  | 'static'
+  | 'build'
+  | 'runtime'
+  | 'api'
+  | 'browser'
+  | 'telemetry'
+  | 'hardware'
+  | 'human';
+export type VerificationReachLevel = 'direct' | 'partial' | 'none';
+export type VerificationEvidenceClass = 'EXECUTED' | 'STATIC' | 'INFERRED' | 'UNKNOWN';
+export type VerificationExecutionStatus = 'passed' | 'failed' | 'not-run' | 'unavailable';
+export type UncoveredDisposition = 'fail' | 'inconclusive' | 'human-review';
+export type VerificationCoverageVerdict = 'pass' | UncoveredDisposition;
+
+export interface VerificationTarget {
+  revision: string;
+  digest: string;
+  environment: string;
+}
+
+export interface VerificationCost {
+  tokens?: number;
+  durationMs?: number;
+  monetary?: number;
+}
+
+export interface VerificationReach {
+  checkId: string;
+  channel: VerificationChannel;
+  reach: VerificationReachLevel;
+  evidenceClass: VerificationEvidenceClass;
+  executionStatus: VerificationExecutionStatus;
+  target: VerificationTarget;
+  oracleRef?: string;
+  observedAt?: string;
+  limitations: string[];
+  cost?: VerificationCost;
+}
+
+export interface FailureModeRequirement {
+  riskId: string;
+  failureMode: string;
+  severity: FailureModeSeverity;
+  requiredOracle: string;
+  requiredObservations: VerificationChannel[];
+  checks: VerificationReach[];
+  dispositionWhenUncovered: UncoveredDisposition;
+}
+
+export interface VerificationReachManifest {
+  id: string;
+  systemUnderTest: string;
+  artifact: VerificationTarget;
+  risks: FailureModeRequirement[];
+  generatedAt: string;
+  expiresAt?: string;
+  manifestHash: string;
+}
+
+export type VerificationReachManifestInput = Omit<VerificationReachManifest, 'manifestHash'>;
+
+export interface FailureModeReachResult {
+  riskId: string;
+  failureMode: string;
+  severity: FailureModeSeverity;
+  verdict: VerificationCoverageVerdict;
+  directCheckIds: string[];
+  partialCheckIds: string[];
+  failedCheckIds: string[];
+  uncoveredObservations: VerificationChannel[];
+  limitations: string[];
+  reason: string;
+}
+
+export interface VerificationReachResult {
+  manifestId: string;
+  manifestHash: string;
+  systemUnderTest: string;
+  artifact: VerificationTarget;
+  coverageVerdict: VerificationCoverageVerdict;
+  risks: FailureModeReachResult[];
+  evaluatedAt: string;
+}
+
+export interface VerificationReachEvaluationOptions {
+  now?: Date;
+}
+
+/** Create a manifest whose hash binds its target, risks, checks, and lifetime. */
+export function createVerificationReachManifest(
+  input: VerificationReachManifestInput,
+): VerificationReachManifest {
+  validateManifestShape(input);
+  const manifest = structuredClone(input) as VerificationReachManifestInput;
+  return {
+    ...manifest,
+    manifestHash: computeVerificationReachManifestHash(manifest),
+  };
+}
+
+/** Compute the canonical SHA-256 identity for all manifest content except the hash itself. */
+export function computeVerificationReachManifestHash(
+  manifest: VerificationReachManifest | VerificationReachManifestInput,
+): string {
+  const { manifestHash: _ignored, ...content } = manifest as VerificationReachManifest;
+  return `sha256:${createHash('sha256').update(canonicalJson(content)).digest('hex')}`;
+}
+
+/** Bind a reach manifest to the exact artifact bytes submitted to the gate. */
+export function computeVerificationArtifactDigest(artifact: string): string {
+  return `sha256:${createHash('sha256').update(artifact).digest('hex')}`;
+}
+
+/** Evaluate whether the declared evidence can directly observe every required failure mode. */
+export function evaluateVerificationReach(
+  manifest: VerificationReachManifest,
+  options: VerificationReachEvaluationOptions = {},
+): VerificationReachResult {
+  validateManifestShape(manifest);
+  const expectedHash = computeVerificationReachManifestHash(manifest);
+  if (manifest.manifestHash !== expectedHash) {
+    throw new Error(`Verification reach manifestHash mismatch: expected ${expectedHash}`);
+  }
+
+  const now = options.now ?? new Date();
+  const evaluatedAt = now.toISOString();
+  const manifestExpired = manifest.expiresAt != null
+    && now.getTime() > parseTimestamp(manifest.expiresAt, 'expiresAt');
+
+  const risks = manifest.risks.map((requirement) => evaluateRisk(
+    requirement,
+    manifest,
+    manifestExpired,
+    now.getTime(),
+  ));
+
+  return {
+    manifestId: manifest.id,
+    manifestHash: manifest.manifestHash,
+    systemUnderTest: manifest.systemUnderTest,
+    artifact: structuredClone(manifest.artifact),
+    coverageVerdict: aggregateVerdicts(risks.map((risk) => risk.verdict)),
+    risks,
+    evaluatedAt,
+  };
+}
+
+function evaluateRisk(
+  requirement: FailureModeRequirement,
+  manifest: VerificationReachManifest,
+  manifestExpired: boolean,
+  evaluatedAt: number,
+): FailureModeReachResult {
+  const direct = new Set<string>();
+  const partial = new Set<string>();
+  const failed = new Set<string>();
+  const covered = new Set<VerificationChannel>();
+  const limitations = new Set<string>();
+
+  for (const check of requirement.checks) {
+    for (const limitation of check.limitations) limitations.add(limitation);
+    if (!isUsableObservation(check, manifest, manifestExpired, evaluatedAt)) continue;
+
+    if (check.reach === 'partial') {
+      partial.add(check.checkId);
+      continue;
+    }
+    if (check.reach !== 'direct') continue;
+    if (!requirement.requiredObservations.includes(check.channel)) continue;
+    if (check.oracleRef !== requirement.requiredOracle) continue;
+
+    if (check.executionStatus === 'failed') {
+      failed.add(check.checkId);
+      continue;
+    }
+    if (check.executionStatus === 'passed') {
+      direct.add(check.checkId);
+      covered.add(check.channel);
+    }
+  }
+
+  const uncoveredObservations = requirement.requiredObservations.filter(
+    (channel) => !covered.has(channel),
+  );
+  const verdict: VerificationCoverageVerdict = failed.size > 0
+    ? 'fail'
+    : uncoveredObservations.length === 0
+      ? 'pass'
+      : requirement.dispositionWhenUncovered;
+
+  return {
+    riskId: requirement.riskId,
+    failureMode: requirement.failureMode,
+    severity: requirement.severity,
+    verdict,
+    directCheckIds: [...direct],
+    partialCheckIds: [...partial],
+    failedCheckIds: [...failed],
+    uncoveredObservations,
+    limitations: [...limitations],
+    reason: buildRiskReason(verdict, failed, uncoveredObservations, manifestExpired),
+  };
+}
+
+function isUsableObservation(
+  check: VerificationReach,
+  manifest: VerificationReachManifest,
+  manifestExpired: boolean,
+  evaluatedAt: number,
+): boolean {
+  if (manifestExpired) return false;
+  if (!sameTarget(check.target, manifest.artifact)) return false;
+  if (check.evidenceClass !== 'EXECUTED') return false;
+  if (check.executionStatus === 'not-run' || check.executionStatus === 'unavailable') return false;
+  if (!check.observedAt) return false;
+
+  const observedAt = parseTimestamp(check.observedAt, `check ${check.checkId} observedAt`);
+  const generatedAt = parseTimestamp(manifest.generatedAt, 'generatedAt');
+  if (observedAt < generatedAt) return false;
+  if (observedAt > evaluatedAt) return false;
+  if (manifest.expiresAt && observedAt > parseTimestamp(manifest.expiresAt, 'expiresAt')) return false;
+  return true;
+}
+
+function sameTarget(actual: VerificationTarget, expected: VerificationTarget): boolean {
+  return actual.revision === expected.revision
+    && actual.digest === expected.digest
+    && actual.environment === expected.environment;
+}
+
+function aggregateVerdicts(verdicts: VerificationCoverageVerdict[]): VerificationCoverageVerdict {
+  if (verdicts.some((verdict) => verdict === 'fail')) return 'fail';
+  if (verdicts.some((verdict) => verdict === 'human-review')) return 'human-review';
+  if (verdicts.some((verdict) => verdict === 'inconclusive')) return 'inconclusive';
+  return 'pass';
+}
+
+function buildRiskReason(
+  verdict: VerificationCoverageVerdict,
+  failed: Set<string>,
+  uncovered: VerificationChannel[],
+  manifestExpired: boolean,
+): string {
+  if (manifestExpired) return `verification manifest expired; uncovered: ${uncovered.join(', ')}`;
+  if (failed.size > 0) return `direct check failed: ${[...failed].join(', ')}`;
+  if (verdict === 'pass') return 'all required observation channels have direct executed reach';
+  return `required reach is uncovered (${uncovered.join(', ')}); disposition: ${verdict}`;
+}
+
+function validateManifestShape(manifest: VerificationReachManifestInput | VerificationReachManifest): void {
+  if (!manifest.id || !manifest.systemUnderTest) {
+    throw new Error('Verification reach manifest requires id and systemUnderTest');
+  }
+  if (!manifest.artifact.revision || !manifest.artifact.digest || !manifest.artifact.environment) {
+    throw new Error('Verification reach manifest artifact requires revision, digest, and environment');
+  }
+  parseTimestamp(manifest.generatedAt, 'generatedAt');
+  if (manifest.expiresAt) parseTimestamp(manifest.expiresAt, 'expiresAt');
+  if (manifest.risks.length === 0) {
+    throw new Error('Verification reach manifest requires at least one failure mode');
+  }
+
+  const riskIds = new Set<string>();
+  for (const risk of manifest.risks) {
+    if (riskIds.has(risk.riskId)) throw new Error(`Duplicate riskId: ${risk.riskId}`);
+    riskIds.add(risk.riskId);
+    if (!risk.riskId || !risk.failureMode || !risk.requiredOracle) {
+      throw new Error('Each failure mode requires riskId, failureMode, and requiredOracle');
+    }
+    if (risk.requiredObservations.length === 0) {
+      throw new Error(`Failure mode ${risk.riskId} requires at least one observation channel`);
+    }
+  }
+}
+
+function parseTimestamp(value: string, field: string): number {
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) throw new Error(`Invalid ${field} timestamp: ${value}`);
+  return timestamp;
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, entry]) => entry !== undefined)
+      .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0);
+    return `{${entries.map(([key, entry]) => `${JSON.stringify(key)}:${canonicalJson(entry)}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}

--- a/tests/unit/cli/commands/quality-gate.test.ts
+++ b/tests/unit/cli/commands/quality-gate.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import type { CLIContext } from '../../../../src/cli/handlers/interfaces.js';
+import {
+  computeVerificationArtifactDigest,
+  createVerificationReachManifest,
+} from '../../../../src/validation/verification-reach.js';
 
 const chat = vi.fn();
 
@@ -13,6 +19,7 @@ import { createQualityGateCommand } from '../../../../src/cli/commands/quality-g
 describe('quality-gate CLI diagnostics', () => {
   let stdout: string[];
   let stderr: string[];
+  const temporaryDirectories: string[] = [];
 
   beforeEach(() => {
     stdout = [];
@@ -24,6 +31,73 @@ describe('quality-gate CLI diagnostics', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    for (const directory of temporaryDirectories.splice(0)) {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('should_acceptRevisionBoundReachManifest_throughSharedCliPath', async () => {
+    chat
+      .mockResolvedValueOnce({ content: 'OK' })
+      .mockRejectedValueOnce(new Error('provider unavailable'))
+      .mockRejectedValueOnce(new Error('provider unavailable'));
+    const directory = mkdtempSync(path.join(tmpdir(), 'aqe-reach-'));
+    temporaryDirectories.push(directory);
+    const manifestPath = path.join(directory, 'manifest.json');
+    writeFileSync(manifestPath, JSON.stringify(createVerificationReachManifest({
+      id: 'cli-reach-v1',
+      systemUnderTest: 'cli-artifact',
+      artifact: {
+        revision: 'abc123',
+        digest: computeVerificationArtifactDigest('test artifact'),
+        environment: 'test',
+      },
+      generatedAt: '2026-09-06T09:00:00.000Z',
+      risks: [{
+        riskId: 'non-execution',
+        failureMode: 'artifact was not executed',
+        severity: 'critical',
+        requiredOracle: 'process-exit',
+        requiredObservations: ['runtime'],
+        dispositionWhenUncovered: 'fail',
+        checks: [{
+          checkId: 'cli-smoke',
+          channel: 'runtime',
+          reach: 'direct',
+          evidenceClass: 'EXECUTED',
+          executionStatus: 'passed',
+          target: {
+            revision: 'abc123',
+            digest: computeVerificationArtifactDigest('test artifact'),
+            environment: 'test',
+          },
+          oracleRef: 'process-exit',
+          observedAt: '2026-09-06T10:00:00.000Z',
+          limitations: [],
+        }],
+      }],
+    })));
+    const cleanupAndExit = vi.fn(async () => undefined) as unknown as (
+      code: number,
+    ) => Promise<never>;
+    const command = createQualityGateCommand(
+      {} as CLIContext,
+      cleanupAndExit,
+      vi.fn(async () => true),
+    );
+
+    await command.parseAsync([
+      '--checklist', 'A1-inRange',
+      '--artifact', 'test artifact',
+      '--oracle-passed',
+      '--baseline-passed',
+      '--anchor', path.resolve('verification/anchors/qe-anchor-v1.json'),
+      '--verification-manifest', manifestPath,
+    ], { from: 'user' });
+
+    expect(stdout.join('\n')).toContain('Coverage verdict: pass');
+    expect(stdout.join('\n')).toContain('non-execution: pass');
+    expect(stdout.join('\n')).toContain('direct=cli-smoke; partial=none; uncovered=none');
   });
 
   it('should_keepStdoutParseable_when_judgeFailureIsLoggedToStderr', async () => {
@@ -53,7 +127,12 @@ describe('quality-gate CLI diagnostics', () => {
 
     // Assert
     expect(stdout, stderr.join('\n')).not.toHaveLength(0);
-    expect(() => JSON.parse(stdout.join('\n'))).not.toThrow();
+    const parsed = JSON.parse(stdout.join('\n'));
+    expect(parsed).toMatchObject({
+      verdict: 'inconclusive',
+      coverageVerdict: 'inconclusive',
+      verification: { kind: 'legacy-unknown' },
+    });
     expect(stderr.join('\n')).toContain('provider spawn failed');
     expect(cleanupAndExit).toHaveBeenCalledWith(3);
   });

--- a/tests/unit/mcp/tools/quality-gate.test.ts
+++ b/tests/unit/mcp/tools/quality-gate.test.ts
@@ -2,8 +2,67 @@ import { describe, expect, it, vi } from 'vitest';
 import path from 'node:path';
 import { QualityGateTool } from '../../../../src/mcp/tools/quality-assessment/gate.js';
 import type { MCPToolContext, ToolLogger } from '../../../../src/mcp/tools/base.js';
+import {
+  computeVerificationArtifactDigest,
+  createVerificationReachManifest,
+} from '../../../../src/validation/verification-reach.js';
 
 describe('QualityGateTool diagnostics', () => {
+  it('should_acceptRevisionBoundReachManifest_throughSharedMcpPath', async () => {
+    const tool = new QualityGateTool();
+    tool.setLogger({ info: vi.fn(), warn: vi.fn(), error: vi.fn() });
+    const result = await tool.execute({
+      checklistId: 'A1-inRange',
+      artifact: 'test artifact',
+      oracle: { passed: true, baselinePassed: true },
+      anchorPath: path.resolve('verification/anchors/qe-anchor-v1.json'),
+      verificationManifest: createVerificationReachManifest({
+        id: 'mcp-reach-v1',
+        systemUnderTest: 'mcp-artifact',
+        artifact: {
+          revision: 'abc123',
+          digest: computeVerificationArtifactDigest('test artifact'),
+          environment: 'test',
+        },
+        generatedAt: '2026-09-06T09:00:00.000Z',
+        risks: [{
+          riskId: 'non-execution',
+          failureMode: 'artifact was not executed',
+          severity: 'critical',
+          requiredOracle: 'process-exit',
+          requiredObservations: ['runtime'],
+          dispositionWhenUncovered: 'fail',
+          checks: [{
+            checkId: 'mcp-smoke',
+            channel: 'runtime',
+            reach: 'direct',
+            evidenceClass: 'EXECUTED',
+            executionStatus: 'passed',
+            target: {
+              revision: 'abc123',
+              digest: computeVerificationArtifactDigest('test artifact'),
+              environment: 'test',
+            },
+            oracleRef: 'process-exit',
+            observedAt: '2026-09-06T10:00:00.000Z',
+            limitations: [],
+          }],
+        }],
+      }),
+    }, {
+      requestId: 'request-reach',
+      llmRouter: { chat: vi.fn().mockRejectedValue(new Error('offline test judge')) },
+    } as unknown as MCPToolContext);
+
+    expect(result).toMatchObject({
+      success: true,
+      data: {
+        coverageVerdict: 'pass',
+        verification: { kind: 'verified', manifestId: 'mcp-reach-v1' },
+      },
+    });
+  });
+
   it('should_routeJudgeFailureToToolLogger_when_providerFails', async () => {
     // Arrange: preflight succeeds, then both grade attempts fail.
     const chat = vi.fn()
@@ -32,6 +91,13 @@ describe('QualityGateTool diagnostics', () => {
 
     // Assert
     expect(result, result.success ? undefined : result.error).toMatchObject({ success: true });
+    expect(result).toMatchObject({
+      data: {
+        verdict: 'inconclusive',
+        coverageVerdict: 'inconclusive',
+        verification: { kind: 'legacy-unknown' },
+      },
+    });
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('provider timeout'),
       { requestId: 'request-621' },

--- a/tests/unit/validation/quality-gate-runner.test.ts
+++ b/tests/unit/validation/quality-gate-runner.test.ts
@@ -7,7 +7,7 @@
  * the real committed `verification/anchors/qe-anchor-v1.json`.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import path from 'node:path';
 import {
   runQualityGate,
@@ -15,6 +15,10 @@ import {
   listChecklistIds,
 } from '../../../src/validation/quality-gate-runner.js';
 import type { Judge, JudgeOpinion } from '../../../src/validation/quality-verdict.js';
+import {
+  computeVerificationArtifactDigest,
+  createVerificationReachManifest,
+} from '../../../src/validation/verification-reach.js';
 
 const ANCHOR = path.resolve(__dirname, '../../../verification/anchors/qe-anchor-v1.json');
 
@@ -28,6 +32,39 @@ function fakeJudge(opinions: JudgeOpinion[], ready = true): Judge {
 }
 
 const passingOracle = { passed: true, baselinePassed: true };
+const passingVerificationManifest = () => createVerificationReachManifest({
+  id: 'test-reach-v1',
+  systemUnderTest: 'test-artifact',
+  artifact: {
+    revision: 'test-revision',
+    digest: computeVerificationArtifactDigest('test source'),
+    environment: 'vitest',
+  },
+  generatedAt: '2026-09-06T09:00:00.000Z',
+  risks: [{
+    riskId: 'test-does-not-execute',
+    failureMode: 'test does not execute against the target',
+    severity: 'critical',
+    requiredOracle: 'mutation-oracle',
+    requiredObservations: ['runtime'],
+    dispositionWhenUncovered: 'fail',
+    checks: [{
+      checkId: 'adr-113-oracle',
+      channel: 'runtime',
+      reach: 'direct',
+      evidenceClass: 'EXECUTED',
+      executionStatus: 'passed',
+      target: {
+        revision: 'test-revision',
+        digest: computeVerificationArtifactDigest('test source'),
+        environment: 'vitest',
+      },
+      oracleRef: 'mutation-oracle',
+      observedAt: '2026-09-06T10:00:00.000Z',
+      limitations: [],
+    }],
+  }],
+});
 
 describe('runQualityGate', () => {
   it('should_returnPass_when_oraclePassesAndJudgeFullCoverage', async () => {
@@ -41,12 +78,50 @@ describe('runQualityGate', () => {
       checklistId: 'A1-inRange',
       judge,
       anchorPath: ANCHOR,
+      verificationManifest: passingVerificationManifest(),
     });
 
     // Assert
     expect(result.verdict).toBe('pass');
+    expect(result.qualityVerdict).toBe('pass');
+    expect(result.coverageVerdict).toBe('pass');
     expect(result.mechanical).toBe('pass');
     expect(result.specCoverage).toBe(1.0);
+  });
+
+  it('should_returnLegacyUnknownCoverage_when_manifestIsMissing', async () => {
+    const judge = fakeJudge([{ ran: true, coverage: 1.0, unmet: [] }]);
+
+    const result = await runQualityGate({
+      oracleResult: passingOracle,
+      artifact: 'test source',
+      checklistId: 'A1-inRange',
+      judge,
+      anchorPath: ANCHOR,
+    });
+
+    expect(result.qualityVerdict).toBe('pass');
+    expect(result.coverageVerdict).toBe('inconclusive');
+    expect(result.verdict).toBe('inconclusive');
+    expect(result.verification).toMatchObject({ kind: 'legacy-unknown' });
+  });
+
+  it('should_rejectReachManifest_when_artifactBytesDoNotMatch', async () => {
+    const judge: Judge = {
+      preflight: vi.fn(() => true),
+      grade: vi.fn(() => ({ ran: true, coverage: 1.0, unmet: [] })),
+    };
+
+    await expect(runQualityGate({
+      oracleResult: passingOracle,
+      artifact: 'different artifact bytes',
+      checklistId: 'A1-inRange',
+      judge,
+      anchorPath: ANCHOR,
+      verificationManifest: passingVerificationManifest(),
+    })).rejects.toThrow(/artifact digest does not match/);
+    expect(judge.preflight).not.toHaveBeenCalled();
+    expect(judge.grade).not.toHaveBeenCalled();
   });
 
   it('should_returnFail_when_oracleDidNotRun', async () => {

--- a/tests/unit/validation/verification-reach.test.ts
+++ b/tests/unit/validation/verification-reach.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createVerificationReachManifest,
+  evaluateVerificationReach,
+  type FailureModeRequirement,
+  type VerificationReach,
+} from '../../../src/validation/verification-reach.js';
+
+const target = {
+  revision: 'abc123',
+  digest: 'sha256:artifact',
+  environment: 'ci-linux-x64',
+};
+
+function check(overrides: Partial<VerificationReach> = {}): VerificationReach {
+  return {
+    checkId: 'boot-probe',
+    channel: 'runtime',
+    reach: 'direct',
+    evidenceClass: 'EXECUTED',
+    executionStatus: 'passed',
+    target,
+    oracleRef: 'process-exit-and-health-response',
+    observedAt: '2026-09-06T10:00:00.000Z',
+    limitations: ['does not exercise concurrent requests'],
+    ...overrides,
+  };
+}
+
+function risk(overrides: Partial<FailureModeRequirement> = {}): FailureModeRequirement {
+  return {
+    riskId: 'service-does-not-start',
+    failureMode: 'service does not start',
+    severity: 'critical',
+    requiredOracle: 'process-exit-and-health-response',
+    requiredObservations: ['runtime'],
+    checks: [check()],
+    dispositionWhenUncovered: 'fail',
+    ...overrides,
+  };
+}
+
+function evaluate(risks: FailureModeRequirement[]) {
+  const manifest = createVerificationReachManifest({
+    id: 'release-gate-v1',
+    systemUnderTest: 'agentic-qe',
+    artifact: target,
+    risks,
+    generatedAt: '2026-09-06T09:00:00.000Z',
+    expiresAt: '2026-09-07T09:00:00.000Z',
+  });
+  return evaluateVerificationReach(manifest, { now: new Date('2026-09-06T11:00:00.000Z') });
+}
+
+describe('verification reach', () => {
+  it('passes a risk only when direct executed evidence covers its channel and oracle', () => {
+    const result = evaluate([risk()]);
+
+    expect(result.coverageVerdict).toBe('pass');
+    expect(result.risks[0]).toMatchObject({
+      riskId: 'service-does-not-start',
+      verdict: 'pass',
+      directCheckIds: ['boot-probe'],
+    });
+  });
+
+  it('keeps concurrency inconclusive when a boot probe has only partial reach', () => {
+    const result = evaluate([risk({
+      riskId: 'concurrent-write-loss',
+      failureMode: 'concurrent writes are lost',
+      requiredOracle: 'linearizability-oracle',
+      checks: [check({ reach: 'partial' })],
+      dispositionWhenUncovered: 'inconclusive',
+    })]);
+
+    expect(result.coverageVerdict).toBe('inconclusive');
+    expect(result.risks[0]).toMatchObject({
+      verdict: 'inconclusive',
+      partialCheckIds: ['boot-probe'],
+      directCheckIds: [],
+    });
+  });
+
+  it('does not let screenshot evidence satisfy an API performance risk', () => {
+    const result = evaluate([risk({
+      riskId: 'scroll-budget',
+      requiredOracle: 'p95-frame-budget',
+      requiredObservations: ['browser', 'telemetry'],
+      checks: [check({
+        checkId: 'screenshot',
+        channel: 'browser',
+        oracleRef: 'visual-overlap-oracle',
+      })],
+      dispositionWhenUncovered: 'human-review',
+    })]);
+
+    expect(result.coverageVerdict).toBe('human-review');
+    expect(result.risks[0].uncoveredObservations).toEqual(['browser', 'telemetry']);
+  });
+
+  it.each([
+    ['wrong revision', check({ target: { ...target, revision: 'other' } })],
+    ['stale evidence', check({ observedAt: '2026-09-05T08:00:00.000Z' })],
+    ['future evidence', check({ observedAt: '2026-09-07T08:00:00.000Z' })],
+    ['static evidence', check({ channel: 'static', evidenceClass: 'STATIC' })],
+    ['non-executed evidence', check({ executionStatus: 'not-run' })],
+  ])('refuses %s rather than reporting green', (_name, evidence) => {
+    const result = evaluate([risk({ checks: [evidence] })]);
+
+    expect(result.coverageVerdict).toBe('fail');
+    expect(result.risks[0].verdict).toBe('fail');
+    expect(result.risks[0].directCheckIds).toEqual([]);
+  });
+
+  it('reports an applicable executed check failure as a failed risk', () => {
+    const result = evaluate([risk({ checks: [check({ executionStatus: 'failed' })] })]);
+
+    expect(result.coverageVerdict).toBe('fail');
+    expect(result.risks[0].failedCheckIds).toEqual(['boot-probe']);
+  });
+
+  it('refuses otherwise-valid evidence after the manifest expires', () => {
+    const manifest = createVerificationReachManifest({
+      id: 'expired-reach-v1',
+      systemUnderTest: 'agentic-qe',
+      artifact: target,
+      risks: [risk()],
+      generatedAt: '2026-09-06T09:00:00.000Z',
+      expiresAt: '2026-09-06T10:30:00.000Z',
+    });
+
+    const result = evaluateVerificationReach(manifest, {
+      now: new Date('2026-09-06T11:00:00.000Z'),
+    });
+
+    expect(result.coverageVerdict).toBe('fail');
+    expect(result.risks[0].reason).toContain('expired');
+  });
+
+  it('rejects a manifest whose revision-bound content changed after hashing', () => {
+    const manifest = createVerificationReachManifest({
+      id: 'release-gate-v1',
+      systemUnderTest: 'agentic-qe',
+      artifact: target,
+      risks: [risk()],
+      generatedAt: '2026-09-06T09:00:00.000Z',
+    });
+    manifest.artifact.revision = 'tampered';
+
+    expect(() => evaluateVerificationReach(manifest)).toThrow(/manifestHash/);
+  });
+});


### PR DESCRIPTION
## Summary

AQE's shared CLI/MCP quality gate could return a pass without recording whether its evidence could observe the failure modes being cleared. This implements the P0 verification-reach slice of #651: a canonical, revision-bound manifest; fail-closed reach preflight; separate quality and coverage verdicts; and complete direct/partial/uncovered evidence in JSON and text output.

Only fresh, exact-target, executed, direct evidence with the required observation channel and oracle can cover a risk. The manifest digest must also match the exact artifact bytes submitted to the gate. Existing callers have an explicit migration state: requests without a manifest return `verification.kind: "legacy-unknown"`, an inconclusive coverage verdict, and cannot produce an overall pass.

The same `verificationManifest` contract is exposed through `aqe quality-gate --verification-manifest` and `qe/quality/gate`, and the construction/evaluation helpers are exported from the package root. A migration and authoring guide is included.

This is part of #651 and does not close it. Minimum-cost portfolio planning, seeded calibration, and migration of the older domain/protocol aggregate-metric gates remain tracked there.

## Verification

- `npx vitest run tests/unit/validation/verification-reach.test.ts tests/unit/validation/quality-gate-runner.test.ts tests/unit/cli/commands/quality-gate.test.ts tests/unit/mcp/tools/quality-gate.test.ts` — 4 files, 24 tests passed.
- `npm run test:unit:fast` — 359 files passed, 1 skipped; 8,590 tests passed, 6 skipped.
- `npm run typecheck` — passed.
- `npm run build` — passed.
- Targeted ESLint over all changed TypeScript source files — zero errors and warnings.
- Package-root ESM import smoke test — all three public construction/evaluation functions resolved.
- `git diff --check` — passed.

## Failure modes

- Wrong-revision, wrong-byte-digest, stale, expired, future-dated, non-executed, static-only, and inferred evidence are covered by negative tests and cannot produce a reach pass.
- Boot-only and partial checks cannot clear concurrency risks; screenshot-only checks cannot clear telemetry/performance risks. Both boundaries are covered by reach tests.
- A manifest changed after hashing is rejected by a tamper test.
- An applicable direct check that executed and failed produces a failed coverage verdict, covered by a focused test.
- A missing legacy manifest remains explicit and inconclusive, covered at the runner, CLI, and MCP paths.
- CLI/MCP drift is covered by exercising the same manifest through both public paths and asserting the same verified coverage result.
- P1 planning/calibration and older aggregate-metric migration are outside this slice and remain tracked by #651.

---

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.** "Unlikely" is not an acceptable substitute. If you wrote "I don't think this can happen but...", that sentence is a failure mode and needs a test or an issue link.

### Optional context

- Linked issues: #651, #635, #649
- Trust tier change (if any): none
- Affects published API or CLI surface: yes; additive manifest input and fail-closed legacy verdict
- Touches the init flow / `npm-publish.yml` / `tests/fixtures/init-corpus/`: no
