### PR TITLE
feat(verification): emit sanitized judge measurement receipts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,8 @@
         "@typescript-eslint/eslint-plugin": "^8.59.3",
         "@typescript-eslint/parser": "^8.59.3",
         "@vitest/coverage-v8": "^4.0.16",
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
         "dotenv": "^17.2.3",
         "esbuild": "^0.28.0",
         "eslint": "^8.55.0",

--- a/package.json
+++ b/package.json
@@ -265,6 +265,8 @@
     "@typescript-eslint/eslint-plugin": "^8.59.3",
     "@typescript-eslint/parser": "^8.59.3",
     "@vitest/coverage-v8": "^4.0.16",
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1",
     "dotenv": "^17.2.3",
     "esbuild": "^0.28.0",
     "eslint": "^8.55.0",

--- a/schemas/finding-verdict.schema.json
+++ b/schemas/finding-verdict.schema.json
@@ -163,19 +163,24 @@
             "type": [
               "number",
               "null"
-            ]
+            ],
+            "minimum": 0
           },
           "topP": {
             "type": [
               "number",
               "null"
-            ]
+            ],
+            "minimum": 0,
+            "maximum": 1
           },
           "seed": {
             "type": [
-              "number",
+              "integer",
               "null"
-            ]
+            ],
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
           },
           "deterministic": {
             "type": [

--- a/schemas/finding-verdict.schema.json
+++ b/schemas/finding-verdict.schema.json
@@ -99,15 +99,66 @@
           },
           "provider": {
             "type": "string",
-            "pattern": "^(?:UNKNOWN|[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255})$"
+            "pattern": "^(?:UNKNOWN|[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255})$",
+            "allOf": [
+              {
+                "not": {
+                  "pattern": "^(?:(?:[sS][kK]|[rR][kK]|[gG][hH][pPoOuUsSrR]|[gG][iI][tT][hH][uU][bB]_[pP][aA][tT]|[xX][oO][xX][bBaApPrRsS]|[nN][pP][mM]|[gG][lL][pP][aA][tT]|[pP][aA][tT])[-_]|(?:[aA][kK][iI][aA]|[aA][sS][iI][aA]|[aA][iI][zZ][aA]))"
+                }
+              },
+              {
+                "not": {
+                  "pattern": "^(?:eyJ[A-Za-z0-9_-]*|e30|ew[A-Za-z0-9_-]*)\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+$"
+                }
+              },
+              {
+                "not": {
+                  "pattern": "^[A-Za-z0-9]{32,}$"
+                }
+              }
+            ]
           },
           "requestedModel": {
             "type": "string",
-            "pattern": "^(?:UNKNOWN|[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255})$"
+            "pattern": "^(?:UNKNOWN|[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255})$",
+            "allOf": [
+              {
+                "not": {
+                  "pattern": "^(?:(?:[sS][kK]|[rR][kK]|[gG][hH][pPoOuUsSrR]|[gG][iI][tT][hH][uU][bB]_[pP][aA][tT]|[xX][oO][xX][bBaApPrRsS]|[nN][pP][mM]|[gG][lL][pP][aA][tT]|[pP][aA][tT])[-_]|(?:[aA][kK][iI][aA]|[aA][sS][iI][aA]|[aA][iI][zZ][aA]))"
+                }
+              },
+              {
+                "not": {
+                  "pattern": "^(?:eyJ[A-Za-z0-9_-]*|e30|ew[A-Za-z0-9_-]*)\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+$"
+                }
+              },
+              {
+                "not": {
+                  "pattern": "^[A-Za-z0-9]{32,}$"
+                }
+              }
+            ]
           },
           "resolvedModel": {
             "type": "string",
-            "pattern": "^(?:UNKNOWN|[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255})$"
+            "pattern": "^(?:UNKNOWN|[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255})$",
+            "allOf": [
+              {
+                "not": {
+                  "pattern": "^(?:(?:[sS][kK]|[rR][kK]|[gG][hH][pPoOuUsSrR]|[gG][iI][tT][hH][uU][bB]_[pP][aA][tT]|[xX][oO][xX][bBaApPrRsS]|[nN][pP][mM]|[gG][lL][pP][aA][tT]|[pP][aA][tT])[-_]|(?:[aA][kK][iI][aA]|[aA][sS][iI][aA]|[aA][iI][zZ][aA]))"
+                }
+              },
+              {
+                "not": {
+                  "pattern": "^(?:eyJ[A-Za-z0-9_-]*|e30|ew[A-Za-z0-9_-]*)\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+$"
+                }
+              },
+              {
+                "not": {
+                  "pattern": "^[A-Za-z0-9]{32,}$"
+                }
+              }
+            ]
           },
           "endpointClass": {
             "enum": [
@@ -133,7 +184,24 @@
           },
           "fingerprint": {
             "type": "string",
-            "pattern": "^(?:UNKNOWN|[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255})$"
+            "pattern": "^(?:UNKNOWN|[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255})$",
+            "allOf": [
+              {
+                "not": {
+                  "pattern": "^(?:(?:[sS][kK]|[rR][kK]|[gG][hH][pPoOuUsSrR]|[gG][iI][tT][hH][uU][bB]_[pP][aA][tT]|[xX][oO][xX][bBaApPrRsS]|[nN][pP][mM]|[gG][lL][pP][aA][tT]|[pP][aA][tT])[-_]|(?:[aA][kK][iI][aA]|[aA][sS][iI][aA]|[aA][iI][zZ][aA]))"
+                }
+              },
+              {
+                "not": {
+                  "pattern": "^(?:eyJ[A-Za-z0-9_-]*|e30|ew[A-Za-z0-9_-]*)\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+$"
+                }
+              },
+              {
+                "not": {
+                  "pattern": "^(?:[A-Za-z0-9+/]{32,}={0,2}|[A-Za-z0-9_-]{48,})$"
+                }
+              }
+            ]
           },
           "requestHash": {
             "type": "string",
@@ -198,7 +266,8 @@
           },
           "retryCount": {
             "type": "integer",
-            "minimum": 0
+            "minimum": 0,
+            "maximum": 9007199254740991
           },
           "timestamp": {
             "type": "string",
@@ -206,7 +275,24 @@
           },
           "windowId": {
             "type": "string",
-            "pattern": "^(?:UNKNOWN|[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255})$"
+            "pattern": "^(?:UNKNOWN|[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255})$",
+            "allOf": [
+              {
+                "not": {
+                  "pattern": "^(?:(?:[sS][kK]|[rR][kK]|[gG][hH][pPoOuUsSrR]|[gG][iI][tT][hH][uU][bB]_[pP][aA][tT]|[xX][oO][xX][bBaApPrRsS]|[nN][pP][mM]|[gG][lL][pP][aA][tT]|[pP][aA][tT])[-_]|(?:[aA][kK][iI][aA]|[aA][sS][iI][aA]|[aA][iI][zZ][aA]))"
+                }
+              },
+              {
+                "not": {
+                  "pattern": "^(?:eyJ[A-Za-z0-9_-]*|e30|ew[A-Za-z0-9_-]*)\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+$"
+                }
+              },
+              {
+                "not": {
+                  "pattern": "^(?:[A-Za-z0-9+/]{32,}={0,2}|[A-Za-z0-9_-]{48,})$"
+                }
+              }
+            ]
           },
           "latencyMs": {
             "type": [
@@ -217,9 +303,159 @@
           },
           "requestId": {
             "type": "string",
-            "pattern": "^(?:UNKNOWN|[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255})$"
+            "pattern": "^(?:UNKNOWN|[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255})$",
+            "allOf": [
+              {
+                "not": {
+                  "pattern": "^(?:(?:[sS][kK]|[rR][kK]|[gG][hH][pPoOuUsSrR]|[gG][iI][tT][hH][uU][bB]_[pP][aA][tT]|[xX][oO][xX][bBaApPrRsS]|[nN][pP][mM]|[gG][lL][pP][aA][tT]|[pP][aA][tT])[-_]|(?:[aA][kK][iI][aA]|[aA][sS][iI][aA]|[aA][iI][zZ][aA]))"
+                }
+              },
+              {
+                "not": {
+                  "pattern": "^(?:eyJ[A-Za-z0-9_-]*|e30|ew[A-Za-z0-9_-]*)\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+$"
+                }
+              },
+              {
+                "not": {
+                  "pattern": "^(?:[A-Za-z0-9+/]{32,}={0,2}|[A-Za-z0-9_-]{48,})$"
+                }
+              }
+            ]
           }
-        }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "snapshotIdentity": {
+                  "const": "L2_CONTENT_BOUND"
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "fingerprint": {
+                  "not": {
+                    "const": "UNKNOWN"
+                  }
+                },
+                "requestHash": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "promptHash": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "configHash": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "parserSchemaHash": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "outputHash": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "parsedVoteHash": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "snapshotIdentity": {
+                  "const": "L1_NAMED"
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "resolvedModel": {
+                  "not": {
+                    "const": "UNKNOWN"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "semantics": {
+                  "const": "verified"
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "snapshotIdentity": {
+                  "const": "L2_CONTENT_BOUND"
+                },
+                "fingerprint": {
+                  "not": {
+                    "const": "UNKNOWN"
+                  }
+                },
+                "requestHash": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "promptHash": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "configHash": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "parserSchemaHash": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "outputHash": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "parsedVoteHash": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "semantics": {
+                  "enum": [
+                    "verified",
+                    "provider-asserted"
+                  ]
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "snapshotIdentity": {
+                  "not": {
+                    "const": "L0_UNKNOWN"
+                  }
+                },
+                "fingerprint": {
+                  "not": {
+                    "const": "UNKNOWN"
+                  }
+                }
+              }
+            }
+          }
+        ]
       }
     }
   }

--- a/schemas/finding-verdict.schema.json
+++ b/schemas/finding-verdict.schema.json
@@ -103,17 +103,17 @@
             "allOf": [
               {
                 "not": {
-                  "pattern": "^(?:(?:[sS][kK]|[rR][kK]|[gG][hH][pPoOuUsSrR]|[gG][iI][tT][hH][uU][bB]_[pP][aA][tT]|[xX][oO][xX][bBaApPrRsS]|[nN][pP][mM]|[gG][lL][pP][aA][tT]|[pP][aA][tT])[-_]|(?:[aA][kK][iI][aA]|[aA][sS][iI][aA]|[aA][iI][zZ][aA]))"
+                  "pattern": "(?:^|[._:/@+\\-])(?:(?:[sS][kK]|[rR][kK]|[gG][hH][pPoOuUsSrR]|[gG][iI][tT][hH][uU][bB]_[pP][aA][tT]|[xX][oO][xX][bBaApPrRsS]|[nN][pP][mM]|[gG][lL][pP][aA][tT]|[pP][aA][tT])(?:[-_][A-Za-z0-9_-]*|(?=$|[.:/@+\\-]))|(?:[aA][kK][iI][aA]|[aA][sS][iI][aA]|[aA][iI][zZ][aA])[A-Za-z0-9]*)"
                 }
               },
               {
                 "not": {
-                  "pattern": "^(?:eyJ[A-Za-z0-9_-]*|e30|ew[A-Za-z0-9_-]*)\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+$"
+                  "pattern": "(?:^|[^A-Za-z0-9_-])(?:eyJ[A-Za-z0-9_-]*|e30|ew[A-Za-z0-9_-]*)\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+(?:$|[^A-Za-z0-9_-])"
                 }
               },
               {
                 "not": {
-                  "pattern": "^[A-Za-z0-9]{32,}$"
+                  "pattern": "(?:^|[._:/@+\\-])[A-Za-z0-9]{32,}(?:$|[._:/@+\\-])"
                 }
               }
             ]
@@ -124,17 +124,17 @@
             "allOf": [
               {
                 "not": {
-                  "pattern": "^(?:(?:[sS][kK]|[rR][kK]|[gG][hH][pPoOuUsSrR]|[gG][iI][tT][hH][uU][bB]_[pP][aA][tT]|[xX][oO][xX][bBaApPrRsS]|[nN][pP][mM]|[gG][lL][pP][aA][tT]|[pP][aA][tT])[-_]|(?:[aA][kK][iI][aA]|[aA][sS][iI][aA]|[aA][iI][zZ][aA]))"
+                  "pattern": "(?:^|[._:/@+\\-])(?:(?:[sS][kK]|[rR][kK]|[gG][hH][pPoOuUsSrR]|[gG][iI][tT][hH][uU][bB]_[pP][aA][tT]|[xX][oO][xX][bBaApPrRsS]|[nN][pP][mM]|[gG][lL][pP][aA][tT]|[pP][aA][tT])(?:[-_][A-Za-z0-9_-]*|(?=$|[.:/@+\\-]))|(?:[aA][kK][iI][aA]|[aA][sS][iI][aA]|[aA][iI][zZ][aA])[A-Za-z0-9]*)"
                 }
               },
               {
                 "not": {
-                  "pattern": "^(?:eyJ[A-Za-z0-9_-]*|e30|ew[A-Za-z0-9_-]*)\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+$"
+                  "pattern": "(?:^|[^A-Za-z0-9_-])(?:eyJ[A-Za-z0-9_-]*|e30|ew[A-Za-z0-9_-]*)\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+(?:$|[^A-Za-z0-9_-])"
                 }
               },
               {
                 "not": {
-                  "pattern": "^[A-Za-z0-9]{32,}$"
+                  "pattern": "(?:^|[._:/@+\\-])[A-Za-z0-9]{32,}(?:$|[._:/@+\\-])"
                 }
               }
             ]
@@ -145,17 +145,17 @@
             "allOf": [
               {
                 "not": {
-                  "pattern": "^(?:(?:[sS][kK]|[rR][kK]|[gG][hH][pPoOuUsSrR]|[gG][iI][tT][hH][uU][bB]_[pP][aA][tT]|[xX][oO][xX][bBaApPrRsS]|[nN][pP][mM]|[gG][lL][pP][aA][tT]|[pP][aA][tT])[-_]|(?:[aA][kK][iI][aA]|[aA][sS][iI][aA]|[aA][iI][zZ][aA]))"
+                  "pattern": "(?:^|[._:/@+\\-])(?:(?:[sS][kK]|[rR][kK]|[gG][hH][pPoOuUsSrR]|[gG][iI][tT][hH][uU][bB]_[pP][aA][tT]|[xX][oO][xX][bBaApPrRsS]|[nN][pP][mM]|[gG][lL][pP][aA][tT]|[pP][aA][tT])(?:[-_][A-Za-z0-9_-]*|(?=$|[.:/@+\\-]))|(?:[aA][kK][iI][aA]|[aA][sS][iI][aA]|[aA][iI][zZ][aA])[A-Za-z0-9]*)"
                 }
               },
               {
                 "not": {
-                  "pattern": "^(?:eyJ[A-Za-z0-9_-]*|e30|ew[A-Za-z0-9_-]*)\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+$"
+                  "pattern": "(?:^|[^A-Za-z0-9_-])(?:eyJ[A-Za-z0-9_-]*|e30|ew[A-Za-z0-9_-]*)\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+(?:$|[^A-Za-z0-9_-])"
                 }
               },
               {
                 "not": {
-                  "pattern": "^[A-Za-z0-9]{32,}$"
+                  "pattern": "(?:^|[._:/@+\\-])[A-Za-z0-9]{32,}(?:$|[._:/@+\\-])"
                 }
               }
             ]
@@ -188,17 +188,17 @@
             "allOf": [
               {
                 "not": {
-                  "pattern": "^(?:(?:[sS][kK]|[rR][kK]|[gG][hH][pPoOuUsSrR]|[gG][iI][tT][hH][uU][bB]_[pP][aA][tT]|[xX][oO][xX][bBaApPrRsS]|[nN][pP][mM]|[gG][lL][pP][aA][tT]|[pP][aA][tT])[-_]|(?:[aA][kK][iI][aA]|[aA][sS][iI][aA]|[aA][iI][zZ][aA]))"
+                  "pattern": "(?:^|[._:/@+\\-])(?:(?:[sS][kK]|[rR][kK]|[gG][hH][pPoOuUsSrR]|[gG][iI][tT][hH][uU][bB]_[pP][aA][tT]|[xX][oO][xX][bBaApPrRsS]|[nN][pP][mM]|[gG][lL][pP][aA][tT]|[pP][aA][tT])(?:[-_][A-Za-z0-9_-]*|(?=$|[.:/@+\\-]))|(?:[aA][kK][iI][aA]|[aA][sS][iI][aA]|[aA][iI][zZ][aA])[A-Za-z0-9]*)"
                 }
               },
               {
                 "not": {
-                  "pattern": "^(?:eyJ[A-Za-z0-9_-]*|e30|ew[A-Za-z0-9_-]*)\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+$"
+                  "pattern": "(?:^|[^A-Za-z0-9_-])(?:eyJ[A-Za-z0-9_-]*|e30|ew[A-Za-z0-9_-]*)\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+(?:$|[^A-Za-z0-9_-])"
                 }
               },
               {
                 "not": {
-                  "pattern": "^(?:[A-Za-z0-9+/]{32,}={0,2}|[A-Za-z0-9_-]{48,})$"
+                  "pattern": "(?:(?:^|[.:@\\-])[A-Za-z0-9+/]{32,}={0,2}(?:$|[.:@\\-])|(?:^|[.:/@+\\-])[A-Za-z0-9_-]{48,}(?:$|[.:/@+\\-]))"
                 }
               }
             ]
@@ -270,8 +270,16 @@
             "maximum": 9007199254740991
           },
           "timestamp": {
-            "type": "string",
-            "pattern": "^(?:UNKNOWN|\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,9})?Z)$"
+            "anyOf": [
+              {
+                "const": "UNKNOWN"
+              },
+              {
+                "type": "string",
+                "pattern": "^\\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\\d|3[01])T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d(?:\\.\\d{1,9})?Z$",
+                "format": "date-time"
+              }
+            ]
           },
           "windowId": {
             "type": "string",
@@ -279,17 +287,17 @@
             "allOf": [
               {
                 "not": {
-                  "pattern": "^(?:(?:[sS][kK]|[rR][kK]|[gG][hH][pPoOuUsSrR]|[gG][iI][tT][hH][uU][bB]_[pP][aA][tT]|[xX][oO][xX][bBaApPrRsS]|[nN][pP][mM]|[gG][lL][pP][aA][tT]|[pP][aA][tT])[-_]|(?:[aA][kK][iI][aA]|[aA][sS][iI][aA]|[aA][iI][zZ][aA]))"
+                  "pattern": "(?:^|[._:/@+\\-])(?:(?:[sS][kK]|[rR][kK]|[gG][hH][pPoOuUsSrR]|[gG][iI][tT][hH][uU][bB]_[pP][aA][tT]|[xX][oO][xX][bBaApPrRsS]|[nN][pP][mM]|[gG][lL][pP][aA][tT]|[pP][aA][tT])(?:[-_][A-Za-z0-9_-]*|(?=$|[.:/@+\\-]))|(?:[aA][kK][iI][aA]|[aA][sS][iI][aA]|[aA][iI][zZ][aA])[A-Za-z0-9]*)"
                 }
               },
               {
                 "not": {
-                  "pattern": "^(?:eyJ[A-Za-z0-9_-]*|e30|ew[A-Za-z0-9_-]*)\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+$"
+                  "pattern": "(?:^|[^A-Za-z0-9_-])(?:eyJ[A-Za-z0-9_-]*|e30|ew[A-Za-z0-9_-]*)\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+(?:$|[^A-Za-z0-9_-])"
                 }
               },
               {
                 "not": {
-                  "pattern": "^(?:[A-Za-z0-9+/]{32,}={0,2}|[A-Za-z0-9_-]{48,})$"
+                  "pattern": "(?:(?:^|[.:@\\-])[A-Za-z0-9+/]{32,}={0,2}(?:$|[.:@\\-])|(?:^|[.:/@+\\-])[A-Za-z0-9_-]{48,}(?:$|[.:/@+\\-]))"
                 }
               }
             ]
@@ -307,17 +315,17 @@
             "allOf": [
               {
                 "not": {
-                  "pattern": "^(?:(?:[sS][kK]|[rR][kK]|[gG][hH][pPoOuUsSrR]|[gG][iI][tT][hH][uU][bB]_[pP][aA][tT]|[xX][oO][xX][bBaApPrRsS]|[nN][pP][mM]|[gG][lL][pP][aA][tT]|[pP][aA][tT])[-_]|(?:[aA][kK][iI][aA]|[aA][sS][iI][aA]|[aA][iI][zZ][aA]))"
+                  "pattern": "(?:^|[._:/@+\\-])(?:(?:[sS][kK]|[rR][kK]|[gG][hH][pPoOuUsSrR]|[gG][iI][tT][hH][uU][bB]_[pP][aA][tT]|[xX][oO][xX][bBaApPrRsS]|[nN][pP][mM]|[gG][lL][pP][aA][tT]|[pP][aA][tT])(?:[-_][A-Za-z0-9_-]*|(?=$|[.:/@+\\-]))|(?:[aA][kK][iI][aA]|[aA][sS][iI][aA]|[aA][iI][zZ][aA])[A-Za-z0-9]*)"
                 }
               },
               {
                 "not": {
-                  "pattern": "^(?:eyJ[A-Za-z0-9_-]*|e30|ew[A-Za-z0-9_-]*)\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+$"
+                  "pattern": "(?:^|[^A-Za-z0-9_-])(?:eyJ[A-Za-z0-9_-]*|e30|ew[A-Za-z0-9_-]*)\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+(?:$|[^A-Za-z0-9_-])"
                 }
               },
               {
                 "not": {
-                  "pattern": "^(?:[A-Za-z0-9+/]{32,}={0,2}|[A-Za-z0-9_-]{48,})$"
+                  "pattern": "(?:(?:^|[.:@\\-])[A-Za-z0-9+/]{32,}={0,2}(?:$|[.:@\\-])|(?:^|[.:/@+\\-])[A-Za-z0-9_-]{48,}(?:$|[.:/@+\\-]))"
                 }
               }
             ]

--- a/schemas/finding-verdict.schema.json
+++ b/schemas/finding-verdict.schema.json
@@ -67,39 +67,153 @@
       "items": {
         "type": "object",
         "required": [
-          "contract", "provider", "requestedModel", "resolvedModel",
-          "endpointClass", "snapshotIdentity", "semantics", "fingerprint",
-          "requestHash", "promptHash", "configHash", "parserSchemaHash",
-          "outputHash", "parsedVoteHash", "temperature", "topP", "seed",
-          "deterministic", "cacheStatus", "retryCount", "timestamp",
-          "windowId", "latencyMs", "requestId"
+          "contract",
+          "provider",
+          "requestedModel",
+          "resolvedModel",
+          "endpointClass",
+          "snapshotIdentity",
+          "semantics",
+          "fingerprint",
+          "requestHash",
+          "promptHash",
+          "configHash",
+          "parserSchemaHash",
+          "outputHash",
+          "parsedVoteHash",
+          "temperature",
+          "topP",
+          "seed",
+          "deterministic",
+          "cacheStatus",
+          "retryCount",
+          "timestamp",
+          "windowId",
+          "latencyMs",
+          "requestId"
         ],
         "additionalProperties": false,
         "properties": {
-          "contract": { "const": "judge-measurement@1" },
-          "provider": { "type": "string", "minLength": 1 },
-          "requestedModel": { "type": "string", "minLength": 1 },
-          "resolvedModel": { "type": "string", "minLength": 1 },
-          "endpointClass": { "enum": ["shared", "dedicated", "local", "UNKNOWN"] },
-          "snapshotIdentity": { "enum": ["L0_UNKNOWN", "L1_NAMED", "L2_CONTENT_BOUND"] },
-          "semantics": { "enum": ["verified", "provider-asserted", "UNKNOWN"] },
-          "fingerprint": { "type": "string", "minLength": 1 },
-          "requestHash": { "type": "string", "minLength": 1 },
-          "promptHash": { "type": "string", "minLength": 1 },
-          "configHash": { "type": "string", "minLength": 1 },
-          "parserSchemaHash": { "type": "string", "minLength": 1 },
-          "outputHash": { "type": "string", "minLength": 1 },
-          "parsedVoteHash": { "type": "string", "minLength": 1 },
-          "temperature": { "type": ["number", "null"] },
-          "topP": { "type": ["number", "null"] },
-          "seed": { "type": ["number", "null"] },
-          "deterministic": { "type": ["boolean", "null"] },
-          "cacheStatus": { "enum": ["hit", "miss", "bypass", "UNKNOWN"] },
-          "retryCount": { "type": "integer", "minimum": 0 },
-          "timestamp": { "type": "string", "minLength": 1 },
-          "windowId": { "type": "string", "minLength": 1 },
-          "latencyMs": { "type": ["number", "null"], "minimum": 0 },
-          "requestId": { "type": "string", "minLength": 1 }
+          "contract": {
+            "const": "judge-measurement@1"
+          },
+          "provider": {
+            "type": "string",
+            "pattern": "^(?:UNKNOWN|[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255})$"
+          },
+          "requestedModel": {
+            "type": "string",
+            "pattern": "^(?:UNKNOWN|[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255})$"
+          },
+          "resolvedModel": {
+            "type": "string",
+            "pattern": "^(?:UNKNOWN|[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255})$"
+          },
+          "endpointClass": {
+            "enum": [
+              "shared",
+              "dedicated",
+              "local",
+              "UNKNOWN"
+            ]
+          },
+          "snapshotIdentity": {
+            "enum": [
+              "L0_UNKNOWN",
+              "L1_NAMED",
+              "L2_CONTENT_BOUND"
+            ]
+          },
+          "semantics": {
+            "enum": [
+              "verified",
+              "provider-asserted",
+              "UNKNOWN"
+            ]
+          },
+          "fingerprint": {
+            "type": "string",
+            "pattern": "^(?:UNKNOWN|[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255})$"
+          },
+          "requestHash": {
+            "type": "string",
+            "pattern": "^(?:UNKNOWN|sha256:[a-f0-9]{64})$"
+          },
+          "promptHash": {
+            "type": "string",
+            "pattern": "^(?:UNKNOWN|sha256:[a-f0-9]{64})$"
+          },
+          "configHash": {
+            "type": "string",
+            "pattern": "^(?:UNKNOWN|sha256:[a-f0-9]{64})$"
+          },
+          "parserSchemaHash": {
+            "type": "string",
+            "pattern": "^(?:UNKNOWN|sha256:[a-f0-9]{64})$"
+          },
+          "outputHash": {
+            "type": "string",
+            "pattern": "^(?:UNKNOWN|sha256:[a-f0-9]{64})$"
+          },
+          "parsedVoteHash": {
+            "type": "string",
+            "pattern": "^(?:UNKNOWN|sha256:[a-f0-9]{64})$"
+          },
+          "temperature": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "topP": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "seed": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "deterministic": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "cacheStatus": {
+            "enum": [
+              "hit",
+              "miss",
+              "bypass",
+              "UNKNOWN"
+            ]
+          },
+          "retryCount": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "timestamp": {
+            "type": "string",
+            "pattern": "^(?:UNKNOWN|\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,9})?Z)$"
+          },
+          "windowId": {
+            "type": "string",
+            "pattern": "^(?:UNKNOWN|[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255})$"
+          },
+          "latencyMs": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "minimum": 0
+          },
+          "requestId": {
+            "type": "string",
+            "pattern": "^(?:UNKNOWN|[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255})$"
+          }
         }
       }
     }

