### PR TITLE
feat(verification): default early exit to shadow mode

### DIFF
--- a/docs/implementation/adrs/ADR-033-early-exit-testing.md
+++ b/docs/implementation/adrs/ADR-033-early-exit-testing.md
@@ -3,7 +3,7 @@
 | Field | Value |
 |-------|-------|
 | **Decision ID** | ADR-033 |
-| **Status** | Accepted |
+| **Status** | Amended — shadow calibration required |
 | **Date** | 2026-01-10 |
 | **Author** | Architecture Team |
 | **Review Cadence** | 6 months |
@@ -90,6 +90,7 @@ Train a classifier to predict when to exit based on historical test data.
 | Review Board | Date | Outcome | Next Review |
 |--------------|------|---------|-------------|
 | Architecture Team | 2026-01-10 | Accepted | 2026-07-10 |
+| Architecture review | 2026-09-06 | Defaulted candidate exits to full-run shadow calibration; enforced stopping requires explicit configuration pending qualification in #657 | 2027-03-06 |
 
 ---
 
@@ -99,3 +100,4 @@ Train a classifier to predict when to exit based on historical test data.
 |--------|------|-------|
 | Proposed | 2026-01-10 | Initial creation from RuVector analysis |
 | Accepted | 2026-01-10 | Approved by Architecture Team |
+| Amended | 2026-09-06 | Full-run results remain authoritative while revision-bound calibration evidence is collected |

--- a/src/early-exit/early-exit-controller.ts
+++ b/src/early-exit/early-exit-controller.ts
@@ -15,8 +15,11 @@ import {
   SpeculativeResult,
   QualitySignal,
   EarlyExitMetrics,
+  ShadowCalibrationContext,
+  ShadowCalibrationResult,
   DEFAULT_EXIT_CONFIG,
 } from './types';
+import { createHash } from 'node:crypto';
 import { calculateQualitySignal } from './quality-signal';
 import { CoherenceEarlyExit } from './early-exit-decision';
 import { SpeculativeExecutor } from './speculative-executor';
@@ -40,8 +43,17 @@ export interface EarlyExitEvents {
   onLayerComplete?: (layer: TestLayer, result: LayerResult, signal: QualitySignal) => void;
   onDecision?: (decision: EarlyExitDecision, layer: number) => void;
   onEarlyExit?: (exitLayer: number, decision: EarlyExitDecision) => void;
+  onCandidateExit?: (exitLayer: number, decision: EarlyExitDecision) => void;
   onSpeculationComplete?: (speculations: SpeculativeResult[]) => void;
   onComplete?: (result: TestPyramidResult) => void;
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === 'object' && !Object.isFrozen(value)) {
+    Object.freeze(value);
+    for (const child of Object.values(value as Record<string, unknown>)) deepFreeze(child);
+  }
+  return value;
 }
 
 // ============================================================================