--- a/schemas/finding-verdict.schema.json
+++ b/schemas/finding-verdict.schema.json
@@ -61,6 +61,47 @@
       "items": {
         "type": "string"
       }
+    },
+    "measurementReceipts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "contract", "provider", "requestedModel", "resolvedModel",
+          "endpointClass", "snapshotIdentity", "semantics", "fingerprint",
+          "requestHash", "promptHash", "configHash", "parserSchemaHash",
+          "outputHash", "parsedVoteHash", "temperature", "topP", "seed",
+          "deterministic", "cacheStatus", "retryCount", "timestamp",
+          "windowId", "latencyMs", "requestId"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contract": { "const": "judge-measurement@1" },
+          "provider": { "type": "string", "minLength": 1 },
+          "requestedModel": { "type": "string", "minLength": 1 },
+          "resolvedModel": { "type": "string", "minLength": 1 },
+          "endpointClass": { "enum": ["shared", "dedicated", "local", "UNKNOWN"] },
+          "snapshotIdentity": { "enum": ["L0_UNKNOWN", "L1_NAMED", "L2_CONTENT_BOUND"] },
+          "semantics": { "enum": ["verified", "provider-asserted", "UNKNOWN"] },
+          "fingerprint": { "type": "string", "minLength": 1 },
+          "requestHash": { "type": "string", "minLength": 1 },
+          "promptHash": { "type": "string", "minLength": 1 },
+          "configHash": { "type": "string", "minLength": 1 },
+          "parserSchemaHash": { "type": "string", "minLength": 1 },
+          "outputHash": { "type": "string", "minLength": 1 },
+          "parsedVoteHash": { "type": "string", "minLength": 1 },
+          "temperature": { "type": ["number", "null"] },
+          "topP": { "type": ["number", "null"] },
+          "seed": { "type": ["number", "null"] },
+          "deterministic": { "type": ["boolean", "null"] },
+          "cacheStatus": { "enum": ["hit", "miss", "bypass", "UNKNOWN"] },
+          "retryCount": { "type": "integer", "minimum": 0 },
+          "timestamp": { "type": "string", "minLength": 1 },
+          "windowId": { "type": "string", "minLength": 1 },
+          "latencyMs": { "type": ["number", "null"], "minimum": 0 },
+          "requestId": { "type": "string", "minLength": 1 }
+        }
+      }
     }
   }
 }

--- a/src/contracts/verdicts.ts
+++ b/src/contracts/verdicts.ts
@@ -122,10 +122,16 @@ function validateMeasurementReceipt(value: unknown, path: string): string[] {
   if (!['hit', 'miss', 'bypass', 'UNKNOWN'].includes(value.cacheStatus as string)) {
     errors.push(`${path}.cacheStatus is invalid`);
   }
-  for (const key of ['temperature', 'topP', 'seed'] as const) {
-    if (value[key] !== null && (typeof value[key] !== 'number' || !Number.isFinite(value[key]))) {
-      errors.push(`${path}.${key} must be a finite number or null`);
-    }
+  if (value.temperature !== null && (typeof value.temperature !== 'number'
+    || !Number.isFinite(value.temperature) || value.temperature < 0)) {
+    errors.push(`${path}.temperature must be a non-negative finite number or null`);
+  }
+  if (value.topP !== null && (typeof value.topP !== 'number'
+    || !Number.isFinite(value.topP) || value.topP < 0 || value.topP > 1)) {
+    errors.push(`${path}.topP must be a finite number in [0,1] or null`);
+  }
+  if (value.seed !== null && (typeof value.seed !== 'number' || !Number.isSafeInteger(value.seed))) {
+    errors.push(`${path}.seed must be a safe integer or null`);
   }
   if (value.deterministic !== null && typeof value.deterministic !== 'boolean') {
     errors.push(`${path}.deterministic must be a boolean or null`);
@@ -311,9 +317,13 @@ export const FINDING_VERDICT_SCHEMA = {
           parserSchemaHash: receiptHash,
           outputHash: receiptHash,
           parsedVoteHash: receiptHash,
-          temperature: { type: ['number', 'null'] },
-          topP: { type: ['number', 'null'] },
-          seed: { type: ['number', 'null'] },
+          temperature: { type: ['number', 'null'], minimum: 0 },
+          topP: { type: ['number', 'null'], minimum: 0, maximum: 1 },
+          seed: {
+            type: ['integer', 'null'],
+            minimum: Number.MIN_SAFE_INTEGER,
+            maximum: Number.MAX_SAFE_INTEGER,
+          },
           deterministic: { type: ['boolean', 'null'] },
           cacheStatus: { enum: ['hit', 'miss', 'bypass', 'UNKNOWN'] },
           retryCount: { type: 'integer', minimum: 0 },

--- a/src/contracts/verdicts.ts
+++ b/src/contracts/verdicts.ts
@@ -13,6 +13,15 @@
  * fields, so schemas keep `additionalProperties: true`.
  */
 import type { JudgeMeasurementReceipt } from '../verification/adversarial-verify/types.js';
+import {
+  isSanitizedReceiptIdentifier,
+  RECEIPT_IDENTIFIER_PATTERN,
+  RECEIPT_JWT_PATTERN,
+  RECEIPT_OPAQUE_CORRELATION_PATTERN,
+  RECEIPT_OPAQUE_DESCRIPTOR_PATTERN,
+  RECEIPT_SENSITIVE_IDENTIFIER_PATTERN,
+  type ReceiptIdentifierField,
+} from '../verification/adversarial-verify/measurement-receipt.js';
 
 export const VERDICT_CONTRACT_VERSION = '1.0' as const;
 
@@ -89,7 +98,6 @@ const RECEIPT_KEYS = new Set([
   'outputHash', 'parsedVoteHash', 'temperature', 'topP', 'seed', 'deterministic', 'cacheStatus',
   'retryCount', 'timestamp', 'windowId', 'latencyMs', 'requestId',
 ]);
-const RECEIPT_IDENTIFIER = /^(?:UNKNOWN|[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255})$/;
 const RECEIPT_HASH = /^(?:UNKNOWN|sha256:[a-f\d]{64})$/;
 const RECEIPT_TIMESTAMP = /^(?:UNKNOWN|\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z)$/;
 
@@ -101,7 +109,7 @@ function validateMeasurementReceipt(value: unknown, path: string): string[] {
   }
   if (value.contract !== 'judge-measurement@1') errors.push(`${path}.contract must be "judge-measurement@1"`);
   for (const key of ['provider', 'requestedModel', 'resolvedModel', 'fingerprint', 'windowId', 'requestId'] as const) {
-    if (typeof value[key] !== 'string' || !RECEIPT_IDENTIFIER.test(value[key] as string)) {
+    if (!isSanitizedReceiptIdentifier(value[key], key)) {
       errors.push(`${path}.${key} must be a sanitized identifier`);
     }
   }
@@ -136,8 +144,8 @@ function validateMeasurementReceipt(value: unknown, path: string): string[] {
   if (value.deterministic !== null && typeof value.deterministic !== 'boolean') {
     errors.push(`${path}.deterministic must be a boolean or null`);
   }
-  if (!Number.isInteger(value.retryCount) || (value.retryCount as number) < 0) {
-    errors.push(`${path}.retryCount must be a non-negative integer`);
+  if (!Number.isSafeInteger(value.retryCount) || (value.retryCount as number) < 0) {
+    errors.push(`${path}.retryCount must be a non-negative safe integer`);
   }
   if (typeof value.timestamp !== 'string' || !RECEIPT_TIMESTAMP.test(value.timestamp)) {
     errors.push(`${path}.timestamp must be UNKNOWN or an ISO-8601 UTC timestamp`);
@@ -145,6 +153,23 @@ function validateMeasurementReceipt(value: unknown, path: string): string[] {
   if (value.latencyMs !== null && (typeof value.latencyMs !== 'number'
     || !Number.isFinite(value.latencyMs) || value.latencyMs < 0)) {
     errors.push(`${path}.latencyMs must be a non-negative finite number or null`);
+  }
+  const contentBound = value.fingerprint !== 'UNKNOWN'
+    && ['requestHash', 'promptHash', 'configHash', 'parserSchemaHash', 'outputHash', 'parsedVoteHash']
+      .every((field) => value[field] !== 'UNKNOWN');
+  if (value.snapshotIdentity === 'L2_CONTENT_BOUND' && !contentBound) {
+    errors.push(`${path}.snapshotIdentity L2_CONTENT_BOUND requires non-UNKNOWN fingerprint and hashes`);
+  }
+  if (value.snapshotIdentity === 'L1_NAMED' && value.resolvedModel === 'UNKNOWN') {
+    errors.push(`${path}.snapshotIdentity L1_NAMED requires a resolved model`);
+  }
+  if (value.semantics === 'verified'
+    && (value.snapshotIdentity !== 'L2_CONTENT_BOUND' || !contentBound)) {
+    errors.push(`${path}.semantics verified requires L2 content-bound identity`);
+  }
+  if (value.semantics !== 'UNKNOWN'
+    && (value.snapshotIdentity === 'L0_UNKNOWN' || value.fingerprint === 'UNKNOWN')) {
+    errors.push(`${path}.semantics requires identified snapshot and fingerprint`);
   }
   return errors;
 }
@@ -252,10 +277,22 @@ export function buildRiskDecisionFromQualityGate(input: {
 
 const unit = { type: 'number', minimum: 0, maximum: 1 } as const;
 const stringArray = { type: 'array', items: { type: 'string' } } as const;
-const receiptIdentifier = {
-  type: 'string', pattern: '^(?:UNKNOWN|[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255})$',
-} as const;
+function receiptIdentifier(field: ReceiptIdentifierField) {
+  const opaquePattern = field === 'provider' || field === 'requestedModel' || field === 'resolvedModel'
+    ? RECEIPT_OPAQUE_DESCRIPTOR_PATTERN
+    : RECEIPT_OPAQUE_CORRELATION_PATTERN;
+  return {
+    type: 'string',
+    pattern: RECEIPT_IDENTIFIER_PATTERN,
+    allOf: [
+      { not: { pattern: RECEIPT_SENSITIVE_IDENTIFIER_PATTERN } },
+      { not: { pattern: RECEIPT_JWT_PATTERN } },
+      { not: { pattern: opaquePattern } },
+    ],
+  } as const;
+}
 const receiptHash = { type: 'string', pattern: '^(?:UNKNOWN|sha256:[a-f0-9]{64})$' } as const;
+const knownReceiptHash = { type: 'string', pattern: '^sha256:[a-f0-9]{64}$' } as const;
 
 export const RISK_DECISION_SCHEMA = {
   $schema: 'http://json-schema.org/draft-07/schema#',
@@ -304,13 +341,13 @@ export const FINDING_VERDICT_SCHEMA = {
         additionalProperties: false,
         properties: {
           contract: { const: 'judge-measurement@1' },
-          provider: receiptIdentifier,
-          requestedModel: receiptIdentifier,
-          resolvedModel: receiptIdentifier,
+          provider: receiptIdentifier('provider'),
+          requestedModel: receiptIdentifier('requestedModel'),
+          resolvedModel: receiptIdentifier('resolvedModel'),
           endpointClass: { enum: ['shared', 'dedicated', 'local', 'UNKNOWN'] },
           snapshotIdentity: { enum: ['L0_UNKNOWN', 'L1_NAMED', 'L2_CONTENT_BOUND'] },
           semantics: { enum: ['verified', 'provider-asserted', 'UNKNOWN'] },
-          fingerprint: receiptIdentifier,
+          fingerprint: receiptIdentifier('fingerprint'),
           requestHash: receiptHash,
           promptHash: receiptHash,
           configHash: receiptHash,
@@ -326,15 +363,59 @@ export const FINDING_VERDICT_SCHEMA = {
           },
           deterministic: { type: ['boolean', 'null'] },
           cacheStatus: { enum: ['hit', 'miss', 'bypass', 'UNKNOWN'] },
-          retryCount: { type: 'integer', minimum: 0 },
+          retryCount: { type: 'integer', minimum: 0, maximum: Number.MAX_SAFE_INTEGER },
           timestamp: {
             type: 'string',
             pattern: '^(?:UNKNOWN|\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,9})?Z)$',
           },
-          windowId: receiptIdentifier,
+          windowId: receiptIdentifier('windowId'),
           latencyMs: { type: ['number', 'null'], minimum: 0 },
-          requestId: receiptIdentifier,
+          requestId: receiptIdentifier('requestId'),
         },
+        allOf: [
+          {
+            if: { properties: { snapshotIdentity: { const: 'L2_CONTENT_BOUND' } } },
+            then: {
+              properties: {
+                fingerprint: { not: { const: 'UNKNOWN' } },
+                requestHash: knownReceiptHash,
+                promptHash: knownReceiptHash,
+                configHash: knownReceiptHash,
+                parserSchemaHash: knownReceiptHash,
+                outputHash: knownReceiptHash,
+                parsedVoteHash: knownReceiptHash,
+              },
+            },
+          },
+          {
+            if: { properties: { snapshotIdentity: { const: 'L1_NAMED' } } },
+            then: { properties: { resolvedModel: { not: { const: 'UNKNOWN' } } } },
+          },
+          {
+            if: { properties: { semantics: { const: 'verified' } } },
+            then: {
+              properties: {
+                snapshotIdentity: { const: 'L2_CONTENT_BOUND' },
+                fingerprint: { not: { const: 'UNKNOWN' } },
+                requestHash: knownReceiptHash,
+                promptHash: knownReceiptHash,
+                configHash: knownReceiptHash,
+                parserSchemaHash: knownReceiptHash,
+                outputHash: knownReceiptHash,
+                parsedVoteHash: knownReceiptHash,
+              },
+            },
+          },
+          {
+            if: { properties: { semantics: { enum: ['verified', 'provider-asserted'] } } },
+            then: {
+              properties: {
+                snapshotIdentity: { not: { const: 'L0_UNKNOWN' } },
+                fingerprint: { not: { const: 'UNKNOWN' } },
+              },
+            },
+          },
+        ],
       },
     },
   },

--- a/src/contracts/verdicts.ts
+++ b/src/contracts/verdicts.ts
@@ -12,6 +12,7 @@
  * additive-only within a major version: consumers must tolerate unknown
  * fields, so schemas keep `additionalProperties: true`.
  */
+import type { JudgeMeasurementReceipt } from '../verification/adversarial-verify/types.js';
 
 export const VERDICT_CONTRACT_VERSION = '1.0' as const;
 
@@ -46,6 +47,8 @@ export interface FindingVerdict {
   verdict: FindingOutcome;
   /** One entry per refuter that voted to refute (empty when none) */
   refutations: string[];
+  /** Sanitized receipts for cast votes whose adapters supplied measurement evidence. */
+  measurementReceipts?: JudgeMeasurementReceipt[];
 }
 
 export interface CoverageGap {
@@ -80,6 +83,66 @@ function inUnitRange(v: unknown): v is number {
   return typeof v === 'number' && Number.isFinite(v) && v >= 0 && v <= 1;
 }
 
+const RECEIPT_KEYS = new Set([
+  'contract', 'provider', 'requestedModel', 'resolvedModel', 'endpointClass', 'snapshotIdentity',
+  'semantics', 'fingerprint', 'requestHash', 'promptHash', 'configHash', 'parserSchemaHash',
+  'outputHash', 'parsedVoteHash', 'temperature', 'topP', 'seed', 'deterministic', 'cacheStatus',
+  'retryCount', 'timestamp', 'windowId', 'latencyMs', 'requestId',
+]);
+const RECEIPT_IDENTIFIER = /^(?:UNKNOWN|[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255})$/;
+const RECEIPT_HASH = /^(?:UNKNOWN|sha256:[a-f\d]{64})$/;
+const RECEIPT_TIMESTAMP = /^(?:UNKNOWN|\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z)$/;
+
+function validateMeasurementReceipt(value: unknown, path: string): string[] {
+  if (!isRecord(value)) return [`${path} must be an object`];
+  const errors: string[] = [];
+  for (const key of Object.keys(value)) {
+    if (!RECEIPT_KEYS.has(key)) errors.push(`${path}.${key} is not allowed`);
+  }
+  if (value.contract !== 'judge-measurement@1') errors.push(`${path}.contract must be "judge-measurement@1"`);
+  for (const key of ['provider', 'requestedModel', 'resolvedModel', 'fingerprint', 'windowId', 'requestId'] as const) {
+    if (typeof value[key] !== 'string' || !RECEIPT_IDENTIFIER.test(value[key] as string)) {
+      errors.push(`${path}.${key} must be a sanitized identifier`);
+    }
+  }
+  for (const key of ['requestHash', 'promptHash', 'configHash', 'parserSchemaHash', 'outputHash', 'parsedVoteHash'] as const) {
+    if (typeof value[key] !== 'string' || !RECEIPT_HASH.test(value[key] as string)) {
+      errors.push(`${path}.${key} must be UNKNOWN or a SHA-256 digest`);
+    }
+  }
+  if (!['shared', 'dedicated', 'local', 'UNKNOWN'].includes(value.endpointClass as string)) {
+    errors.push(`${path}.endpointClass is invalid`);
+  }
+  if (!['L0_UNKNOWN', 'L1_NAMED', 'L2_CONTENT_BOUND'].includes(value.snapshotIdentity as string)) {
+    errors.push(`${path}.snapshotIdentity is invalid`);
+  }
+  if (!['verified', 'provider-asserted', 'UNKNOWN'].includes(value.semantics as string)) {
+    errors.push(`${path}.semantics is invalid`);
+  }
+  if (!['hit', 'miss', 'bypass', 'UNKNOWN'].includes(value.cacheStatus as string)) {
+    errors.push(`${path}.cacheStatus is invalid`);
+  }
+  for (const key of ['temperature', 'topP', 'seed'] as const) {
+    if (value[key] !== null && (typeof value[key] !== 'number' || !Number.isFinite(value[key]))) {
+      errors.push(`${path}.${key} must be a finite number or null`);
+    }
+  }
+  if (value.deterministic !== null && typeof value.deterministic !== 'boolean') {
+    errors.push(`${path}.deterministic must be a boolean or null`);
+  }
+  if (!Number.isInteger(value.retryCount) || (value.retryCount as number) < 0) {
+    errors.push(`${path}.retryCount must be a non-negative integer`);
+  }
+  if (typeof value.timestamp !== 'string' || !RECEIPT_TIMESTAMP.test(value.timestamp)) {
+    errors.push(`${path}.timestamp must be UNKNOWN or an ISO-8601 UTC timestamp`);
+  }
+  if (value.latencyMs !== null && (typeof value.latencyMs !== 'number'
+    || !Number.isFinite(value.latencyMs) || value.latencyMs < 0)) {
+    errors.push(`${path}.latencyMs must be a non-negative finite number or null`);
+  }
+  return errors;
+}
+
 export function validateRiskDecision(value: unknown): ValidationResult {
   const errors: string[] = [];
   if (!isRecord(value)) return { valid: false, errors: ['not an object'] };
@@ -111,6 +174,15 @@ export function validateFindingVerdict(value: unknown): ValidationResult {
     errors.push('verdict must be upheld|refuted|uncertain');
   }
   if (!isStringArray(value.refutations)) errors.push('refutations must be string[]');
+  if (value.measurementReceipts !== undefined) {
+    if (!Array.isArray(value.measurementReceipts)) {
+      errors.push('measurementReceipts must be an array when present');
+    } else {
+      value.measurementReceipts.forEach((receipt, index) => {
+        errors.push(...validateMeasurementReceipt(receipt, `measurementReceipts[${index}]`));
+      });
+    }
+  }
   return { valid: errors.length === 0, errors };
 }
 
@@ -174,6 +246,10 @@ export function buildRiskDecisionFromQualityGate(input: {
 
 const unit = { type: 'number', minimum: 0, maximum: 1 } as const;
 const stringArray = { type: 'array', items: { type: 'string' } } as const;
+const receiptIdentifier = {
+  type: 'string', pattern: '^(?:UNKNOWN|[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255})$',
+} as const;
+const receiptHash = { type: 'string', pattern: '^(?:UNKNOWN|sha256:[a-f0-9]{64})$' } as const;
 
 export const RISK_DECISION_SCHEMA = {
   $schema: 'http://json-schema.org/draft-07/schema#',
@@ -208,6 +284,49 @@ export const FINDING_VERDICT_SCHEMA = {
     evidence: stringArray,
     verdict: { enum: ['upheld', 'refuted', 'uncertain'] },
     refutations: stringArray,
+    measurementReceipts: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: [
+          'contract', 'provider', 'requestedModel', 'resolvedModel', 'endpointClass',
+          'snapshotIdentity', 'semantics', 'fingerprint', 'requestHash', 'promptHash',
+          'configHash', 'parserSchemaHash', 'outputHash', 'parsedVoteHash', 'temperature',
+          'topP', 'seed', 'deterministic', 'cacheStatus', 'retryCount', 'timestamp',
+          'windowId', 'latencyMs', 'requestId',
+        ],
+        additionalProperties: false,
+        properties: {
+          contract: { const: 'judge-measurement@1' },
+          provider: receiptIdentifier,
+          requestedModel: receiptIdentifier,
+          resolvedModel: receiptIdentifier,
+          endpointClass: { enum: ['shared', 'dedicated', 'local', 'UNKNOWN'] },
+          snapshotIdentity: { enum: ['L0_UNKNOWN', 'L1_NAMED', 'L2_CONTENT_BOUND'] },
+          semantics: { enum: ['verified', 'provider-asserted', 'UNKNOWN'] },
+          fingerprint: receiptIdentifier,
+          requestHash: receiptHash,
+          promptHash: receiptHash,
+          configHash: receiptHash,
+          parserSchemaHash: receiptHash,
+          outputHash: receiptHash,
+          parsedVoteHash: receiptHash,
+          temperature: { type: ['number', 'null'] },
+          topP: { type: ['number', 'null'] },
+          seed: { type: ['number', 'null'] },
+          deterministic: { type: ['boolean', 'null'] },
+          cacheStatus: { enum: ['hit', 'miss', 'bypass', 'UNKNOWN'] },
+          retryCount: { type: 'integer', minimum: 0 },
+          timestamp: {
+            type: 'string',
+            pattern: '^(?:UNKNOWN|\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,9})?Z)$',
+          },
+          windowId: receiptIdentifier,
+          latencyMs: { type: ['number', 'null'], minimum: 0 },
+          requestId: receiptIdentifier,
+        },
+      },
+    },
   },
 } as const;
 

--- a/src/contracts/verdicts.ts
+++ b/src/contracts/verdicts.ts
@@ -15,8 +15,10 @@
 import type { JudgeMeasurementReceipt } from '../verification/adversarial-verify/types.js';
 import {
   isSanitizedReceiptIdentifier,
+  isSanitizedReceiptTimestamp,
   RECEIPT_IDENTIFIER_PATTERN,
   RECEIPT_JWT_PATTERN,
+  RECEIPT_KNOWN_TIMESTAMP_PATTERN,
   RECEIPT_OPAQUE_CORRELATION_PATTERN,
   RECEIPT_OPAQUE_DESCRIPTOR_PATTERN,
   RECEIPT_SENSITIVE_IDENTIFIER_PATTERN,
@@ -99,7 +101,6 @@ const RECEIPT_KEYS = new Set([
   'retryCount', 'timestamp', 'windowId', 'latencyMs', 'requestId',
 ]);
 const RECEIPT_HASH = /^(?:UNKNOWN|sha256:[a-f\d]{64})$/;
-const RECEIPT_TIMESTAMP = /^(?:UNKNOWN|\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z)$/;
 
 function validateMeasurementReceipt(value: unknown, path: string): string[] {
   if (!isRecord(value)) return [`${path} must be an object`];
@@ -147,7 +148,7 @@ function validateMeasurementReceipt(value: unknown, path: string): string[] {
   if (!Number.isSafeInteger(value.retryCount) || (value.retryCount as number) < 0) {
     errors.push(`${path}.retryCount must be a non-negative safe integer`);
   }
-  if (typeof value.timestamp !== 'string' || !RECEIPT_TIMESTAMP.test(value.timestamp)) {
+  if (!isSanitizedReceiptTimestamp(value.timestamp)) {
     errors.push(`${path}.timestamp must be UNKNOWN or an ISO-8601 UTC timestamp`);
   }
   if (value.latencyMs !== null && (typeof value.latencyMs !== 'number'
@@ -365,8 +366,10 @@ export const FINDING_VERDICT_SCHEMA = {
           cacheStatus: { enum: ['hit', 'miss', 'bypass', 'UNKNOWN'] },
           retryCount: { type: 'integer', minimum: 0, maximum: Number.MAX_SAFE_INTEGER },
           timestamp: {
-            type: 'string',
-            pattern: '^(?:UNKNOWN|\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,9})?Z)$',
+            anyOf: [
+              { const: 'UNKNOWN' },
+              { type: 'string', pattern: RECEIPT_KNOWN_TIMESTAMP_PATTERN, format: 'date-time' },
+            ],
           },
           windowId: receiptIdentifier('windowId'),
           latencyMs: { type: ['number', 'null'], minimum: 0 },

--- a/src/verification/adversarial-verify/index.ts
+++ b/src/verification/adversarial-verify/index.ts
@@ -17,6 +17,11 @@ export type {
   FindingSeverity,
   FindingOutcome,
   RefuterVote,
+  JudgeMeasurementReceipt,
+  EndpointClass,
+  SnapshotIdentityLevel,
+  ReceiptSemantics,
+  CacheStatus,
   Judge,
   AdversarialVerifyOptions,
 } from './types.js';

--- a/src/verification/adversarial-verify/measurement-receipt.ts
+++ b/src/verification/adversarial-verify/measurement-receipt.ts
@@ -1,0 +1,123 @@
+import type {
+  CacheStatus,
+  EndpointClass,
+  JudgeMeasurementReceipt,
+  ReceiptSemantics,
+  SnapshotIdentityLevel,
+} from './types.js';
+
+const ENDPOINT_CLASSES = new Set<EndpointClass>(['shared', 'dedicated', 'local', 'UNKNOWN']);
+const SNAPSHOT_LEVELS = new Set<SnapshotIdentityLevel>(['L0_UNKNOWN', 'L1_NAMED', 'L2_CONTENT_BOUND']);
+const SEMANTICS = new Set<ReceiptSemantics>(['verified', 'provider-asserted', 'UNKNOWN']);
+const CACHE_STATUSES = new Set<CacheStatus>(['hit', 'miss', 'bypass', 'UNKNOWN']);
+const SAFE_IDENTIFIER = /^[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255}$/;
+const SENSITIVE_IDENTIFIER = /^(?:(?:sk|rk|gh[pousr]|github_pat|xox[baprs]|npm|glpat|pat)[-_]|(?:akia|asia|aiza))/i;
+const JWT = /^[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}$/;
+const OPAQUE_TOKEN = /^[A-Za-z0-9_-]{32,}$/;
+const RECEIPT_HASH_FIELDS = [
+  'requestHash', 'promptHash', 'configHash', 'parserSchemaHash', 'outputHash', 'parsedVoteHash',
+] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function looksLikeOpaqueCredential(value: string): boolean {
+  if (SENSITIVE_IDENTIFIER.test(value) || JWT.test(value)) return true;
+  return OPAQUE_TOKEN.test(value) && /[A-Za-z]/.test(value) && /\d/.test(value);
+}
+
+function identifier(candidate: unknown): string {
+  return typeof candidate === 'string'
+    && SAFE_IDENTIFIER.test(candidate)
+    && !looksLikeOpaqueCredential(candidate)
+    ? candidate
+    : 'UNKNOWN';
+}
+
+function timestamp(candidate: unknown): string {
+  return typeof candidate === 'string'
+    && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$/.test(candidate)
+    && Number.isFinite(Date.parse(candidate))
+    ? candidate
+    : 'UNKNOWN';
+}
+
+function hash(candidate: unknown): string {
+  return typeof candidate === 'string' && /^(?:sha256:)?[a-f\d]{64}$/i.test(candidate)
+    ? `sha256:${candidate.replace(/^sha256:/i, '').toLowerCase()}`
+    : 'UNKNOWN';
+}
+
+function enumOr<T extends string>(candidate: unknown, allowed: Set<T>, fallback: T): T {
+  return typeof candidate === 'string' && allowed.has(candidate as T) ? candidate as T : fallback;
+}
+
+function finiteNonNegativeOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+function unitOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1 ? value : null;
+}
+
+function unknownReceipt(): JudgeMeasurementReceipt {
+  return {
+    contract: 'judge-measurement@1',
+    provider: 'UNKNOWN', requestedModel: 'UNKNOWN', resolvedModel: 'UNKNOWN',
+    endpointClass: 'UNKNOWN', snapshotIdentity: 'L0_UNKNOWN', semantics: 'UNKNOWN',
+    fingerprint: 'UNKNOWN', requestHash: 'UNKNOWN', promptHash: 'UNKNOWN', configHash: 'UNKNOWN',
+    parserSchemaHash: 'UNKNOWN', outputHash: 'UNKNOWN', parsedVoteHash: 'UNKNOWN',
+    temperature: null, topP: null, seed: null, deterministic: null, cacheStatus: 'UNKNOWN',
+    retryCount: 0, timestamp: 'UNKNOWN', windowId: 'UNKNOWN', latencyMs: null, requestId: 'UNKNOWN',
+  };
+}
+
+/** Convert adapter-supplied receipt evidence into the content-free public contract. */
+export function sanitizeJudgeMeasurementReceipt(value: unknown): JudgeMeasurementReceipt {
+  if (!isRecord(value)) return unknownReceipt();
+  try {
+    const sanitized: JudgeMeasurementReceipt = {
+      contract: 'judge-measurement@1',
+      provider: identifier(value.provider),
+      requestedModel: identifier(value.requestedModel),
+      resolvedModel: identifier(value.resolvedModel),
+      endpointClass: enumOr(value.endpointClass, ENDPOINT_CLASSES, 'UNKNOWN'),
+      snapshotIdentity: enumOr(value.snapshotIdentity, SNAPSHOT_LEVELS, 'L0_UNKNOWN'),
+      semantics: enumOr(value.semantics, SEMANTICS, 'UNKNOWN'),
+      fingerprint: identifier(value.fingerprint),
+      requestHash: hash(value.requestHash),
+      promptHash: hash(value.promptHash),
+      configHash: hash(value.configHash),
+      parserSchemaHash: hash(value.parserSchemaHash),
+      outputHash: hash(value.outputHash),
+      parsedVoteHash: hash(value.parsedVoteHash),
+      temperature: finiteNonNegativeOrNull(value.temperature),
+      topP: unitOrNull(value.topP),
+      seed: typeof value.seed === 'number' && Number.isSafeInteger(value.seed) ? value.seed : null,
+      deterministic: typeof value.deterministic === 'boolean' ? value.deterministic : null,
+      cacheStatus: enumOr(value.cacheStatus, CACHE_STATUSES, 'UNKNOWN'),
+      retryCount: typeof value.retryCount === 'number' && Number.isInteger(value.retryCount) && value.retryCount >= 0
+        ? value.retryCount
+        : 0,
+      timestamp: timestamp(value.timestamp),
+      windowId: identifier(value.windowId),
+      latencyMs: finiteNonNegativeOrNull(value.latencyMs),
+      requestId: identifier(value.requestId),
+    };
+
+    const contentBound = sanitized.fingerprint !== 'UNKNOWN'
+      && RECEIPT_HASH_FIELDS.every((field) => sanitized[field] !== 'UNKNOWN');
+    const namedSnapshot = sanitized.resolvedModel !== 'UNKNOWN';
+    if ((sanitized.snapshotIdentity === 'L2_CONTENT_BOUND' && !contentBound)
+      || (sanitized.snapshotIdentity === 'L1_NAMED' && !namedSnapshot)) {
+      sanitized.snapshotIdentity = 'L0_UNKNOWN';
+    }
+    if (sanitized.snapshotIdentity === 'L0_UNKNOWN' || sanitized.fingerprint === 'UNKNOWN') {
+      sanitized.semantics = 'UNKNOWN';
+    }
+    return sanitized;
+  } catch {
+    return unknownReceipt();
+  }
+}

--- a/src/verification/adversarial-verify/measurement-receipt.ts
+++ b/src/verification/adversarial-verify/measurement-receipt.ts
@@ -20,18 +20,22 @@ export type ReceiptIdentifierField =
 
 export const RECEIPT_IDENTIFIER_PATTERN = '^(?:UNKNOWN|[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255})$';
 export const RECEIPT_SENSITIVE_IDENTIFIER_PATTERN =
-  '^(?:(?:[sS][kK]|[rR][kK]|[gG][hH][pPoOuUsSrR]|[gG][iI][tT][hH][uU][bB]_[pP][aA][tT]|[xX][oO][xX][bBaApPrRsS]|[nN][pP][mM]|[gG][lL][pP][aA][tT]|[pP][aA][tT])[-_]|(?:[aA][kK][iI][aA]|[aA][sS][iI][aA]|[aA][iI][zZ][aA]))';
+  '(?:^|[._:/@+\\-])(?:(?:[sS][kK]|[rR][kK]|[gG][hH][pPoOuUsSrR]|[gG][iI][tT][hH][uU][bB]_[pP][aA][tT]|[xX][oO][xX][bBaApPrRsS]|[nN][pP][mM]|[gG][lL][pP][aA][tT]|[pP][aA][tT])(?:[-_][A-Za-z0-9_-]*|(?=$|[.:/@+\\-]))|(?:[aA][kK][iI][aA]|[aA][sS][iI][aA]|[aA][iI][zZ][aA])[A-Za-z0-9]*)';
 export const RECEIPT_JWT_PATTERN =
-  '^(?:eyJ[A-Za-z0-9_-]*|e30|ew[A-Za-z0-9_-]*)\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+$';
-export const RECEIPT_OPAQUE_DESCRIPTOR_PATTERN = '^[A-Za-z0-9]{32,}$';
+  '(?:^|[^A-Za-z0-9_-])(?:eyJ[A-Za-z0-9_-]*|e30|ew[A-Za-z0-9_-]*)\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+(?:$|[^A-Za-z0-9_-])';
+export const RECEIPT_OPAQUE_DESCRIPTOR_PATTERN =
+  '(?:^|[._:/@+\\-])[A-Za-z0-9]{32,}(?:$|[._:/@+\\-])';
 export const RECEIPT_OPAQUE_CORRELATION_PATTERN =
-  '^(?:[A-Za-z0-9+/]{32,}={0,2}|[A-Za-z0-9_-]{48,})$';
+  '(?:(?:^|[.:@\\-])[A-Za-z0-9+/]{32,}={0,2}(?:$|[.:@\\-])|(?:^|[.:/@+\\-])[A-Za-z0-9_-]{48,}(?:$|[.:/@+\\-]))';
+export const RECEIPT_KNOWN_TIMESTAMP_PATTERN =
+  '^\\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\\d|3[01])T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d(?:\\.\\d{1,9})?Z$';
 
 const SAFE_IDENTIFIER = new RegExp(RECEIPT_IDENTIFIER_PATTERN);
 const SENSITIVE_IDENTIFIER = new RegExp(RECEIPT_SENSITIVE_IDENTIFIER_PATTERN);
 const JWT = new RegExp(RECEIPT_JWT_PATTERN);
 const OPAQUE_DESCRIPTOR = new RegExp(RECEIPT_OPAQUE_DESCRIPTOR_PATTERN);
 const OPAQUE_CORRELATION = new RegExp(RECEIPT_OPAQUE_CORRELATION_PATTERN);
+const KNOWN_TIMESTAMP = new RegExp(RECEIPT_KNOWN_TIMESTAMP_PATTERN);
 const RECEIPT_HASH_FIELDS = [
   'requestHash', 'promptHash', 'configHash', 'parserSchemaHash', 'outputHash', 'parsedVoteHash',
 ] as const;
@@ -64,12 +68,21 @@ function identifier(candidate: unknown, field: ReceiptIdentifierField): string {
     : 'UNKNOWN';
 }
 
+export function isSanitizedReceiptTimestamp(candidate: unknown): candidate is string {
+  if (candidate === 'UNKNOWN') return true;
+  if (typeof candidate !== 'string' || !KNOWN_TIMESTAMP.test(candidate)) return false;
+  const [date] = candidate.split('T');
+  const [yearText, monthText, dayText] = date.split('-');
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  return day <= daysInMonth[month - 1];
+}
+
 function timestamp(candidate: unknown): string {
-  return typeof candidate === 'string'
-    && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$/.test(candidate)
-    && Number.isFinite(Date.parse(candidate))
-    ? candidate
-    : 'UNKNOWN';
+  return isSanitizedReceiptTimestamp(candidate) ? candidate : 'UNKNOWN';
 }
 
 function hash(candidate: unknown): string {

--- a/src/verification/adversarial-verify/measurement-receipt.ts
+++ b/src/verification/adversarial-verify/measurement-receipt.ts
@@ -10,10 +10,28 @@ const ENDPOINT_CLASSES = new Set<EndpointClass>(['shared', 'dedicated', 'local',
 const SNAPSHOT_LEVELS = new Set<SnapshotIdentityLevel>(['L0_UNKNOWN', 'L1_NAMED', 'L2_CONTENT_BOUND']);
 const SEMANTICS = new Set<ReceiptSemantics>(['verified', 'provider-asserted', 'UNKNOWN']);
 const CACHE_STATUSES = new Set<CacheStatus>(['hit', 'miss', 'bypass', 'UNKNOWN']);
-const SAFE_IDENTIFIER = /^[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255}$/;
-const SENSITIVE_IDENTIFIER = /^(?:(?:sk|rk|gh[pousr]|github_pat|xox[baprs]|npm|glpat|pat)[-_]|(?:akia|asia|aiza))/i;
-const JWT = /^[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}$/;
-const OPAQUE_TOKEN = /^[A-Za-z0-9_-]{32,}$/;
+export type ReceiptIdentifierField =
+  | 'provider'
+  | 'requestedModel'
+  | 'resolvedModel'
+  | 'fingerprint'
+  | 'windowId'
+  | 'requestId';
+
+export const RECEIPT_IDENTIFIER_PATTERN = '^(?:UNKNOWN|[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255})$';
+export const RECEIPT_SENSITIVE_IDENTIFIER_PATTERN =
+  '^(?:(?:[sS][kK]|[rR][kK]|[gG][hH][pPoOuUsSrR]|[gG][iI][tT][hH][uU][bB]_[pP][aA][tT]|[xX][oO][xX][bBaApPrRsS]|[nN][pP][mM]|[gG][lL][pP][aA][tT]|[pP][aA][tT])[-_]|(?:[aA][kK][iI][aA]|[aA][sS][iI][aA]|[aA][iI][zZ][aA]))';
+export const RECEIPT_JWT_PATTERN =
+  '^(?:eyJ[A-Za-z0-9_-]*|e30|ew[A-Za-z0-9_-]*)\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+$';
+export const RECEIPT_OPAQUE_DESCRIPTOR_PATTERN = '^[A-Za-z0-9]{32,}$';
+export const RECEIPT_OPAQUE_CORRELATION_PATTERN =
+  '^(?:[A-Za-z0-9+/]{32,}={0,2}|[A-Za-z0-9_-]{48,})$';
+
+const SAFE_IDENTIFIER = new RegExp(RECEIPT_IDENTIFIER_PATTERN);
+const SENSITIVE_IDENTIFIER = new RegExp(RECEIPT_SENSITIVE_IDENTIFIER_PATTERN);
+const JWT = new RegExp(RECEIPT_JWT_PATTERN);
+const OPAQUE_DESCRIPTOR = new RegExp(RECEIPT_OPAQUE_DESCRIPTOR_PATTERN);
+const OPAQUE_CORRELATION = new RegExp(RECEIPT_OPAQUE_CORRELATION_PATTERN);
 const RECEIPT_HASH_FIELDS = [
   'requestHash', 'promptHash', 'configHash', 'parserSchemaHash', 'outputHash', 'parsedVoteHash',
 ] as const;
@@ -22,15 +40,26 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-function looksLikeOpaqueCredential(value: string): boolean {
+function looksLikeOpaqueCredential(value: string, field: ReceiptIdentifierField): boolean {
   if (SENSITIVE_IDENTIFIER.test(value) || JWT.test(value)) return true;
-  return OPAQUE_TOKEN.test(value) && /[A-Za-z]/.test(value) && /\d/.test(value);
+  if (field === 'provider' || field === 'requestedModel' || field === 'resolvedModel') {
+    return OPAQUE_DESCRIPTOR.test(value);
+  }
+  return OPAQUE_CORRELATION.test(value);
 }
 
-function identifier(candidate: unknown): string {
+export function isSanitizedReceiptIdentifier(
+  candidate: unknown,
+  field: ReceiptIdentifierField,
+): candidate is string {
   return typeof candidate === 'string'
     && SAFE_IDENTIFIER.test(candidate)
-    && !looksLikeOpaqueCredential(candidate)
+    && !looksLikeOpaqueCredential(candidate, field);
+}
+
+function identifier(candidate: unknown, field: ReceiptIdentifierField): string {
+  return typeof candidate === 'string'
+    && isSanitizedReceiptIdentifier(candidate, field)
     ? candidate
     : 'UNKNOWN';
 }
@@ -79,13 +108,13 @@ export function sanitizeJudgeMeasurementReceipt(value: unknown): JudgeMeasuremen
   try {
     const sanitized: JudgeMeasurementReceipt = {
       contract: 'judge-measurement@1',
-      provider: identifier(value.provider),
-      requestedModel: identifier(value.requestedModel),
-      resolvedModel: identifier(value.resolvedModel),
+      provider: identifier(value.provider, 'provider'),
+      requestedModel: identifier(value.requestedModel, 'requestedModel'),
+      resolvedModel: identifier(value.resolvedModel, 'resolvedModel'),
       endpointClass: enumOr(value.endpointClass, ENDPOINT_CLASSES, 'UNKNOWN'),
       snapshotIdentity: enumOr(value.snapshotIdentity, SNAPSHOT_LEVELS, 'L0_UNKNOWN'),
       semantics: enumOr(value.semantics, SEMANTICS, 'UNKNOWN'),
-      fingerprint: identifier(value.fingerprint),
+      fingerprint: identifier(value.fingerprint, 'fingerprint'),
       requestHash: hash(value.requestHash),
       promptHash: hash(value.promptHash),
       configHash: hash(value.configHash),
@@ -97,13 +126,13 @@ export function sanitizeJudgeMeasurementReceipt(value: unknown): JudgeMeasuremen
       seed: typeof value.seed === 'number' && Number.isSafeInteger(value.seed) ? value.seed : null,
       deterministic: typeof value.deterministic === 'boolean' ? value.deterministic : null,
       cacheStatus: enumOr(value.cacheStatus, CACHE_STATUSES, 'UNKNOWN'),
-      retryCount: typeof value.retryCount === 'number' && Number.isInteger(value.retryCount) && value.retryCount >= 0
+      retryCount: typeof value.retryCount === 'number' && Number.isSafeInteger(value.retryCount) && value.retryCount >= 0
         ? value.retryCount
         : 0,
       timestamp: timestamp(value.timestamp),
-      windowId: identifier(value.windowId),
+      windowId: identifier(value.windowId, 'windowId'),
       latencyMs: finiteNonNegativeOrNull(value.latencyMs),
-      requestId: identifier(value.requestId),
+      requestId: identifier(value.requestId, 'requestId'),
     };
 
     const contentBound = sanitized.fingerprint !== 'UNKNOWN'
@@ -113,7 +142,10 @@ export function sanitizeJudgeMeasurementReceipt(value: unknown): JudgeMeasuremen
       || (sanitized.snapshotIdentity === 'L1_NAMED' && !namedSnapshot)) {
       sanitized.snapshotIdentity = 'L0_UNKNOWN';
     }
-    if (sanitized.snapshotIdentity === 'L0_UNKNOWN' || sanitized.fingerprint === 'UNKNOWN') {
+    if (sanitized.snapshotIdentity === 'L0_UNKNOWN'
+      || sanitized.fingerprint === 'UNKNOWN'
+      || (sanitized.semantics === 'verified'
+        && (sanitized.snapshotIdentity !== 'L2_CONTENT_BOUND' || !contentBound))) {
       sanitized.semantics = 'UNKNOWN';
     }
     return sanitized;

--- a/src/verification/adversarial-verify/synthesize.ts
+++ b/src/verification/adversarial-verify/synthesize.ts
@@ -20,6 +20,7 @@ export function synthesizeVerdict(
   killThreshold: (castVotes: number) => number = majorityKill,
 ): FindingVerdict {
   const refutations = votes.filter((v) => v.refuted).map((v) => v.reasoning);
+  const measurementReceipts = votes.flatMap((v) => v.measurementReceipt ? [v.measurementReceipt] : []);
   const killed = votes.length > 0 && refutations.length >= killThreshold(votes.length);
   return {
     contract: 'finding-verdict@1',
@@ -31,6 +32,7 @@ export function synthesizeVerdict(
     evidence: finding.evidence,
     verdict: votes.length === 0 ? 'uncertain' : killed ? 'refuted' : 'upheld',
     refutations,
+    ...(measurementReceipts.length > 0 ? { measurementReceipts } : {}),
   };
 }
 

--- a/src/verification/adversarial-verify/synthesize.ts
+++ b/src/verification/adversarial-verify/synthesize.ts
@@ -6,6 +6,7 @@
  * refuters failed); else `upheld`. No LLM, no I/O — byte-identical across runs.
  */
 import type { Finding, FindingVerdict, RefuterVote } from './types.js';
+import { validateFindingVerdict } from '../../contracts/verdicts.js';
 
 /** Default kill threshold: simple majority of cast votes (2-of-3, 1-of-1, 2-of-2). */
 export const majorityKill = (castVotes: number): number => Math.ceil(castVotes / 2);
@@ -38,15 +39,5 @@ export function synthesizeVerdict(
 
 /** Runtime guard: does `x` conform to finding-verdict@1 at the boundary? */
 export function isFindingVerdict(x: unknown): x is FindingVerdict {
-  if (!x || typeof x !== 'object') return false;
-  const v = x as Record<string, unknown>;
-  return (
-    v.contract === 'finding-verdict@1' &&
-    typeof v.id === 'string' &&
-    typeof v.title === 'string' &&
-    typeof v.confidence === 'number' &&
-    Array.isArray(v.evidence) &&
-    Array.isArray(v.refutations) &&
-    (v.verdict === 'upheld' || v.verdict === 'refuted' || v.verdict === 'uncertain')
-  );
+  return validateFindingVerdict(x).valid;
 }

--- a/src/verification/adversarial-verify/synthesize.ts
+++ b/src/verification/adversarial-verify/synthesize.ts
@@ -7,6 +7,7 @@
  */
 import type { Finding, FindingVerdict, RefuterVote } from './types.js';
 import { validateFindingVerdict } from '../../contracts/verdicts.js';
+import { sanitizeJudgeMeasurementReceipt } from './measurement-receipt.js';
 
 /** Default kill threshold: simple majority of cast votes (2-of-3, 1-of-1, 2-of-2). */
 export const majorityKill = (castVotes: number): number => Math.ceil(castVotes / 2);
@@ -21,7 +22,9 @@ export function synthesizeVerdict(
   killThreshold: (castVotes: number) => number = majorityKill,
 ): FindingVerdict {
   const refutations = votes.filter((v) => v.refuted).map((v) => v.reasoning);
-  const measurementReceipts = votes.flatMap((v) => v.measurementReceipt ? [v.measurementReceipt] : []);
+  const measurementReceipts = votes.flatMap((v) => v.measurementReceipt
+    ? [sanitizeJudgeMeasurementReceipt(v.measurementReceipt)]
+    : []);
   const killed = votes.length > 0 && refutations.length >= killThreshold(votes.length);
   return {
     contract: 'finding-verdict@1',

--- a/src/verification/adversarial-verify/types.ts
+++ b/src/verification/adversarial-verify/types.ts
@@ -9,6 +9,10 @@
 
 export type FindingSeverity = 'critical' | 'high' | 'medium' | 'low' | 'info';
 export type FindingOutcome = 'upheld' | 'refuted' | 'uncertain';
+export type EndpointClass = 'shared' | 'dedicated' | 'local' | 'UNKNOWN';
+export type SnapshotIdentityLevel = 'L0_UNKNOWN' | 'L1_NAMED' | 'L2_CONTENT_BOUND';
+export type ReceiptSemantics = 'verified' | 'provider-asserted' | 'UNKNOWN';
+export type CacheStatus = 'hit' | 'miss' | 'bypass' | 'UNKNOWN';
 
 /** A claim to be adversarially verified (input). */
 export interface Finding {
@@ -26,6 +30,36 @@ export interface Finding {
 export interface RefuterVote {
   refuted: boolean;
   reasoning: string;
+  /** Optional sanitized identity/configuration evidence supplied by a real adapter. */
+  measurementReceipt?: JudgeMeasurementReceipt;
+}
+
+/** Hash-bound, content-free evidence for one judge request and parsed vote. */
+export interface JudgeMeasurementReceipt {
+  contract: 'judge-measurement@1';
+  provider: string;
+  requestedModel: string;
+  resolvedModel: string;
+  endpointClass: EndpointClass;
+  snapshotIdentity: SnapshotIdentityLevel;
+  semantics: ReceiptSemantics;
+  fingerprint: string;
+  requestHash: string;
+  promptHash: string;
+  configHash: string;
+  parserSchemaHash: string;
+  outputHash: string;
+  parsedVoteHash: string;
+  temperature: number | null;
+  topP: number | null;
+  seed: number | null;
+  deterministic: boolean | null;
+  cacheStatus: CacheStatus;
+  retryCount: number;
+  timestamp: string;
+  windowId: string;
+  latencyMs: number | null;
+  requestId: string;
 }
 
 /**
@@ -47,6 +81,8 @@ export interface FindingVerdict {
   verdict: FindingOutcome;
   /** One entry per refuter that voted to refute (empty when none). */
   refutations: string[];
+  /** Sanitized receipts for cast votes whose adapters supplied measurement evidence. */
+  measurementReceipts?: JudgeMeasurementReceipt[];
 }
 
 export interface AdversarialVerifyOptions {

--- a/src/verification/adversarial-verify/verify.ts
+++ b/src/verification/adversarial-verify/verify.ts
@@ -5,15 +5,78 @@
  * claim + evidence + a distinct lens), then deterministically synthesize the
  * finding-verdict@1. The LLM is injected (`Judge`) — no host dependency.
  */
-import type { AdversarialVerifyOptions, Finding, FindingVerdict, RefuterVote } from './types.js';
+import type {
+  AdversarialVerifyOptions,
+  CacheStatus,
+  EndpointClass,
+  Finding,
+  FindingVerdict,
+  JudgeMeasurementReceipt,
+  ReceiptSemantics,
+  RefuterVote,
+  SnapshotIdentityLevel,
+} from './types.js';
 import { DEFAULT_LENSES, refuterPrompt } from './prompts.js';
 import { majorityKill, synthesizeVerdict } from './synthesize.js';
+
+const ENDPOINT_CLASSES = new Set<EndpointClass>(['shared', 'dedicated', 'local', 'UNKNOWN']);
+const SNAPSHOT_LEVELS = new Set<SnapshotIdentityLevel>(['L0_UNKNOWN', 'L1_NAMED', 'L2_CONTENT_BOUND']);
+const SEMANTICS = new Set<ReceiptSemantics>(['verified', 'provider-asserted', 'UNKNOWN']);
+const CACHE_STATUSES = new Set<CacheStatus>(['hit', 'miss', 'bypass', 'UNKNOWN']);
+
+function finiteOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function sanitizeReceipt(value: JudgeMeasurementReceipt): JudgeMeasurementReceipt {
+  const text = (candidate: unknown): string => typeof candidate === 'string' && candidate.length > 0
+    ? candidate
+    : 'UNKNOWN';
+  const hash = (candidate: unknown): string => typeof candidate === 'string'
+    && /^(?:sha256:)?[a-f\d]{64}$/i.test(candidate)
+    ? candidate.toLowerCase()
+    : 'UNKNOWN';
+  const enumOr = <T extends string>(candidate: unknown, allowed: Set<T>, fallback: T): T =>
+    typeof candidate === 'string' && allowed.has(candidate as T) ? candidate as T : fallback;
+  return {
+    contract: 'judge-measurement@1',
+    provider: text(value.provider),
+    requestedModel: text(value.requestedModel),
+    resolvedModel: text(value.resolvedModel),
+    endpointClass: enumOr(value.endpointClass, ENDPOINT_CLASSES, 'UNKNOWN'),
+    snapshotIdentity: enumOr(value.snapshotIdentity, SNAPSHOT_LEVELS, 'L0_UNKNOWN'),
+    semantics: enumOr(value.semantics, SEMANTICS, 'UNKNOWN'),
+    fingerprint: text(value.fingerprint),
+    requestHash: hash(value.requestHash),
+    promptHash: hash(value.promptHash),
+    configHash: hash(value.configHash),
+    parserSchemaHash: hash(value.parserSchemaHash),
+    outputHash: hash(value.outputHash),
+    parsedVoteHash: hash(value.parsedVoteHash),
+    temperature: finiteOrNull(value.temperature),
+    topP: finiteOrNull(value.topP),
+    seed: finiteOrNull(value.seed),
+    deterministic: typeof value.deterministic === 'boolean' ? value.deterministic : null,
+    cacheStatus: enumOr(value.cacheStatus, CACHE_STATUSES, 'UNKNOWN'),
+    retryCount: typeof value.retryCount === 'number' && Number.isInteger(value.retryCount) && value.retryCount >= 0
+      ? value.retryCount
+      : 0,
+    timestamp: text(value.timestamp),
+    windowId: text(value.windowId),
+    latencyMs: finiteOrNull(value.latencyMs),
+    requestId: text(value.requestId),
+  };
+}
 
 /** Call one refuter; a thrown/`null` result is a failed vote (excluded). */
 async function castVote(judge: AdversarialVerifyOptions['judge'], finding: Finding, lens: string): Promise<RefuterVote | null> {
   try {
     const v = await judge(refuterPrompt(finding, lens));
-    return v && typeof v.refuted === 'boolean' ? { refuted: v.refuted, reasoning: String(v.reasoning ?? '') } : null;
+    return v && typeof v.refuted === 'boolean' ? {
+      refuted: v.refuted,
+      reasoning: String(v.reasoning ?? ''),
+      ...(v.measurementReceipt ? { measurementReceipt: sanitizeReceipt(v.measurementReceipt) } : {}),
+    } : null;
   } catch {
     return null;
   }

--- a/src/verification/adversarial-verify/verify.ts
+++ b/src/verification/adversarial-verify/verify.ts
@@ -23,30 +23,42 @@ const ENDPOINT_CLASSES = new Set<EndpointClass>(['shared', 'dedicated', 'local',
 const SNAPSHOT_LEVELS = new Set<SnapshotIdentityLevel>(['L0_UNKNOWN', 'L1_NAMED', 'L2_CONTENT_BOUND']);
 const SEMANTICS = new Set<ReceiptSemantics>(['verified', 'provider-asserted', 'UNKNOWN']);
 const CACHE_STATUSES = new Set<CacheStatus>(['hit', 'miss', 'bypass', 'UNKNOWN']);
+const SAFE_IDENTIFIER = /^[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255}$/;
+const SENSITIVE_IDENTIFIER = /^(?:(?:sk|rk|gh[pousr]|github_pat|xox[baprs]|npm)[-_]|(?:akia|asia|aiza))/i;
+const RECEIPT_HASH_FIELDS = [
+  'requestHash', 'promptHash', 'configHash', 'parserSchemaHash', 'outputHash', 'parsedVoteHash',
+] as const;
 
 function finiteOrNull(value: unknown): number | null {
   return typeof value === 'number' && Number.isFinite(value) ? value : null;
 }
 
 function sanitizeReceipt(value: JudgeMeasurementReceipt): JudgeMeasurementReceipt {
-  const text = (candidate: unknown): string => typeof candidate === 'string' && candidate.length > 0
+  const identifier = (candidate: unknown): string => typeof candidate === 'string'
+    && SAFE_IDENTIFIER.test(candidate)
+    && !SENSITIVE_IDENTIFIER.test(candidate)
+    ? candidate
+    : 'UNKNOWN';
+  const timestamp = (candidate: unknown): string => typeof candidate === 'string'
+    && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$/.test(candidate)
+    && Number.isFinite(Date.parse(candidate))
     ? candidate
     : 'UNKNOWN';
   const hash = (candidate: unknown): string => typeof candidate === 'string'
     && /^(?:sha256:)?[a-f\d]{64}$/i.test(candidate)
-    ? candidate.toLowerCase()
+    ? `sha256:${candidate.replace(/^sha256:/i, '').toLowerCase()}`
     : 'UNKNOWN';
   const enumOr = <T extends string>(candidate: unknown, allowed: Set<T>, fallback: T): T =>
     typeof candidate === 'string' && allowed.has(candidate as T) ? candidate as T : fallback;
-  return {
+  const sanitized: JudgeMeasurementReceipt = {
     contract: 'judge-measurement@1',
-    provider: text(value.provider),
-    requestedModel: text(value.requestedModel),
-    resolvedModel: text(value.resolvedModel),
+    provider: identifier(value.provider),
+    requestedModel: identifier(value.requestedModel),
+    resolvedModel: identifier(value.resolvedModel),
     endpointClass: enumOr(value.endpointClass, ENDPOINT_CLASSES, 'UNKNOWN'),
     snapshotIdentity: enumOr(value.snapshotIdentity, SNAPSHOT_LEVELS, 'L0_UNKNOWN'),
     semantics: enumOr(value.semantics, SEMANTICS, 'UNKNOWN'),
-    fingerprint: text(value.fingerprint),
+    fingerprint: identifier(value.fingerprint),
     requestHash: hash(value.requestHash),
     promptHash: hash(value.promptHash),
     configHash: hash(value.configHash),
@@ -61,11 +73,26 @@ function sanitizeReceipt(value: JudgeMeasurementReceipt): JudgeMeasurementReceip
     retryCount: typeof value.retryCount === 'number' && Number.isInteger(value.retryCount) && value.retryCount >= 0
       ? value.retryCount
       : 0,
-    timestamp: text(value.timestamp),
-    windowId: text(value.windowId),
-    latencyMs: finiteOrNull(value.latencyMs),
-    requestId: text(value.requestId),
+    timestamp: timestamp(value.timestamp),
+    windowId: identifier(value.windowId),
+    latencyMs: typeof value.latencyMs === 'number' && Number.isFinite(value.latencyMs) && value.latencyMs >= 0
+      ? value.latencyMs
+      : null,
+    requestId: identifier(value.requestId),
   };
+
+  const contentBound = sanitized.fingerprint !== 'UNKNOWN'
+    && RECEIPT_HASH_FIELDS.every((field) => sanitized[field] !== 'UNKNOWN');
+  const namedSnapshot = sanitized.resolvedModel !== 'UNKNOWN';
+  if ((sanitized.snapshotIdentity === 'L2_CONTENT_BOUND' && !contentBound)
+    || (sanitized.snapshotIdentity === 'L1_NAMED' && !namedSnapshot)) {
+    sanitized.snapshotIdentity = 'L0_UNKNOWN';
+  }
+  if (sanitized.snapshotIdentity === 'L0_UNKNOWN' || sanitized.fingerprint === 'UNKNOWN') {
+    sanitized.semantics = 'UNKNOWN';
+  }
+
+  return sanitized;
 }
 
 /** Call one refuter; a thrown/`null` result is a failed vote (excluded). */

--- a/src/verification/adversarial-verify/verify.ts
+++ b/src/verification/adversarial-verify/verify.ts
@@ -7,93 +7,13 @@
  */
 import type {
   AdversarialVerifyOptions,
-  CacheStatus,
-  EndpointClass,
   Finding,
   FindingVerdict,
-  JudgeMeasurementReceipt,
-  ReceiptSemantics,
   RefuterVote,
-  SnapshotIdentityLevel,
 } from './types.js';
 import { DEFAULT_LENSES, refuterPrompt } from './prompts.js';
 import { majorityKill, synthesizeVerdict } from './synthesize.js';
-
-const ENDPOINT_CLASSES = new Set<EndpointClass>(['shared', 'dedicated', 'local', 'UNKNOWN']);
-const SNAPSHOT_LEVELS = new Set<SnapshotIdentityLevel>(['L0_UNKNOWN', 'L1_NAMED', 'L2_CONTENT_BOUND']);
-const SEMANTICS = new Set<ReceiptSemantics>(['verified', 'provider-asserted', 'UNKNOWN']);
-const CACHE_STATUSES = new Set<CacheStatus>(['hit', 'miss', 'bypass', 'UNKNOWN']);
-const SAFE_IDENTIFIER = /^[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255}$/;
-const SENSITIVE_IDENTIFIER = /^(?:(?:sk|rk|gh[pousr]|github_pat|xox[baprs]|npm)[-_]|(?:akia|asia|aiza))/i;
-const RECEIPT_HASH_FIELDS = [
-  'requestHash', 'promptHash', 'configHash', 'parserSchemaHash', 'outputHash', 'parsedVoteHash',
-] as const;
-
-function finiteOrNull(value: unknown): number | null {
-  return typeof value === 'number' && Number.isFinite(value) ? value : null;
-}
-
-function sanitizeReceipt(value: JudgeMeasurementReceipt): JudgeMeasurementReceipt {
-  const identifier = (candidate: unknown): string => typeof candidate === 'string'
-    && SAFE_IDENTIFIER.test(candidate)
-    && !SENSITIVE_IDENTIFIER.test(candidate)
-    ? candidate
-    : 'UNKNOWN';
-  const timestamp = (candidate: unknown): string => typeof candidate === 'string'
-    && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$/.test(candidate)
-    && Number.isFinite(Date.parse(candidate))
-    ? candidate
-    : 'UNKNOWN';
-  const hash = (candidate: unknown): string => typeof candidate === 'string'
-    && /^(?:sha256:)?[a-f\d]{64}$/i.test(candidate)
-    ? `sha256:${candidate.replace(/^sha256:/i, '').toLowerCase()}`
-    : 'UNKNOWN';
-  const enumOr = <T extends string>(candidate: unknown, allowed: Set<T>, fallback: T): T =>
-    typeof candidate === 'string' && allowed.has(candidate as T) ? candidate as T : fallback;
-  const sanitized: JudgeMeasurementReceipt = {
-    contract: 'judge-measurement@1',
-    provider: identifier(value.provider),
-    requestedModel: identifier(value.requestedModel),
-    resolvedModel: identifier(value.resolvedModel),
-    endpointClass: enumOr(value.endpointClass, ENDPOINT_CLASSES, 'UNKNOWN'),
-    snapshotIdentity: enumOr(value.snapshotIdentity, SNAPSHOT_LEVELS, 'L0_UNKNOWN'),
-    semantics: enumOr(value.semantics, SEMANTICS, 'UNKNOWN'),
-    fingerprint: identifier(value.fingerprint),
-    requestHash: hash(value.requestHash),
-    promptHash: hash(value.promptHash),
-    configHash: hash(value.configHash),
-    parserSchemaHash: hash(value.parserSchemaHash),
-    outputHash: hash(value.outputHash),
-    parsedVoteHash: hash(value.parsedVoteHash),
-    temperature: finiteOrNull(value.temperature),
-    topP: finiteOrNull(value.topP),
-    seed: finiteOrNull(value.seed),
-    deterministic: typeof value.deterministic === 'boolean' ? value.deterministic : null,
-    cacheStatus: enumOr(value.cacheStatus, CACHE_STATUSES, 'UNKNOWN'),
-    retryCount: typeof value.retryCount === 'number' && Number.isInteger(value.retryCount) && value.retryCount >= 0
-      ? value.retryCount
-      : 0,
-    timestamp: timestamp(value.timestamp),
-    windowId: identifier(value.windowId),
-    latencyMs: typeof value.latencyMs === 'number' && Number.isFinite(value.latencyMs) && value.latencyMs >= 0
-      ? value.latencyMs
-      : null,
-    requestId: identifier(value.requestId),
-  };
-
-  const contentBound = sanitized.fingerprint !== 'UNKNOWN'
-    && RECEIPT_HASH_FIELDS.every((field) => sanitized[field] !== 'UNKNOWN');
-  const namedSnapshot = sanitized.resolvedModel !== 'UNKNOWN';
-  if ((sanitized.snapshotIdentity === 'L2_CONTENT_BOUND' && !contentBound)
-    || (sanitized.snapshotIdentity === 'L1_NAMED' && !namedSnapshot)) {
-    sanitized.snapshotIdentity = 'L0_UNKNOWN';
-  }
-  if (sanitized.snapshotIdentity === 'L0_UNKNOWN' || sanitized.fingerprint === 'UNKNOWN') {
-    sanitized.semantics = 'UNKNOWN';
-  }
-
-  return sanitized;
-}
+import { sanitizeJudgeMeasurementReceipt } from './measurement-receipt.js';
 
 /** Call one refuter; a thrown/`null` result is a failed vote (excluded). */
 async function castVote(judge: AdversarialVerifyOptions['judge'], finding: Finding, lens: string): Promise<RefuterVote | null> {
@@ -102,7 +22,7 @@ async function castVote(judge: AdversarialVerifyOptions['judge'], finding: Findi
     return v && typeof v.refuted === 'boolean' ? {
       refuted: v.refuted,
       reasoning: String(v.reasoning ?? ''),
-      ...(v.measurementReceipt ? { measurementReceipt: sanitizeReceipt(v.measurementReceipt) } : {}),
+      ...(v.measurementReceipt ? { measurementReceipt: sanitizeJudgeMeasurementReceipt(v.measurementReceipt) } : {}),
     } : null;
   } catch {
     return null;

--- a/tests/unit/contracts/verdicts.test.ts
+++ b/tests/unit/contracts/verdicts.test.ts
@@ -159,6 +159,7 @@ describe('validateFindingVerdict', () => {
     ['topP', 1.01],
     ['seed', 1.5],
     ['seed', Number.MAX_SAFE_INTEGER + 1],
+    ['retryCount', Number.MAX_SAFE_INTEGER + 1],
   ])('should reject an invalid receipt %s value', (field, invalidValue) => {
     const verdict = {
       ...goldenFindingVerdict,
@@ -171,6 +172,36 @@ describe('validateFindingVerdict', () => {
     expect(result.errors.join()).toContain(`measurementReceipts[0].${field}`);
   });
 
+  it.each([
+    ['known credential prefix', { requestId: 'sk-live-example' }],
+    ['short-segment JWT', { fingerprint: 'eyJhbGciOiJIUzI1NiJ9.e30.sig' }],
+    ['minimal-header JWT', { requestId: 'e30.e30.sig' }],
+    ['generic alphabetic token', { requestId: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN' }],
+    ['generic base64 token', { requestId: 'Abcdefghijklmnop/qrstuvwxyz123456789' }],
+  ])('should reject a receipt containing a %s', (_label, override) => {
+    const verdict = {
+      ...goldenFindingVerdict,
+      measurementReceipts: [{ ...goldenMeasurementReceipt, ...override }],
+    };
+
+    expect(validateFindingVerdict(verdict).valid).toBe(false);
+  });
+
+  it.each([
+    ['L2 without binding evidence', { fingerprint: 'UNKNOWN', requestHash: 'UNKNOWN' }],
+    ['verified semantics below L2', { snapshotIdentity: 'L1_NAMED' }],
+    ['provider assertion without a fingerprint', {
+      snapshotIdentity: 'L1_NAMED', semantics: 'provider-asserted', fingerprint: 'UNKNOWN',
+    }],
+  ])('should reject impossible receipt trust: %s', (_label, override) => {
+    const verdict = {
+      ...goldenFindingVerdict,
+      measurementReceipts: [{ ...goldenMeasurementReceipt, ...override }],
+    };
+
+    expect(validateFindingVerdict(verdict).valid).toBe(false);
+  });
+
   it('should expose measurement receipts in the source-of-truth JSON schema', () => {
     expect(FINDING_VERDICT_SCHEMA.properties).toHaveProperty('measurementReceipts');
     const receipt = FINDING_VERDICT_SCHEMA.properties.measurementReceipts.items.properties;
@@ -181,6 +212,10 @@ describe('validateFindingVerdict', () => {
       minimum: Number.MIN_SAFE_INTEGER,
       maximum: Number.MAX_SAFE_INTEGER,
     });
+    expect(receipt.retryCount).toMatchObject({
+      type: 'integer', minimum: 0, maximum: Number.MAX_SAFE_INTEGER,
+    });
+    expect(FINDING_VERDICT_SCHEMA.properties.measurementReceipts.items.allOf).toHaveLength(4);
   });
 });
 

--- a/tests/unit/contracts/verdicts.test.ts
+++ b/tests/unit/contracts/verdicts.test.ts
@@ -11,10 +11,39 @@ import {
   validateFindingVerdict,
   validateCoverageGap,
   buildRiskDecisionFromQualityGate,
+  FINDING_VERDICT_SCHEMA,
   type RiskDecision,
   type FindingVerdict,
   type CoverageGap,
 } from '../../../src/contracts/verdicts';
+
+const digest = `sha256:${'a'.repeat(64)}`;
+const goldenMeasurementReceipt = {
+  contract: 'judge-measurement@1' as const,
+  provider: 'provider-a',
+  requestedModel: 'judge',
+  resolvedModel: 'judge-2026-09',
+  endpointClass: 'shared' as const,
+  snapshotIdentity: 'L2_CONTENT_BOUND' as const,
+  semantics: 'verified' as const,
+  fingerprint: 'fp-1',
+  requestHash: digest,
+  promptHash: digest,
+  configHash: digest,
+  parserSchemaHash: digest,
+  outputHash: digest,
+  parsedVoteHash: digest,
+  temperature: 0,
+  topP: 1,
+  seed: 7,
+  deterministic: true,
+  cacheStatus: 'miss' as const,
+  retryCount: 0,
+  timestamp: '2026-09-06T00:00:00.000Z',
+  windowId: '2026-09-06',
+  latencyMs: 42,
+  requestId: 'request-1',
+};
 
 const goldenRiskDecision: RiskDecision = {
   contract: 'risk-decision@1',
@@ -105,6 +134,28 @@ describe('validateFindingVerdict', () => {
 
   it('should reject an unknown verdict value', () => {
     expect(validateFindingVerdict({ ...goldenFindingVerdict, verdict: 'plausible' }).valid).toBe(false);
+  });
+
+  it('should validate a well-formed measurement receipt', () => {
+    const verdict = { ...goldenFindingVerdict, measurementReceipts: [goldenMeasurementReceipt] };
+
+    expect(validateFindingVerdict(verdict)).toEqual({ valid: true, errors: [] });
+  });
+
+  it('should reject a malformed measurement receipt', () => {
+    const verdict = {
+      ...goldenFindingVerdict,
+      measurementReceipts: [{ ...goldenMeasurementReceipt, latencyMs: -1 }],
+    };
+
+    const result = validateFindingVerdict(verdict);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.join()).toContain('measurementReceipts[0].latencyMs');
+  });
+
+  it('should expose measurement receipts in the source-of-truth JSON schema', () => {
+    expect(FINDING_VERDICT_SCHEMA.properties).toHaveProperty('measurementReceipts');
   });
 });
 

--- a/tests/unit/contracts/verdicts.test.ts
+++ b/tests/unit/contracts/verdicts.test.ts
@@ -154,8 +154,33 @@ describe('validateFindingVerdict', () => {
     expect(result.errors.join()).toContain('measurementReceipts[0].latencyMs');
   });
 
+  it.each([
+    ['temperature', -1],
+    ['topP', 1.01],
+    ['seed', 1.5],
+    ['seed', Number.MAX_SAFE_INTEGER + 1],
+  ])('should reject an invalid receipt %s value', (field, invalidValue) => {
+    const verdict = {
+      ...goldenFindingVerdict,
+      measurementReceipts: [{ ...goldenMeasurementReceipt, [field]: invalidValue }],
+    };
+
+    const result = validateFindingVerdict(verdict);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.join()).toContain(`measurementReceipts[0].${field}`);
+  });
+
   it('should expose measurement receipts in the source-of-truth JSON schema', () => {
     expect(FINDING_VERDICT_SCHEMA.properties).toHaveProperty('measurementReceipts');
+    const receipt = FINDING_VERDICT_SCHEMA.properties.measurementReceipts.items.properties;
+    expect(receipt.temperature).toMatchObject({ minimum: 0 });
+    expect(receipt.topP).toMatchObject({ minimum: 0, maximum: 1 });
+    expect(receipt.seed).toMatchObject({
+      type: ['integer', 'null'],
+      minimum: Number.MIN_SAFE_INTEGER,
+      maximum: Number.MAX_SAFE_INTEGER,
+    });
   });
 });
 

--- a/tests/unit/contracts/verdicts.test.ts
+++ b/tests/unit/contracts/verdicts.test.ts
@@ -5,6 +5,9 @@
  * errors; the quality-gate builder always emits a valid envelope.
  */
 
+import { readFileSync } from 'node:fs';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
 import { describe, it, expect } from 'vitest';
 import {
   validateRiskDecision,
@@ -188,6 +191,34 @@ describe('validateFindingVerdict', () => {
   });
 
   it.each([
+    ['wrapped API key', { requestId: 'req:sk' }],
+    ['wrapped GitHub token', { fingerprint: 'fp:ghp' }],
+    ['wrapped JWT', { windowId: 'window:eyJhbGciOiJIUzI1NiJ9.e30.sig' }],
+    ['wrapped opaque token', { requestId: `req:${'A'.repeat(48)}` }],
+  ])('should reject a receipt containing a %s', (_label, override) => {
+    const verdict = {
+      ...goldenFindingVerdict,
+      measurementReceipts: [{ ...goldenMeasurementReceipt, ...override }],
+    };
+
+    expect(validateFindingVerdict(verdict).valid).toBe(false);
+  });
+
+  it.each([
+    '2026-02-30T00:00:00Z',
+    '2025-02-29T00:00:00Z',
+    '2026-13-01T00:00:00Z',
+    '2026-01-01T24:00:00Z',
+  ])('should reject impossible receipt timestamp %s', (timestamp) => {
+    const verdict = {
+      ...goldenFindingVerdict,
+      measurementReceipts: [{ ...goldenMeasurementReceipt, timestamp }],
+    };
+
+    expect(validateFindingVerdict(verdict).valid).toBe(false);
+  });
+
+  it.each([
     ['L2 without binding evidence', { fingerprint: 'UNKNOWN', requestHash: 'UNKNOWN' }],
     ['verified semantics below L2', { snapshotIdentity: 'L1_NAMED' }],
     ['provider assertion without a fingerprint', {
@@ -216,6 +247,39 @@ describe('validateFindingVerdict', () => {
       type: 'integer', minimum: 0, maximum: Number.MAX_SAFE_INTEGER,
     });
     expect(FINDING_VERDICT_SCHEMA.properties.measurementReceipts.items.allOf).toHaveLength(4);
+  });
+
+  it('should keep generated schema and Ajv enforcement aligned with the runtime boundary', () => {
+    const generatedSchema = JSON.parse(readFileSync(
+      new URL('../../../schemas/finding-verdict.schema.json', import.meta.url),
+      'utf8',
+    ));
+    expect(generatedSchema).toEqual(FINDING_VERDICT_SCHEMA);
+
+    const ajv = new Ajv({ allErrors: true, strict: false });
+    addFormats(ajv);
+    const validateSchema = ajv.compile(generatedSchema);
+    const invalidOverrides = [
+      { requestId: 'req:sk' },
+      { fingerprint: 'fp:ghp' },
+      { windowId: 'window:eyJhbGciOiJIUzI1NiJ9.e30.sig' },
+      { requestId: `req:${'A'.repeat(48)}` },
+      { timestamp: '2026-02-30T00:00:00Z' },
+      { timestamp: '2025-02-29T00:00:00Z' },
+      { timestamp: '2026-13-01T00:00:00Z' },
+      { timestamp: '2026-01-01T24:00:00Z' },
+    ];
+
+    for (const override of invalidOverrides) {
+      expect(validateSchema({
+        ...goldenFindingVerdict,
+        measurementReceipts: [{ ...goldenMeasurementReceipt, ...override }],
+      })).toBe(false);
+    }
+    expect(validateSchema({
+      ...goldenFindingVerdict,
+      measurementReceipts: [goldenMeasurementReceipt],
+    })).toBe(true);
   });
 });
 

--- a/tests/unit/verification/adversarial-verify/measurement-receipt.test.ts
+++ b/tests/unit/verification/adversarial-verify/measurement-receipt.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeJudgeMeasurementReceipt } from '../../../../src/verification/adversarial-verify/measurement-receipt.js';
+
+describe('sanitizeJudgeMeasurementReceipt', () => {
+  it.each([
+    ['requestId', 'req:sk'],
+    ['fingerprint', 'fp:ghp'],
+    ['windowId', 'window:eyJhbGciOiJIUzI1NiJ9.e30.sig'],
+    ['requestId', `req:${'A'.repeat(48)}`],
+  ] as const)('should redact a wrapped secret in %s without copying it elsewhere', (field, value) => {
+    const sanitized = sanitizeJudgeMeasurementReceipt({ [field]: value });
+
+    expect(sanitized[field]).toBe('UNKNOWN');
+    expect(Object.values(sanitized)).not.toContain(value);
+  });
+
+  it.each([
+    '2026-02-30T00:00:00Z',
+    '2025-02-29T00:00:00Z',
+    '2026-13-01T00:00:00Z',
+    '2026-01-01T24:00:00Z',
+  ])('should redact impossible timestamp %s', (timestamp) => {
+    expect(sanitizeJudgeMeasurementReceipt({ timestamp }).timestamp).toBe('UNKNOWN');
+  });
+
+  it('should preserve a valid leap-day UTC timestamp', () => {
+    const timestamp = '2024-02-29T23:59:59.123456789Z';
+
+    expect(sanitizeJudgeMeasurementReceipt({ timestamp }).timestamp).toBe(timestamp);
+  });
+});

--- a/tests/unit/verification/adversarial-verify/synthesize.test.ts
+++ b/tests/unit/verification/adversarial-verify/synthesize.test.ts
@@ -62,6 +62,31 @@ describe('synthesizeVerdict', () => {
     expect(isFindingVerdict({ ...verdict, measurementReceipts: [{ contract: 'judge-measurement@1' }] })).toBe(false);
   });
 
+  it('should sanitize hostile receipts passed directly to the exported synthesis path', () => {
+    const digest = `sha256:${'a'.repeat(64)}`;
+    const hostileReceipt = {
+      contract: 'judge-measurement@1', provider: 'provider-a', requestedModel: 'judge',
+      resolvedModel: 'judge-2026-09', endpointClass: 'shared', snapshotIdentity: 'L1_NAMED',
+      semantics: 'provider-asserted', fingerprint: 'fp-1', requestHash: digest,
+      promptHash: digest, configHash: digest, parserSchemaHash: digest,
+      outputHash: digest, parsedVoteHash: digest, temperature: -1, topP: 4,
+      seed: 1.5, deterministic: false, cacheStatus: 'miss', retryCount: 0,
+      timestamp: '2026-09-06T00:00:00.000Z', windowId: '2026-09-06', latencyMs: 42,
+      requestId: 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.c2lnbmF0dXJl',
+      secret: 'must-not-escape',
+    };
+
+    const verdict = synthesizeVerdict(finding, [{
+      refuted: false, reasoning: 'verified', measurementReceipt: hostileReceipt,
+    } as RefuterVote]);
+
+    expect(verdict.measurementReceipts?.[0]).toMatchObject({
+      requestId: 'UNKNOWN', temperature: null, topP: null, seed: null,
+    });
+    expect(verdict.measurementReceipts?.[0]).not.toHaveProperty('secret');
+    expect(isFindingVerdict(verdict)).toBe(true);
+  });
+
   it('should omit file when the finding has none', () => {
     const { file, ...noFile } = finding;
     const v = synthesizeVerdict(noFile, [uphold()]);

--- a/tests/unit/verification/adversarial-verify/synthesize.test.ts
+++ b/tests/unit/verification/adversarial-verify/synthesize.test.ts
@@ -56,6 +56,12 @@ describe('synthesizeVerdict', () => {
     expect(v).toMatchObject({ contract: 'finding-verdict@1', id: 'complexity:god-fn', title: 'god function', file: 'src/x.ts', severity: 'high', confidence: 0.8 });
   });
 
+  it('should reject a verdict containing a malformed measurement receipt at the runtime boundary', () => {
+    const verdict = synthesizeVerdict(finding, [uphold()]);
+
+    expect(isFindingVerdict({ ...verdict, measurementReceipts: [{ contract: 'judge-measurement@1' }] })).toBe(false);
+  });
+
   it('should omit file when the finding has none', () => {
     const { file, ...noFile } = finding;
     const v = synthesizeVerdict(noFile, [uphold()]);

--- a/tests/unit/verification/adversarial-verify/synthesize.test.ts
+++ b/tests/unit/verification/adversarial-verify/synthesize.test.ts
@@ -87,6 +87,51 @@ describe('synthesizeVerdict', () => {
     expect(isFindingVerdict(verdict)).toBe(true);
   });
 
+  it.each([
+    ['requestId', 'req:sk'],
+    ['fingerprint', 'fp:ghp'],
+    ['windowId', 'window:eyJhbGciOiJIUzI1NiJ9.e30.sig'],
+    ['requestId', `req:${'A'.repeat(48)}`],
+  ] as const)('should redact a wrapped secret in %s on direct synthesis', (field, value) => {
+    const digest = `sha256:${'a'.repeat(64)}`;
+    const receipt = {
+      contract: 'judge-measurement@1', provider: 'provider-a', requestedModel: 'judge',
+      resolvedModel: 'judge-2026-09', endpointClass: 'shared', snapshotIdentity: 'L2_CONTENT_BOUND',
+      semantics: 'verified', fingerprint: 'fp-1', requestHash: digest, promptHash: digest,
+      configHash: digest, parserSchemaHash: digest, outputHash: digest, parsedVoteHash: digest,
+      temperature: 0, topP: 1, seed: 7, deterministic: true, cacheStatus: 'miss', retryCount: 0,
+      timestamp: '2026-09-06T00:00:00.000Z', windowId: 'window-1', latencyMs: 42,
+      requestId: 'request-1', [field]: value,
+    };
+
+    const verdict = synthesizeVerdict(finding, [{
+      refuted: false, reasoning: 'verified', measurementReceipt: receipt,
+    } as RefuterVote]);
+
+    expect(verdict.measurementReceipts?.[0]?.[field]).toBe('UNKNOWN');
+    expect(isFindingVerdict(verdict)).toBe(true);
+  });
+
+  it('should replace an impossible receipt timestamp during direct synthesis', () => {
+    const verdict = synthesizeVerdict(finding, [{
+      refuted: false,
+      reasoning: 'verified',
+      measurementReceipt: {
+        contract: 'judge-measurement@1', provider: 'provider-a', requestedModel: 'judge',
+        resolvedModel: 'judge-2026-09', endpointClass: 'shared', snapshotIdentity: 'L1_NAMED',
+        semantics: 'provider-asserted', fingerprint: 'fp-1', requestHash: 'UNKNOWN',
+        promptHash: 'UNKNOWN', configHash: 'UNKNOWN', parserSchemaHash: 'UNKNOWN',
+        outputHash: 'UNKNOWN', parsedVoteHash: 'UNKNOWN', temperature: 0, topP: 1,
+        seed: 7, deterministic: true, cacheStatus: 'miss', retryCount: 0,
+        timestamp: '2026-02-30T00:00:00Z', windowId: 'window-1', latencyMs: 42,
+        requestId: 'request-1',
+      },
+    }]);
+
+    expect(verdict.measurementReceipts?.[0]?.timestamp).toBe('UNKNOWN');
+    expect(isFindingVerdict(verdict)).toBe(true);
+  });
+
   it('should omit file when the finding has none', () => {
     const { file, ...noFile } = finding;
     const v = synthesizeVerdict(noFile, [uphold()]);

--- a/tests/unit/verification/adversarial-verify/synthesize.test.ts
+++ b/tests/unit/verification/adversarial-verify/synthesize.test.ts
@@ -72,7 +72,7 @@ describe('synthesizeVerdict', () => {
       outputHash: digest, parsedVoteHash: digest, temperature: -1, topP: 4,
       seed: 1.5, deterministic: false, cacheStatus: 'miss', retryCount: 0,
       timestamp: '2026-09-06T00:00:00.000Z', windowId: '2026-09-06', latencyMs: 42,
-      requestId: 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.c2lnbmF0dXJl',
+      requestId: 'eyJhbGciOiJIUzI1NiJ9.e30.sig',
       secret: 'must-not-escape',
     };
 

--- a/tests/unit/verification/adversarial-verify/verify.test.ts
+++ b/tests/unit/verification/adversarial-verify/verify.test.ts
@@ -12,6 +12,63 @@ const mk = (id: string, over: Partial<Finding> = {}): Finding => ({
 });
 
 describe('adversarialVerify — verdicts', () => {
+  it('should emit only the sanitized measurement receipt fields supplied by an adapter', async () => {
+    const digest = `sha256:${'a'.repeat(64)}`;
+    const judge: Judge = async () => ({
+      refuted: false,
+      reasoning: 'verified',
+      measurementReceipt: {
+        contract: 'judge-measurement@1', provider: 'provider-a', requestedModel: 'judge',
+        resolvedModel: 'judge-2026-09', endpointClass: 'shared', snapshotIdentity: 'L1_NAMED',
+        semantics: 'provider-asserted', fingerprint: 'fp-1', requestHash: digest,
+        promptHash: digest, configHash: digest, parserSchemaHash: digest,
+        outputHash: digest, parsedVoteHash: digest, temperature: 0, topP: 1,
+        seed: 7, deterministic: false, cacheStatus: 'miss', retryCount: 0,
+        timestamp: '2026-09-06T00:00:00.000Z', windowId: '2026-09-06', latencyMs: 42,
+        requestId: 'request-1',
+        secret: 'must-not-escape',
+      } as never,
+    });
+
+    const [verdict] = await adversarialVerify([mk('receipt')], { judge, refuters: 1 });
+
+    expect(verdict.measurementReceipts).toHaveLength(1);
+    expect(verdict.measurementReceipts?.[0]).toMatchObject({
+      contract: 'judge-measurement@1', provider: 'provider-a', resolvedModel: 'judge-2026-09',
+      snapshotIdentity: 'L1_NAMED', requestHash: digest, parsedVoteHash: digest,
+    });
+    expect(verdict.measurementReceipts?.[0]).not.toHaveProperty('secret');
+  });
+
+  it('should preserve UNKNOWN instead of accepting malformed identity and hash claims', async () => {
+    const judge: Judge = async () => ({
+      refuted: false,
+      reasoning: 'verified',
+      measurementReceipt: {
+        contract: 'judge-measurement@1', provider: '', requestedModel: '', resolvedModel: '',
+        endpointClass: 'shared', snapshotIdentity: 'L2_CONTENT_BOUND', semantics: 'verified',
+        fingerprint: '', requestHash: 'not-a-hash', promptHash: '', configHash: '',
+        parserSchemaHash: '', outputHash: '', parsedVoteHash: '', temperature: Number.NaN,
+        topP: null, seed: null, deterministic: null, cacheStatus: 'miss', retryCount: -1,
+        timestamp: '', windowId: '', latencyMs: Number.POSITIVE_INFINITY, requestId: '',
+      },
+    });
+
+    const [verdict] = await adversarialVerify([mk('unknown')], { judge, refuters: 1 });
+    expect(verdict.measurementReceipts?.[0]).toMatchObject({
+      provider: 'UNKNOWN', requestedModel: 'UNKNOWN', resolvedModel: 'UNKNOWN',
+      fingerprint: 'UNKNOWN', requestHash: 'UNKNOWN', promptHash: 'UNKNOWN', retryCount: 0,
+      timestamp: 'UNKNOWN', windowId: 'UNKNOWN', latencyMs: null, requestId: 'UNKNOWN',
+    });
+  });
+
+  it('should preserve deterministic stubs that do not emit measurement receipts', async () => {
+    const judge: Judge = async () => ({ refuted: false, reasoning: 'stable stub' });
+    const [verdict] = await adversarialVerify([mk('stub')], { judge, refuters: 1 });
+    expect(verdict.verdict).toBe('upheld');
+    expect(verdict).not.toHaveProperty('measurementReceipts');
+  });
+
   it('should kill a finding when the majority of refuters refute', async () => {
     let n = 0;
     const judge: Judge = async () => ({ refuted: ++n <= 2, reasoning: 'r' }); // 2 refute, 1 uphold

--- a/tests/unit/verification/adversarial-verify/verify.test.ts
+++ b/tests/unit/verification/adversarial-verify/verify.test.ts
@@ -87,6 +87,30 @@ describe('adversarialVerify — verdicts', () => {
     });
   });
 
+  it('should redact JWT and generic opaque token identifiers', async () => {
+    const digest = `sha256:${'a'.repeat(64)}`;
+    const judge: Judge = async () => ({
+      refuted: false,
+      reasoning: 'verified',
+      measurementReceipt: {
+        contract: 'judge-measurement@1', provider: 'provider-a', requestedModel: 'judge',
+        resolvedModel: 'judge-2026-09', endpointClass: 'shared', snapshotIdentity: 'L1_NAMED',
+        semantics: 'provider-asserted', fingerprint: 'Ab3'.repeat(12), requestHash: digest,
+        promptHash: digest, configHash: digest, parserSchemaHash: digest,
+        outputHash: digest, parsedVoteHash: digest, temperature: 0, topP: 1,
+        seed: 7, deterministic: false, cacheStatus: 'miss', retryCount: 0,
+        timestamp: '2026-09-06T00:00:00.000Z', windowId: '2026-09-06', latencyMs: 42,
+        requestId: 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.c2lnbmF0dXJl',
+      },
+    });
+
+    const [verdict] = await adversarialVerify([mk('opaque-secrets')], { judge, refuters: 1 });
+
+    expect(verdict.measurementReceipts?.[0]).toMatchObject({
+      fingerprint: 'UNKNOWN', requestId: 'UNKNOWN', semantics: 'UNKNOWN',
+    });
+  });
+
   it('should replace negative latency with null so emitted receipts remain schema-valid', async () => {
     const digest = `sha256:${'a'.repeat(64)}`;
     const judge: Judge = async () => ({
@@ -97,7 +121,7 @@ describe('adversarialVerify — verdicts', () => {
         resolvedModel: 'judge-2026-09', endpointClass: 'shared', snapshotIdentity: 'L2_CONTENT_BOUND',
         semantics: 'verified', fingerprint: 'fp-1', requestHash: digest, promptHash: digest,
         configHash: digest, parserSchemaHash: digest, outputHash: digest, parsedVoteHash: digest,
-        temperature: 0, topP: 1, seed: 7, deterministic: true, cacheStatus: 'miss', retryCount: 0,
+        temperature: -1, topP: 2, seed: 1.5, deterministic: true, cacheStatus: 'miss', retryCount: 0,
         timestamp: '2026-09-06T00:00:00.000Z', windowId: '2026-09-06', latencyMs: -1,
         requestId: 'request-1',
       },
@@ -105,7 +129,9 @@ describe('adversarialVerify — verdicts', () => {
 
     const [verdict] = await adversarialVerify([mk('negative-latency')], { judge, refuters: 1 });
 
-    expect(verdict.measurementReceipts?.[0]?.latencyMs).toBeNull();
+    expect(verdict.measurementReceipts?.[0]).toMatchObject({
+      temperature: null, topP: null, seed: null, latencyMs: null,
+    });
   });
 
   it('should preserve deterministic stubs that do not emit measurement receipts', async () => {

--- a/tests/unit/verification/adversarial-verify/verify.test.ts
+++ b/tests/unit/verification/adversarial-verify/verify.test.ts
@@ -59,7 +59,53 @@ describe('adversarialVerify — verdicts', () => {
       provider: 'UNKNOWN', requestedModel: 'UNKNOWN', resolvedModel: 'UNKNOWN',
       fingerprint: 'UNKNOWN', requestHash: 'UNKNOWN', promptHash: 'UNKNOWN', retryCount: 0,
       timestamp: 'UNKNOWN', windowId: 'UNKNOWN', latencyMs: null, requestId: 'UNKNOWN',
+      snapshotIdentity: 'L0_UNKNOWN', semantics: 'UNKNOWN',
     });
+  });
+
+  it('should reject prompt-like and credential-like values from public receipt identifiers', async () => {
+    const digest = `sha256:${'a'.repeat(64)}`;
+    const judge: Judge = async () => ({
+      refuted: false,
+      reasoning: 'verified',
+      measurementReceipt: {
+        contract: 'judge-measurement@1', provider: 'PRIVATE SYSTEM PROMPT: keep this hidden',
+        requestedModel: 'sk-live-example', resolvedModel: 'judge-2026-09', endpointClass: 'shared',
+        snapshotIdentity: 'L1_NAMED', semantics: 'provider-asserted', fingerprint: 'fp-1',
+        requestHash: digest, promptHash: digest, configHash: digest, parserSchemaHash: digest,
+        outputHash: digest, parsedVoteHash: digest, temperature: 0, topP: 1, seed: 7,
+        deterministic: false, cacheStatus: 'miss', retryCount: 0,
+        timestamp: '2026-09-06T00:00:00.000Z', windowId: '2026-09-06', latencyMs: 42,
+        requestId: 'PRIVATE CHAIN OF THOUGHT',
+      },
+    });
+
+    const [verdict] = await adversarialVerify([mk('sensitive')], { judge, refuters: 1 });
+
+    expect(verdict.measurementReceipts?.[0]).toMatchObject({
+      provider: 'UNKNOWN', requestedModel: 'UNKNOWN', requestId: 'UNKNOWN',
+    });
+  });
+
+  it('should replace negative latency with null so emitted receipts remain schema-valid', async () => {
+    const digest = `sha256:${'a'.repeat(64)}`;
+    const judge: Judge = async () => ({
+      refuted: false,
+      reasoning: 'verified',
+      measurementReceipt: {
+        contract: 'judge-measurement@1', provider: 'provider-a', requestedModel: 'judge',
+        resolvedModel: 'judge-2026-09', endpointClass: 'shared', snapshotIdentity: 'L2_CONTENT_BOUND',
+        semantics: 'verified', fingerprint: 'fp-1', requestHash: digest, promptHash: digest,
+        configHash: digest, parserSchemaHash: digest, outputHash: digest, parsedVoteHash: digest,
+        temperature: 0, topP: 1, seed: 7, deterministic: true, cacheStatus: 'miss', retryCount: 0,
+        timestamp: '2026-09-06T00:00:00.000Z', windowId: '2026-09-06', latencyMs: -1,
+        requestId: 'request-1',
+      },
+    });
+
+    const [verdict] = await adversarialVerify([mk('negative-latency')], { judge, refuters: 1 });
+
+    expect(verdict.measurementReceipts?.[0]?.latencyMs).toBeNull();
   });
 
   it('should preserve deterministic stubs that do not emit measurement receipts', async () => {

--- a/tests/unit/verification/adversarial-verify/verify.test.ts
+++ b/tests/unit/verification/adversarial-verify/verify.test.ts
@@ -87,27 +87,57 @@ describe('adversarialVerify — verdicts', () => {
     });
   });
 
-  it('should redact JWT and generic opaque token identifiers', async () => {
+  it('should redact short-segment JWT and broad opaque token identifiers', async () => {
     const digest = `sha256:${'a'.repeat(64)}`;
     const judge: Judge = async () => ({
       refuted: false,
       reasoning: 'verified',
       measurementReceipt: {
-        contract: 'judge-measurement@1', provider: 'provider-a', requestedModel: 'judge',
-        resolvedModel: 'judge-2026-09', endpointClass: 'shared', snapshotIdentity: 'L1_NAMED',
-        semantics: 'provider-asserted', fingerprint: 'Ab3'.repeat(12), requestHash: digest,
+        contract: 'judge-measurement@1', provider: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN',
+        requestedModel: 'judge', resolvedModel: 'judge-2026-09', endpointClass: 'shared',
+        snapshotIdentity: 'L2_CONTENT_BOUND', semantics: 'verified',
+        fingerprint: 'eyJhbGciOiJIUzI1NiJ9.e30.sig', requestHash: digest,
         promptHash: digest, configHash: digest, parserSchemaHash: digest,
         outputHash: digest, parsedVoteHash: digest, temperature: 0, topP: 1,
-        seed: 7, deterministic: false, cacheStatus: 'miss', retryCount: 0,
+        seed: 7, deterministic: false, cacheStatus: 'miss',
+        retryCount: Number.MAX_SAFE_INTEGER + 1,
         timestamp: '2026-09-06T00:00:00.000Z', windowId: '2026-09-06', latencyMs: 42,
-        requestId: 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.c2lnbmF0dXJl',
+        requestId: 'Abcdefghijklmnop/qrstuvwxyz123456789',
       },
     });
 
     const [verdict] = await adversarialVerify([mk('opaque-secrets')], { judge, refuters: 1 });
 
     expect(verdict.measurementReceipts?.[0]).toMatchObject({
-      fingerprint: 'UNKNOWN', requestId: 'UNKNOWN', semantics: 'UNKNOWN',
+      provider: 'UNKNOWN', fingerprint: 'UNKNOWN', requestId: 'UNKNOWN', retryCount: 0,
+      snapshotIdentity: 'L0_UNKNOWN', semantics: 'UNKNOWN',
+    });
+  });
+
+  it('should preserve structured model, UUID, and short public identifiers', async () => {
+    const digest = `sha256:${'a'.repeat(64)}`;
+    const judge: Judge = async () => ({
+      refuted: false,
+      reasoning: 'verified',
+      measurementReceipt: {
+        contract: 'judge-measurement@1', provider: 'provider-a',
+        requestedModel: 'openrouter/anthropic/claude-3.7-sonnet:beta',
+        resolvedModel: 'judge-2026-09', endpointClass: 'shared', snapshotIdentity: 'L1_NAMED',
+        semantics: 'provider-asserted', fingerprint: 'fp-1', requestHash: digest,
+        promptHash: digest, configHash: digest, parserSchemaHash: digest,
+        outputHash: digest, parsedVoteHash: digest, temperature: 0, topP: 1,
+        seed: 7, deterministic: false, cacheStatus: 'miss', retryCount: 0,
+        timestamp: '2026-09-06T00:00:00.000Z', windowId: '2026-09-06', latencyMs: 42,
+        requestId: '550e8400-e29b-41d4-a716-446655440000',
+      },
+    });
+
+    const [verdict] = await adversarialVerify([mk('valid-identifiers')], { judge, refuters: 1 });
+
+    expect(verdict.measurementReceipts?.[0]).toMatchObject({
+      provider: 'provider-a', requestedModel: 'openrouter/anthropic/claude-3.7-sonnet:beta',
+      fingerprint: 'fp-1', requestId: '550e8400-e29b-41d4-a716-446655440000',
+      snapshotIdentity: 'L1_NAMED', semantics: 'provider-asserted',
     });
   });
 


### PR DESCRIPTION
## Summary

Adds the first instrument-identity slice from #658. Real judge adapters can attach a versioned, content-free `judge-measurement@1` receipt to each vote; adversarial verification sanitizes the receipt and carries it into `finding-verdict@1` without allowing arbitrary adapter fields or raw prompts to escape. Missing and malformed identity fields remain explicit `UNKNOWN`, while deterministic stubs remain compatible.

The sanitizer and canonical validator now share the same identifier and timestamp policy. Credential prefixes, JWTs, and opaque token shapes are rejected even when embedded in allowed wrapper segments such as `req:sk`, `fp:ghp`, or `window:<jwt>`. UTC timestamps receive semantic calendar validation at runtime, while the generated schema combines a strict UTC pattern with Ajv `date-time` validation.

This addresses the measurement-receipt foundation of #658. Repeatability pilots, replay statistics, bias diagnostics, expiry, and qualification gating remain tracked in #658, so this PR does not close it.

## Verification

- `npm test -- --run tests/unit/contracts/verdicts.test.ts tests/unit/verification/adversarial-verify/measurement-receipt.test.ts tests/unit/verification/adversarial-verify/synthesize.test.ts tests/unit/verification/adversarial-verify/verify.test.ts`: 80 passed
- `npm run typecheck`: pass
- focused ESLint on the changed receipt TypeScript modules: pass
- `npm run build`: pass
- `node scripts/generate-verdict-schemas.mjs`: pass; contract test proves checked-in schema parity
- hostile runtime/Ajv probe for wrapped keys, JWTs, opaque tokens, leap dates, invalid dates, hours, and seconds: pass
- `git diff --check`: pass

## Failure modes

- An adapter could try to attach secrets or arbitrary properties; adversarial tests inject an extra `secret` field and verify it is discarded.
- A credential could be hidden behind a syntactically allowed identifier wrapper; sanitizer, direct-synthesis, runtime-validator, and Ajv tests cover wrapped API keys, GitHub tokens, JWTs, and opaque tokens.
- An impossible calendar timestamp could pass a shape-only regex; runtime semantic validation and generated-schema Ajv tests reject invalid dates and times while preserving valid leap days.
- Empty identity and malformed hash claims could be mistaken for stable evidence; boundary tests verify they become `UNKNOWN`.
- Invalid temperature, top-p, seed, and latency claims become null; unsafe retry counts become zero; runtime and generated schemas enforce the same numeric domains.
- L2 and verified semantics require non-UNKNOWN content-binding evidence in both the runtime validator and generated schema.
- Repeatability gating is not part of this slice and remains explicitly tracked by #658.

---

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.** "Unlikely" is not an acceptable substitute. If you wrote "I don't think this can happen but...", that sentence is a failure mode and needs a test or an issue link.

### Optional context

- Linked issues: #658
- Trust tier change (if any): no authority change; receipt evidence only
- Affects published API or CLI surface: yes, additive TypeScript interfaces and verdict field
- Touches the init flow / `npm-publish.yml` / `tests/fixtures/init-corpus/`: no