@@ -123,12 +135,20 @@ export class EarlyExitController {
    */
   async runWithEarlyExit(
     layers: TestLayer[],
-    executor: LayerExecutor
+    executor: LayerExecutor,
+    calibrationContext?: ShadowCalibrationContext,
   ): Promise<TestPyramidResult> {
     const startTime = Date.now();
     const results: LayerResult[] = [];
     let exitDecision: EarlyExitDecision | null = null;
     let previousSignal: QualitySignal | undefined;
+    let shadowCandidate: {
+      layer: number;
+      decision: EarlyExitDecision;
+      speculations: SpeculativeResult[];
+      estimatedSavings: number;
+      signal: QualitySignal;
+    } | null = null;
 
     // Execute layers until early exit or completion
     for (let i = 0; i < layers.length; i++) {
@@ -156,6 +176,10 @@ export class EarlyExitController {
       // Emit layer complete event
       this.events.onLayerComplete?.(layer, layerResult, signal);
 
+      // The first candidate is the pre-registered counterfactual. The full run
+      // remains authoritative and later signals cannot rewrite that decision.
+      if (shadowCandidate) continue;
+
       // Check for early exit
       exitDecision = this.earlyExit.shouldExit(signal, i);
 
@@ -167,9 +191,6 @@ export class EarlyExitController {
       }
 
       if (exitDecision.canExit) {
-        // Emit early exit event
-        this.events.onEarlyExit?.(i, exitDecision);
-
         // Generate speculative predictions for remaining layers
         const skippedLayers = layers.slice(i + 1);
         let speculations: SpeculativeResult[] = [];
@@ -178,8 +199,9 @@ export class EarlyExitController {
           const batch = await this.speculator.speculate(exitDecision, skippedLayers);
           speculations = batch.predictions;
 
-          // Optionally verify some speculations
-          if (this.config.verificationLayers > 0) {
+          // Enforced mode may sample verification layers. Shadow mode executes
+          // every remaining layer exactly once below.
+          if (this.config.mode === 'enforced' && this.config.verificationLayers > 0) {
             speculations = await this.speculator.verify(
               speculations,
               skippedLayers,
@@ -191,8 +213,20 @@ export class EarlyExitController {
           this.events.onSpeculationComplete?.(speculations);
         }
 
-        const totalDuration = Date.now() - startTime;
         const computeSavings = this.estimateComputeSavings(i, layers);
+        if (this.config.mode !== 'enforced') {
+          shadowCandidate = {
+            layer: i, decision: exitDecision, speculations,
+            estimatedSavings: computeSavings, signal,
+          };
+          this.events.onCandidateExit?.(i, exitDecision);
+          continue;
+        }
+
+        // Emit an actual early exit only in explicitly enforced mode.
+        this.events.onEarlyExit?.(i, exitDecision);
+
+        const totalDuration = Date.now() - startTime;
 
         const result = this.createPyramidResult(
           results,
@@ -220,17 +254,19 @@ export class EarlyExitController {
     const totalDuration = Date.now() - startTime;
     const finalSignal = previousSignal || this.createDefaultSignal();
 
-    const result = this.createPyramidResult(
-      results,
-      false,
-      layers.length - 1,
-      exitDecision || this.createDefaultDecision(layers.length - 1),
-      [],
-      0,
-      totalDuration,
-      0,
-      finalSignal
-    );
+    const result = shadowCandidate
+      ? this.createShadowResult(results, shadowCandidate, totalDuration, finalSignal, calibrationContext)
+      : this.createPyramidResult(
+        results,
+        false,
+        layers.length - 1,
+        exitDecision || this.createDefaultDecision(layers.length - 1),
+        [],
+        0,
+        totalDuration,
+        0,
+        finalSignal
+      );
 
     // Update metrics
     this.updateMetrics(result);
@@ -238,6 +274,76 @@ export class EarlyExitController {
     // Emit complete event
     this.events.onComplete?.(result);
 
+    return result;
+  }
+
+  private createShadowResult(
+    layers: LayerResult[],
+    candidate: {
+      layer: number;
+      decision: EarlyExitDecision;
+      speculations: SpeculativeResult[];
+      estimatedSavings: number;
+      signal: QualitySignal;
+    },
+    totalDuration: number,
+    finalSignal: QualitySignal,
+    context?: ShadowCalibrationContext,
+  ): TestPyramidResult {
+    const contextBound = context !== undefined && Object.values(context).every(
+      value => typeof value === 'string' && value.trim().length > 0,
+    );
+    const prefixFailed = layers.slice(0, candidate.layer + 1).some(layer => layer.failedTests > 0);
+    const speculativeOutcomes = candidate.speculations.map(result => result.predicted);
+    const predictedVerdict = prefixFailed || speculativeOutcomes.includes('fail')
+      ? 'fail'
+      : speculativeOutcomes.includes('flaky') ? 'inconclusive' : 'pass';
+    const fullRunVerdict = layers.some(layer => layer.failedTests > 0) ? 'fail' : 'pass';
+    const firstMissed = layers.slice(candidate.layer + 1).find(layer => layer.failedTests > 0);
+    const result = this.createPyramidResult(
+      layers, false, candidate.layer, candidate.decision, candidate.speculations,
+      0, totalDuration, 0, finalSignal,
+    );
+    const receiptPayload: Omit<ShadowCalibrationResult, 'receiptId'> = {
+      evidenceClass: contextBound ? 'EXECUTED' : 'INCONCLUSIVE',
+      candidateExitLayer: candidate.layer,
+      candidateSignal: {
+        lambda: candidate.signal.lambda,
+        lambdaPrev: candidate.signal.lambdaPrev,
+        boundaryConcentration: candidate.signal.boundaryConcentration,
+        flags: candidate.signal.flags,
+        timestamp: candidate.signal.timestamp.toISOString(),
+      },
+      thresholds: {
+        minLambdaForExit: this.config.minLambdaForExit,
+        minLambdaStability: this.config.minLambdaStability,
+        maxBoundaryConcentration: this.config.maxBoundaryConcentration,
+        minConfidence: this.config.minConfidence,
+      },
+      predictedLayers: candidate.speculations.map(prediction => ({
+        layerIndex: prediction.layerIndex,
+        layerType: prediction.layerType,
+        outcome: prediction.predicted,
+        confidence: prediction.confidence,
+        evidenceClass: 'PREDICTED' as const,
+      })),
+      predictedVerdict,
+      fullRunVerdict,
+      falsePass: predictedVerdict === 'pass' && fullRunVerdict === 'fail',
+      falseFail: predictedVerdict === 'fail' && fullRunVerdict === 'pass',
+      ...(firstMissed ? { firstMissedFailure: {
+        layerIndex: firstMissed.layerIndex,
+        layerType: firstMissed.layerType,
+        failedTests: firstMissed.failedTests,
+      } } : {}),
+      estimatedSavings: candidate.estimatedSavings,
+      actualSavings: 0,
+      ...(contextBound ? { context: { ...context } } : {}),
+    };
+    result.shadowCalibration = deepFreeze({
+      ...receiptPayload,
+      receiptId: createHash('sha256').update(JSON.stringify(receiptPayload)).digest('hex'),
+    });
     return result;
   }
 
@@ -378,6 +484,7 @@ export class EarlyExitController {
       speculationAccuracy: 0,
       falsePositiveRate: 0,
       falseNegativeRate: 0,
+      shadowCandidateCount: 0,
     };
   }
 
@@ -414,6 +521,17 @@ export class EarlyExitController {
     // Update speculation accuracy
     const speculatorStats = this.speculator.getAccuracyStats();
     this.executionMetrics.speculationAccuracy = speculatorStats.accuracy;
+
+    if (result.shadowCalibration) {
+      const previousCount = this.executionMetrics.shadowCandidateCount;
+      const falsePasses = this.executionMetrics.falsePositiveRate * previousCount
+        + Number(result.shadowCalibration.falsePass);
+      const falseFails = this.executionMetrics.falseNegativeRate * previousCount
+        + Number(result.shadowCalibration.falseFail);
+      this.executionMetrics.shadowCandidateCount++;
+      this.executionMetrics.falsePositiveRate = falsePasses / this.executionMetrics.shadowCandidateCount;
+      this.executionMetrics.falseNegativeRate = falseFails / this.executionMetrics.shadowCandidateCount;
+    }
   }
 
   /**

--- a/src/early-exit/index.ts
+++ b/src/early-exit/index.ts
@@ -53,6 +53,8 @@ export type {
   // Result types
   TestPyramidResult,
   EarlyExitMetrics,
+  ShadowCalibrationContext,
+  ShadowCalibrationResult,
 } from './types';
 
 export {

--- a/src/early-exit/speculative-executor.ts
+++ b/src/early-exit/speculative-executor.ts
@@ -147,6 +147,7 @@ export class SpeculativeExecutor {
 
         const verifiedPrediction: SpeculativeResult = {
           ...prediction,
+          evidenceClass: 'EXECUTED',
           verified: true,
           actual: actualOutcome,
           correct: prediction.predicted === actualOutcome,
@@ -160,6 +161,7 @@ export class SpeculativeExecutor {
         // Verification failed - keep original prediction unverified
         verified.push({
           ...prediction,
+          evidenceClass: 'INCONCLUSIVE',
           verified: false,
           reasoning: `${prediction.reasoning} (verification failed: ${error instanceof Error ? error.message : 'unknown error'})`,
         });
@@ -216,6 +218,7 @@ export class SpeculativeExecutor {
     }
 
     return {
+      evidenceClass: 'PREDICTED',
       predicted: predictedOutcome,
       confidence: Math.round(adjustedConfidence * 1000) / 1000,
       verified: false,

--- a/src/early-exit/types.ts
+++ b/src/early-exit/types.ts
@@ -191,6 +191,9 @@ export interface EarlyExitDecision {
  * Configuration for early exit behavior
  */
 export interface EarlyExitConfig {
+  /** Shadow executes all layers; enforced permits a qualified early stop. */
+  mode?: 'shadow' | 'enforced';
+
   /** Target exit layer (0-indexed) - exit after this layer if conditions met */
   exitLayer: number;
 
@@ -223,6 +226,7 @@ export interface EarlyExitConfig {
  * Default configuration for balanced early exit
  */
 export const DEFAULT_EXIT_CONFIG: EarlyExitConfig = {
+  mode: 'shadow',
   exitLayer: 1, // Exit after integration tests
   minLambdaForExit: 80,
   minLambdaStability: 0.85,
@@ -238,6 +242,7 @@ export const DEFAULT_EXIT_CONFIG: EarlyExitConfig = {
  * Aggressive configuration for fast feedback
  */
 export const AGGRESSIVE_EXIT_CONFIG: EarlyExitConfig = {
+  mode: 'shadow',
   exitLayer: 0, // Exit after unit tests
   minLambdaForExit: 60,
   minLambdaStability: 0.75,
@@ -253,6 +258,7 @@ export const AGGRESSIVE_EXIT_CONFIG: EarlyExitConfig = {
  * Conservative configuration for high-risk changes
  */
 export const CONSERVATIVE_EXIT_CONFIG: EarlyExitConfig = {
+  mode: 'shadow',
   exitLayer: 2, // Exit after E2E tests
   minLambdaForExit: 95,
   minLambdaStability: 0.92,
@@ -277,6 +283,9 @@ export type PredictedOutcome = 'pass' | 'fail' | 'flaky';
  * Result of speculative prediction
  */
 export interface SpeculativeResult {
+  /** Predictions and executions are never interchangeable evidence. */
+  evidenceClass: 'PREDICTED' | 'EXECUTED' | 'INCONCLUSIVE';
+
   /** Predicted outcome */
   predicted: PredictedOutcome;
 
@@ -362,6 +371,50 @@ export interface TestPyramidResult {
 
   /** Early exit decision details */
   decision: EarlyExitDecision;
+
+  /** Full-run counterfactual evidence when the controller is calibrating. */
+  shadowCalibration?: ShadowCalibrationResult;
+}
+
+export interface ShadowCalibrationContext {
+  revision: string;
+  environment: string;
+  featureSchemaVersion: string;
+  heuristicVersion: string;
+}
+
+export interface ShadowCalibrationResult {
+  receiptId: string;
+  evidenceClass: 'EXECUTED' | 'INCONCLUSIVE';
+  candidateExitLayer: number;
+  candidateSignal: {
+    lambda: number;
+    lambdaPrev: number;
+    boundaryConcentration: number;
+    flags: number;
+    timestamp: string;
+  };
+  thresholds: {
+    minLambdaForExit: number;
+    minLambdaStability: number;
+    maxBoundaryConcentration: number;
+    minConfidence: number;
+  };
+  predictedLayers: Array<{
+    layerIndex: number;
+    layerType: TestLayerType;
+    outcome: PredictedOutcome;
+    confidence: number;
+    evidenceClass: 'PREDICTED';
+  }>;
+  predictedVerdict: 'pass' | 'fail' | 'inconclusive';
+  fullRunVerdict: 'pass' | 'fail';
+  falsePass: boolean;
+  falseFail: boolean;
+  firstMissedFailure?: { layerIndex: number; layerType: TestLayerType; failedTests: number };
+  estimatedSavings: number;
+  actualSavings: 0;
+  context?: ShadowCalibrationContext;
 }
 
 // ============================================================================
@@ -404,4 +457,7 @@ export interface EarlyExitMetrics {
 
   /** False negative rate (didn't exit when should have) */
   falseNegativeRate: number;
+
+  /** Candidate exits observed while full execution remained authoritative. */
+  shadowCandidateCount: number;
 }

--- a/tests/unit/early-exit/shadow-calibration.test.ts
+++ b/tests/unit/early-exit/shadow-calibration.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import { EarlyExitController } from '../../../src/early-exit/early-exit-controller.js';
+import { SpeculativeExecutor } from '../../../src/early-exit/speculative-executor.js';
+import type { LayerResult, TestLayer } from '../../../src/early-exit/types.js';
+
+const layers: TestLayer[] = [
+  { index: 0, type: 'unit', name: 'unit', testFiles: [] },
+  { index: 1, type: 'integration', name: 'concurrency', testFiles: [] },
+  { index: 2, type: 'e2e', name: 'security', testFiles: [] },
+  { index: 3, type: 'performance', name: 'performance', testFiles: [] },
+];
+
+function result(layer: TestLayer, failing = false): LayerResult {
+  return {
+    layerIndex: layer.index,
+    layerType: layer.type,
+    passRate: failing ? 0 : 1,
+    coverage: 1,
+    flakyRatio: 0,
+    totalTests: 10,
+    passedTests: failing ? 9 : 10,
+    failedTests: failing ? 1 : 0,
+    skippedTests: 0,
+    duration: 10,
+  };
+}
+
+const candidateConfig = {
+  mode: 'shadow' as const,
+  exitLayer: 0,
+  adaptiveExitLayer: false,
+  minLambdaForExit: 0,
+  minLambdaStability: 0,
+  maxBoundaryConcentration: 1,
+  minConfidence: 0,
+  verificationLayers: 0,
+};
+
+const context = {
+  revision: 'abc123', environment: 'node-22-linux',
+  featureSchemaVersion: 'lambda/v1', heuristicVersion: 'coherence/v1',
+};
+
+describe('early-exit shadow calibration', () => {
+  it.each([
+    ['concurrency', 1],
+    ['security', 2],
+    ['performance', 3],
+  ])('keeps a deep %s failure authoritative', async (_risk, failureLayer) => {
+    const controller = new EarlyExitController(candidateConfig, layers.length);
+    const executed: number[] = [];
+    const run = await controller.runWithEarlyExit(layers, async layer => {
+      executed.push(layer.index);
+      return result(layer, layer.index === failureLayer);
+    }, context);
+
+    expect(executed).toEqual([0, 1, 2, 3]);
+    expect(run.exitedEarly).toBe(false);
+    expect(run.skippedLayers).toBe(0);
+    expect(run.computeSavings).toBe(0);
+    expect(run.shadowCalibration).toMatchObject({
+      evidenceClass: 'EXECUTED',
+      candidateExitLayer: 0,
+      fullRunVerdict: 'fail',
+      actualSavings: 0,
+      context,
+      firstMissedFailure: { layerIndex: failureLayer, failedTests: 1 },
+    });
+    expect(run.shadowCalibration?.receiptId).toMatch(/^[a-f0-9]{64}$/);
+    expect(run.shadowCalibration?.candidateSignal.lambda).toBe(100);
+    expect(run.shadowCalibration?.thresholds).toMatchObject({ minLambdaForExit: 0, minConfidence: 0 });
+    expect(run.shadowCalibration?.predictedLayers.every(item => item.evidenceClass === 'PREDICTED')).toBe(true);
+    expect(Object.isFrozen(run.shadowCalibration)).toBe(true);
+    expect(Object.isFrozen(run.shadowCalibration?.predictedLayers)).toBe(true);
+    expect(run.speculations.every(item => item.evidenceClass === 'PREDICTED')).toBe(true);
+  });
+
+  it('fails open to inconclusive calibration evidence when target provenance is absent', async () => {
+    const controller = new EarlyExitController(candidateConfig, layers.length);
+    const run = await controller.runWithEarlyExit(layers, async layer => result(layer));
+    expect(run.layers).toHaveLength(4);
+    expect(run.shadowCalibration?.evidenceClass).toBe('INCONCLUSIVE');
+    expect(run.shadowCalibration?.context).toBeUndefined();
+  });
+
+  it('retains explicit enforced mode for a qualified caller', async () => {
+    const controller = new EarlyExitController({ ...candidateConfig, mode: 'enforced' }, layers.length);
+    let executions = 0;
+    const run = await controller.runWithEarlyExit(layers, async layer => {
+      executions++;
+      return result(layer);
+    });
+    expect(run.exitedEarly).toBe(true);
+    expect(executions).toBe(1);
+    expect(run.shadowCalibration).toBeUndefined();
+  });
+
+  it('labels a verification exception inconclusive rather than executed', async () => {
+    const speculator = new SpeculativeExecutor({ verificationLayers: 1 });
+    const predictions = await speculator.speculate({
+      canExit: true, confidence: 1, exitLayer: 0, reason: 'confident_exit', enableSpeculation: true,
+      explanation: 'test', timestamp: new Date(), lambdaStability: 1, lambdaValue: 100,
+    }, [layers[1]!]);
+    const verified = await speculator.verify(predictions.predictions, [layers[1]!], async () => {
+      throw new Error('oracle unavailable');
+    });
+    expect(verified[0]).toMatchObject({ verified: false, evidenceClass: 'INCONCLUSIVE' });
+    expect(verified[0]?.actual).toBeUndefined();
+  });
+
+  it('updates false-pass metrics from full-run counterfactuals', async () => {
+    const controller = new EarlyExitController(candidateConfig, layers.length);
+    await controller.runWithEarlyExit(layers, async layer => result(layer, layer.index === 2), context);
+    expect(controller.getMetrics()).toMatchObject({
+      shadowCandidateCount: 1,
+      falsePositiveRate: 1,
+      falseNegativeRate: 0,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Changes AQE's early-exit presets to shadow calibration by default for the first P0 slice of #657. A candidate exit now records the candidate-time signal, thresholds, predicted deeper-layer outcomes, revision/environment context, full-run verdict, first missed failure, false-pass/false-fail classification, estimated savings, zero actual savings, and an immutable SHA-256 receipt while executing every layer exactly once.

`mode: "enforced"` remains an explicit compatibility option. ADR-033's overdue review is recorded as amended. This PR does not close #657; corpus-scale calibration, confidence intervals/risk slices, promotion artifacts, drift policy, and CLI/MCP receipt parity remain tracked there.

## Verification

- `npx vitest run tests/unit/early-exit` — 6 files, 133 tests passed
- `npm run typecheck` — passed
- `npm run build` — passed; CLI and MCP bundles built successfully
- `npm run test:unit:fast` — 359 files passed, 1 skipped; 8,585 tests passed, 6 skipped
- `git diff --check` — passed
- targeted ESLint — only the four unchanged `require()` factory imports already present on `main`

## Failure modes

- Deep concurrency, security, and performance failures after a candidate exit remain authoritative and have focused tests.
- Missing calibration target provenance yields `INCONCLUSIVE` receipt evidence and full execution; covered by a focused test.
- Verification exceptions yield `INCONCLUSIVE` instead of inheriting a predicted pass; covered by a focused test.
- Predicted and executed evidence use distinct classes; covered by focused serialization assertions.
- Explicit enforced mode can still skip layers and is covered by a compatibility test. Qualification/promotion controls for enabling it remain tracked in #657.
- Corpus-scale calibration, risk-sliced confidence intervals, expiration/drift, and CLI/MCP parity remain tracked in #657.
- Repository-wide lint remains red on four pre-existing CommonJS factory imports in this module.
- External browser and PostgreSQL services were not exercised because the change is confined to the early-exit controller.

---

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.** "Unlikely" is not an acceptable substitute.

### Optional context

- Linked issues: #657
- Trust tier change (if any): none
- Affects published API or CLI surface: published TypeScript API behavior; no CLI command change
- Touches the init flow / `npm-publish.yml` / `tests/fixtures/init-corpus/`: no
