### PR TITLE
feat(reliability): make legacy session resume fail closed

### DIFF
--- a/src/mcp/services/session-resume.ts
+++ b/src/mcp/services/session-resume.ts
@@ -31,6 +31,10 @@ const DEFAULT_MAX_RECORDS = 100_000;
 const RECENT_ENTRY_LIMIT = 256;
 const ENTRY_TYPES = new Set(['tool_call', 'tool_result', 'state_change', 'error']);
 const ENTRY_STATES = new Set(['idle', 'running', 'requires_action']);
+const ENTRY_KEYS = new Set([
+  'uuid', 'parentUuid', 'timestamp', 'type', 'toolName', 'params', 'result', 'state', 'tokenEstimate',
+]);
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function emptyResult(filePath: string, disposition: SessionRecoveryDisposition, diagnostics: string[] = []): SessionResumeResult {
   return {
@@ -50,11 +54,57 @@ function isWithin(root: string, candidate: string): boolean {
 function isValidEntry(value: unknown): value is SessionEntry {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
   const entry = value as Record<string, unknown>;
-  return typeof entry.uuid === 'string' && entry.uuid.length > 0
-    && (entry.parentUuid === null || typeof entry.parentUuid === 'string')
-    && typeof entry.timestamp === 'number' && Number.isFinite(entry.timestamp)
+  if (Object.keys(entry).some(key => !ENTRY_KEYS.has(key))) return false;
+  const params = entry.params;
+  return typeof entry.uuid === 'string' && UUID_PATTERN.test(entry.uuid)
+    && (entry.parentUuid === null
+      || (typeof entry.parentUuid === 'string' && UUID_PATTERN.test(entry.parentUuid)))
+    && typeof entry.timestamp === 'number' && Number.isSafeInteger(entry.timestamp) && entry.timestamp >= 0
     && typeof entry.type === 'string' && ENTRY_TYPES.has(entry.type)
-    && typeof entry.state === 'string' && ENTRY_STATES.has(entry.state);
+    && typeof entry.state === 'string' && ENTRY_STATES.has(entry.state)
+    && (entry.toolName === undefined || (typeof entry.toolName === 'string' && entry.toolName.length > 0))
+    && (params === undefined || (
+      typeof params === 'object' && params !== null && !Array.isArray(params)
+    ))
+    && (entry.tokenEstimate === undefined || (
+      typeof entry.tokenEstimate === 'number'
+      && Number.isSafeInteger(entry.tokenEstimate)
+      && entry.tokenEstimate >= 0
+    ));
+}
+
+function resolveLimit(value: number | undefined, defaultValue: number): number | undefined {
+  const limit = value ?? defaultValue;
+  return Number.isSafeInteger(limit) && limit > 0 && limit <= defaultValue ? limit : undefined;
+}
+
+function sameFile(left: fs.Stats, right: fs.Stats): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function validateOpenedPath(
+  fd: number,
+  candidate: string,
+  root: string,
+  openedStat: fs.Stats,
+): string | undefined {
+  try {
+    const canonicalTarget = fs.realpathSync(candidate);
+    const currentStat = fs.lstatSync(candidate);
+    if (!isWithin(root, canonicalTarget) || currentStat.isSymbolicLink() || !sameFile(openedStat, currentStat)) {
+      return 'session path changed or escaped the configured root';
+    }
+
+    // Linux exposes the descriptor target directly. This closes intermediate
+    // component substitution without relying only on the current pathname.
+    if (process.platform === 'linux') {
+      const descriptorTarget = fs.realpathSync(`/proc/self/fd/${fd}`);
+      if (!isWithin(root, descriptorTarget)) return 'opened session descriptor escapes the configured root';
+    }
+  } catch {
+    return 'opened session path cannot be verified';
+  }
+  return undefined;
 }
 
 function readExactly(fd: number, fileSize: number): Buffer {
@@ -73,9 +123,15 @@ function readExactly(fd: number, fileSize: number): Buffer {
  * resume requires an explicit opt-in because this format has no commit marker.
  */
 export function resumeSession(filePath: string, options: SessionResumeOptions): SessionResumeResult {
-  const maxFileBytes = options.maxFileBytes ?? DEFAULT_MAX_FILE_BYTES;
-  const maxRecordBytes = options.maxRecordBytes ?? DEFAULT_MAX_RECORD_BYTES;
-  const maxRecords = options.maxRecords ?? DEFAULT_MAX_RECORDS;
+  if (!options || typeof options.sessionRoot !== 'string' || options.sessionRoot.trim().length === 0) {
+    return emptyResult(filePath, 'UNTRUSTED', ['a non-empty session root is required']);
+  }
+  const maxFileBytes = resolveLimit(options.maxFileBytes, DEFAULT_MAX_FILE_BYTES);
+  const maxRecordBytes = resolveLimit(options.maxRecordBytes, DEFAULT_MAX_RECORD_BYTES);
+  const maxRecords = resolveLimit(options.maxRecords, DEFAULT_MAX_RECORDS);
+  if (maxFileBytes === undefined || maxRecordBytes === undefined || maxRecords === undefined) {
+    return emptyResult(filePath, 'RESOURCE_LIMIT', ['recovery limits must be finite positive integers within hard ceilings']);
+  }
   const candidate = path.resolve(filePath);
 
   let root: string;
@@ -83,6 +139,7 @@ export function resumeSession(filePath: string, options: SessionResumeOptions): 
   try {
     root = fs.realpathSync(options.sessionRoot);
     parent = fs.realpathSync(path.dirname(candidate));
+    if (!fs.statSync(root).isDirectory()) throw new Error('session root is not a directory');
   } catch {
     return emptyResult(filePath, 'UNTRUSTED', ['session root or parent cannot be resolved']);
   }
@@ -112,8 +169,16 @@ export function resumeSession(filePath: string, options: SessionResumeOptions): 
     if (stat.size > maxFileBytes) {
       return emptyResult(filePath, 'RESOURCE_LIMIT', [`file exceeds ${maxFileBytes} bytes`]);
     }
+    const pathError = validateOpenedPath(fd, candidate, root, stat);
+    if (pathError) return emptyResult(filePath, 'UNTRUSTED', [pathError]);
 
     const bytes = readExactly(fd, stat.size);
+    const finalStat = fs.fstatSync(fd);
+    const finalPathError = validateOpenedPath(fd, candidate, root, finalStat);
+    if (finalPathError || !sameFile(stat, finalStat) || stat.size !== finalStat.size
+      || stat.mtimeMs !== finalStat.mtimeMs || stat.ctimeMs !== finalStat.ctimeMs) {
+      return emptyResult(filePath, 'UNTRUSTED', [finalPathError ?? 'session changed while it was being inspected']);
+    }
     const hasTornTail = bytes[bytes.length - 1] !== 0x0a;
     let text: string;
     try {

--- a/src/mcp/services/session-resume.ts
+++ b/src/mcp/services/session-resume.ts
@@ -1,257 +1,180 @@
-/**
- * Agentic QE v3 - Session Resume Service
- *
- * IMP-04: Transcript-First Session Durability
- * Reads an existing JSONL session file by sampling the head (first 4KB)
- * and tail (last 64KB) to reconstruct metadata and recent entries
- * without reading the entire file.
- *
- * @module mcp/services/session-resume
- */
-
+/** Bounded, fail-closed recovery for legacy JSONL session transcripts. */
 import * as fs from 'fs';
 import * as path from 'path';
 import type { SessionEntry, SessionMetadata } from './session-store';
 
-// ============================================================================
-// Types
-// ============================================================================
+export type SessionRecoveryDisposition =
+  | 'MISSING' | 'EMPTY' | 'LEGACY_UNVERIFIED' | 'INVALID' | 'UNTRUSTED' | 'RESOURCE_LIMIT';
+
+export interface SessionResumeOptions {
+  /** Canonical directory that must contain the session file. */
+  sessionRoot: string;
+  /** Explicit compatibility opt-in; legacy JSONL has no commit proof. */
+  allowLegacyUnverified?: boolean;
+  maxFileBytes?: number;
+  maxRecordBytes?: number;
+  maxRecords?: number;
+}
 
 export interface SessionResumeResult {
   metadata: SessionMetadata;
   recentEntries: SessionEntry[];
   lastState: 'idle' | 'running' | 'requires_action';
   canResume: boolean;
+  disposition: SessionRecoveryDisposition;
+  diagnostics: string[];
 }
 
-// ============================================================================
-// Constants
-// ============================================================================
+const DEFAULT_MAX_FILE_BYTES = 16 * 1024 * 1024;
+const DEFAULT_MAX_RECORD_BYTES = 1024 * 1024;
+const DEFAULT_MAX_RECORDS = 100_000;
+const RECENT_ENTRY_LIMIT = 256;
+const ENTRY_TYPES = new Set(['tool_call', 'tool_result', 'state_change', 'error']);
+const ENTRY_STATES = new Set(['idle', 'running', 'requires_action']);
 
-const HEAD_BYTES = 4 * 1024;  // 4KB
-const TAIL_BYTES = 64 * 1024; // 64KB
-
-// ============================================================================
-// Public API
-// ============================================================================
-
-/**
- * Resume a session from a JSONL file.
- *
- * Reads the first 4KB (head) to extract session start metadata and
- * the last 64KB (tail) to get recent entries. Parses JSONL lines,
- * reconstructs the parentUuid linked list, and returns metadata +
- * recent entries + resume capability.
- *
- * Corrupt or incomplete lines are skipped gracefully.
- */
-export function resumeSession(filePath: string): SessionResumeResult {
-  // If file doesn't exist, return non-resumable result
-  if (!fs.existsSync(filePath)) {
-    return {
-      metadata: {
-        sessionId: extractSessionId(filePath),
-        createdAt: 0,
-        lastActivityAt: 0,
-        entryCount: 0,
-        state: 'idle',
-      },
-      recentEntries: [],
-      lastState: 'idle',
-      canResume: false,
-    };
-  }
-
-  const stat = fs.statSync(filePath);
-  const fileSize = stat.size;
-
-  if (fileSize === 0) {
-    return {
-      metadata: {
-        sessionId: extractSessionId(filePath),
-        createdAt: 0,
-        lastActivityAt: 0,
-        entryCount: 0,
-        state: 'idle',
-      },
-      recentEntries: [],
-      lastState: 'idle',
-      canResume: false,
-    };
-  }
-
-  // Read head (first 4KB)
-  const headEntries = readHead(filePath, fileSize);
-
-  // Read tail (last 64KB)
-  const tailEntries = readTail(filePath, fileSize);
-
-  // Merge and deduplicate: use a Map keyed by uuid to ensure uniqueness
-  const entryMap = new Map<string, SessionEntry>();
-  for (const entry of headEntries) {
-    entryMap.set(entry.uuid, entry);
-  }
-  for (const entry of tailEntries) {
-    entryMap.set(entry.uuid, entry);
-  }
-
-  const allEntries = Array.from(entryMap.values());
-  allEntries.sort((a, b) => a.timestamp - b.timestamp);
-
-  // Reconstruct metadata from available entries
-  const firstEntry = headEntries[0] ?? allEntries[0];
-  const lastEntry = tailEntries[tailEntries.length - 1] ?? allEntries[allEntries.length - 1];
-
-  // For entry count: if file is small enough that head+tail overlap,
-  // allEntries.length is accurate. Otherwise, count total lines.
-  let entryCount: number;
-  if (fileSize <= HEAD_BYTES + TAIL_BYTES) {
-    entryCount = allEntries.length;
-  } else {
-    entryCount = countLines(filePath);
-  }
-
-  const lastState = lastEntry?.state ?? 'idle';
-
-  const metadata: SessionMetadata = {
-    sessionId: extractSessionId(filePath),
-    createdAt: firstEntry?.timestamp ?? 0,
-    lastActivityAt: lastEntry?.timestamp ?? 0,
-    entryCount,
-    state: lastState,
-  };
-
+function emptyResult(filePath: string, disposition: SessionRecoveryDisposition, diagnostics: string[] = []): SessionResumeResult {
   return {
-    metadata,
-    recentEntries: tailEntries,
-    lastState,
-    canResume: allEntries.length > 0,
+    metadata: {
+      sessionId: path.basename(filePath, '.jsonl'), createdAt: 0, lastActivityAt: 0,
+      entryCount: 0, state: 'idle',
+    },
+    recentEntries: [], lastState: 'idle', canResume: false, disposition, diagnostics,
   };
 }
 
-// ============================================================================
-// Private helpers
-// ============================================================================
-
-/**
- * Extract session ID from file path (filename without extension).
- */
-function extractSessionId(filePath: string): string {
-  return path.basename(filePath, '.jsonl');
+function isWithin(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative === '' || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative));
 }
 
-/**
- * Read and parse the first HEAD_BYTES of the file.
- */
-function readHead(filePath: string, fileSize: number): SessionEntry[] {
-  const bytesToRead = Math.min(HEAD_BYTES, fileSize);
-  const fd = fs.openSync(filePath, 'r');
-  try {
-    const buffer = Buffer.alloc(bytesToRead);
-    fs.readSync(fd, buffer, 0, bytesToRead, 0);
-    const text = buffer.toString('utf-8');
-    return parseJsonlLines(text, /* isHead */ true);
-  } finally {
-    fs.closeSync(fd);
+function isValidEntry(value: unknown): value is SessionEntry {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const entry = value as Record<string, unknown>;
+  return typeof entry.uuid === 'string' && entry.uuid.length > 0
+    && (entry.parentUuid === null || typeof entry.parentUuid === 'string')
+    && typeof entry.timestamp === 'number' && Number.isFinite(entry.timestamp)
+    && typeof entry.type === 'string' && ENTRY_TYPES.has(entry.type)
+    && typeof entry.state === 'string' && ENTRY_STATES.has(entry.state);
+}
+
+function readExactly(fd: number, fileSize: number): Buffer {
+  const buffer = Buffer.alloc(fileSize);
+  let offset = 0;
+  while (offset < fileSize) {
+    const count = fs.readSync(fd, buffer, offset, fileSize - offset, offset);
+    if (count === 0) throw new Error('unexpected EOF while reading session transcript');
+    offset += count;
   }
+  return buffer;
 }
 
 /**
- * Read and parse the last TAIL_BYTES of the file.
+ * Inspect a legacy transcript through one no-follow descriptor. Automatic
+ * resume requires an explicit opt-in because this format has no commit marker.
  */
-function readTail(filePath: string, fileSize: number): SessionEntry[] {
-  const bytesToRead = Math.min(TAIL_BYTES, fileSize);
-  const offset = Math.max(0, fileSize - bytesToRead);
-  const fd = fs.openSync(filePath, 'r');
+export function resumeSession(filePath: string, options: SessionResumeOptions): SessionResumeResult {
+  const maxFileBytes = options.maxFileBytes ?? DEFAULT_MAX_FILE_BYTES;
+  const maxRecordBytes = options.maxRecordBytes ?? DEFAULT_MAX_RECORD_BYTES;
+  const maxRecords = options.maxRecords ?? DEFAULT_MAX_RECORDS;
+  const candidate = path.resolve(filePath);
+
+  let root: string;
+  let parent: string;
   try {
-    const buffer = Buffer.alloc(bytesToRead);
-    fs.readSync(fd, buffer, 0, bytesToRead, offset);
-    const text = buffer.toString('utf-8');
-    // When offset is 0, we read from the start of the file so
-    // the first line is complete -- don't skip it.
-    const isMidFileRead = offset > 0;
-    return parseJsonlLines(text, /* isHead */ false, isMidFileRead);
-  } finally {
-    fs.closeSync(fd);
+    root = fs.realpathSync(options.sessionRoot);
+    parent = fs.realpathSync(path.dirname(candidate));
+  } catch {
+    return emptyResult(filePath, 'UNTRUSTED', ['session root or parent cannot be resolved']);
   }
-}
+  if (!isWithin(root, parent)) {
+    return emptyResult(filePath, 'UNTRUSTED', ['session path escapes the configured root']);
+  }
 
-/**
- * Parse JSONL text into SessionEntry[], skipping corrupt/incomplete lines.
- * When reading from a mid-file offset (tail), the first partial line is skipped.
- * When reading head, the last partial line is skipped if the chunk doesn't
- * end with a newline.
- *
- * @param text - Raw text from the file chunk
- * @param isHead - Whether this is a head read (skip trailing partial line)
- * @param skipFirstLine - Whether to skip the first line (true for mid-file
- *   tail reads where the first line is likely a partial). Defaults to !isHead.
- */
-function parseJsonlLines(
-  text: string,
-  isHead: boolean,
-  skipFirstLine?: boolean,
-): SessionEntry[] {
-  const lines = text.split('\n');
-  const entries: SessionEntry[] = [];
+  let linkStat: fs.Stats;
+  try {
+    linkStat = fs.lstatSync(candidate);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    return emptyResult(filePath, code === 'ENOENT' ? 'MISSING' : 'UNTRUSTED', [`lstat failed: ${code ?? 'UNKNOWN'}`]);
+  }
+  if (linkStat.isSymbolicLink() || !linkStat.isFile()) {
+    return emptyResult(filePath, 'UNTRUSTED', ['session path is not a regular, non-symlink file']);
+  }
 
-  // Default: skip first line for non-head reads (standard tail behavior)
-  const shouldSkipFirst = skipFirstLine ?? !isHead;
+  let fd: number | undefined;
+  try {
+    fd = fs.openSync(candidate, fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0));
+    const stat = fs.fstatSync(fd);
+    if (!stat.isFile() || stat.nlink !== 1) {
+      return emptyResult(filePath, 'UNTRUSTED', ['opened session is not an exclusive regular file']);
+    }
+    if (stat.size === 0) return emptyResult(filePath, 'EMPTY');
+    if (stat.size > maxFileBytes) {
+      return emptyResult(filePath, 'RESOURCE_LIMIT', [`file exceeds ${maxFileBytes} bytes`]);
+    }
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i].trim();
-    if (!line) continue;
-
-    // Skip first line of mid-file tail read (may be partial)
-    if (shouldSkipFirst && i === 0 && lines.length > 1) continue;
-    // Skip last line of head read if it may be truncated
-    if (isHead && i === lines.length - 1 && lines.length > 1 && !text.endsWith('\n')) continue;
-
+    const bytes = readExactly(fd, stat.size);
+    const hasTornTail = bytes[bytes.length - 1] !== 0x0a;
+    let text: string;
     try {
-      const entry = JSON.parse(line) as SessionEntry;
-      if (isValidEntry(entry)) {
-        entries.push(entry);
-      }
+      text = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
     } catch {
-      // Skip corrupt lines
-      continue;
+      return emptyResult(filePath, 'INVALID', ['transcript is not valid UTF-8']);
     }
-  }
+    const lines = text.split('\n');
+    if (hasTornTail) lines.pop();
+    const entries: SessionEntry[] = [];
+    const seen = new Set<string>();
+    let previous: SessionEntry | undefined;
 
-  return entries;
-}
-
-/**
- * Minimal validation that a parsed object looks like a SessionEntry.
- */
-function isValidEntry(obj: unknown): obj is SessionEntry {
-  if (typeof obj !== 'object' || obj === null) return false;
-  const entry = obj as Record<string, unknown>;
-  return (
-    typeof entry.uuid === 'string' &&
-    typeof entry.timestamp === 'number' &&
-    typeof entry.type === 'string' &&
-    typeof entry.state === 'string'
-  );
-}
-
-/**
- * Count total lines in a file (for large files where head+tail don't overlap).
- * Only counts non-empty lines that parse as valid JSON.
- */
-function countLines(filePath: string): number {
-  const content = fs.readFileSync(filePath, 'utf-8');
-  let count = 0;
-  for (const line of content.split('\n')) {
-    const trimmed = line.trim();
-    if (trimmed) {
-      try {
-        JSON.parse(trimmed);
-        count++;
-      } catch {
-        // Skip corrupt lines in count
+    for (const rawLine of lines) {
+      if (!rawLine.trim()) continue;
+      if (Buffer.byteLength(rawLine, 'utf8') > maxRecordBytes) {
+        return emptyResult(filePath, 'RESOURCE_LIMIT', [`record exceeds ${maxRecordBytes} bytes`]);
       }
+      if (entries.length >= maxRecords) {
+        return emptyResult(filePath, 'RESOURCE_LIMIT', [`record count exceeds ${maxRecords}`]);
+      }
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(rawLine);
+      } catch {
+        return emptyResult(filePath, 'INVALID', ['corrupt JSON occurs before the final torn record']);
+      }
+      if (!isValidEntry(parsed)) return emptyResult(filePath, 'INVALID', ['entry fails the session schema']);
+      if (seen.has(parsed.uuid)) return emptyResult(filePath, 'INVALID', ['duplicate entry UUID']);
+      if (previous) {
+        if (parsed.parentUuid !== previous.uuid) return emptyResult(filePath, 'INVALID', ['broken parentUuid lineage']);
+        if (parsed.timestamp < previous.timestamp) return emptyResult(filePath, 'INVALID', ['timestamps are not monotonic']);
+      } else if (parsed.parentUuid !== null) {
+        return emptyResult(filePath, 'INVALID', ['first entry has a forged parentUuid']);
+      }
+      seen.add(parsed.uuid);
+      entries.push(parsed);
+      previous = parsed;
     }
+
+    if (entries.length === 0) {
+      return emptyResult(filePath, hasTornTail ? 'INVALID' : 'EMPTY', hasTornTail ? ['only record is torn'] : []);
+    }
+    const lastEntry = entries[entries.length - 1];
+    const diagnostics = [
+      'legacy JSONL has no durable commit marker',
+      ...(hasTornTail ? ['discarded an incomplete final record'] : []),
+    ];
+    return {
+      metadata: {
+        sessionId: path.basename(filePath, '.jsonl'), createdAt: entries[0].timestamp,
+        lastActivityAt: lastEntry.timestamp, entryCount: entries.length, state: lastEntry.state,
+      },
+      recentEntries: entries.slice(-RECENT_ENTRY_LIMIT), lastState: lastEntry.state,
+      canResume: options.allowLegacyUnverified === true,
+      disposition: 'LEGACY_UNVERIFIED', diagnostics,
+    };
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    return emptyResult(filePath, 'UNTRUSTED', [`secure open/read failed: ${code ?? 'UNKNOWN'}`]);
+  } finally {
+    if (fd !== undefined) fs.closeSync(fd);
   }
-  return count;
 }

--- a/src/mcp/services/session-resume.ts
+++ b/src/mcp/services/session-resume.ts
@@ -187,7 +187,13 @@ export function resumeSession(filePath: string, options: SessionResumeOptions): 
       return emptyResult(filePath, 'INVALID', ['transcript is not valid UTF-8']);
     }
     const lines = text.split('\n');
-    if (hasTornTail) lines.pop();
+    if (hasTornTail) {
+      const tornTail = lines[lines.length - 1] ?? '';
+      if (Buffer.byteLength(tornTail, 'utf8') > maxRecordBytes) {
+        return emptyResult(filePath, 'RESOURCE_LIMIT', [`record exceeds ${maxRecordBytes} bytes`]);
+      }
+      lines.pop();
+    }
     const entries: SessionEntry[] = [];
     const seen = new Set<string>();
     let previous: SessionEntry | undefined;

--- a/src/mcp/services/session-resume.ts
+++ b/src/mcp/services/session-resume.ts
@@ -162,6 +162,9 @@ export function resumeSession(filePath: string, options: SessionResumeOptions): 
   try {
     fd = fs.openSync(candidate, fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0));
     const stat = fs.fstatSync(fd);
+    if (!sameFile(linkStat, stat)) {
+      return emptyResult(filePath, 'UNTRUSTED', ['session path changed before secure open']);
+    }
     if (!stat.isFile() || stat.nlink !== 1) {
       return emptyResult(filePath, 'UNTRUSTED', ['opened session is not an exclusive regular file']);
     }
@@ -180,20 +183,23 @@ export function resumeSession(filePath: string, options: SessionResumeOptions): 
       return emptyResult(filePath, 'UNTRUSTED', [finalPathError ?? 'session changed while it was being inspected']);
     }
     const hasTornTail = bytes[bytes.length - 1] !== 0x0a;
+    let committedBytes = bytes;
+    if (hasTornTail) {
+      const finalLineBreak = bytes.lastIndexOf(0x0a);
+      const tornTailStart = finalLineBreak + 1;
+      const tornTailBytes = bytes.length - tornTailStart;
+      if (tornTailBytes > maxRecordBytes) {
+        return emptyResult(filePath, 'RESOURCE_LIMIT', [`record exceeds ${maxRecordBytes} bytes`]);
+      }
+      committedBytes = bytes.subarray(0, tornTailStart);
+    }
     let text: string;
     try {
-      text = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+      text = new TextDecoder('utf-8', { fatal: true }).decode(committedBytes);
     } catch {
       return emptyResult(filePath, 'INVALID', ['transcript is not valid UTF-8']);
     }
     const lines = text.split('\n');
-    if (hasTornTail) {
-      const tornTail = lines[lines.length - 1] ?? '';
-      if (Buffer.byteLength(tornTail, 'utf8') > maxRecordBytes) {
-        return emptyResult(filePath, 'RESOURCE_LIMIT', [`record exceeds ${maxRecordBytes} bytes`]);
-      }
-      lines.pop();
-    }
     const entries: SessionEntry[] = [];
     const seen = new Set<string>();
     let previous: SessionEntry | undefined;

--- a/tests/mcp/services/session-resume.test.ts
+++ b/tests/mcp/services/session-resume.test.ts
@@ -269,6 +269,28 @@ describe('resumeSession', () => {
       }
     });
 
+    it('should reject a final-file substitution between lstat and open', () => {
+      const filePath = path.join(tmpDir, 'session.jsonl');
+      const displacedPath = path.join(tmpDir, 'session-original.jsonl');
+      const replacementPath = path.join(tmpDir, 'session-replacement.jsonl');
+      writeJsonlFile(filePath, buildLinkedEntries(1));
+      writeJsonlFile(replacementPath, buildLinkedEntries(1));
+
+      fsOpenControl.beforeOpen = () => {
+        fs.renameSync(filePath, displacedPath);
+        fs.renameSync(replacementPath, filePath);
+      };
+
+      const result = inspectSession(filePath, {
+        sessionRoot: tmpDir,
+        allowLegacyUnverified: true,
+      });
+
+      expect(result.canResume).toBe(false);
+      expect(result.disposition).toBe('UNTRUSTED');
+      expect(result.diagnostics).toContain('session path changed before secure open');
+    });
+
     it('should reject a broken parent lineage instead of reconstructing a suffix', () => {
       const filePath = path.join(tmpDir, 'broken-chain.jsonl');
       const entries = buildLinkedEntries(3);
@@ -324,6 +346,22 @@ describe('resumeSession', () => {
 
       expect(result.disposition).toBe('RESOURCE_LIMIT');
       expect(result.diagnostics).toContain(`record exceeds ${maxRecordBytes} bytes`);
+    });
+
+    it('should discard a torn tail ending midway through a UTF-8 sequence', () => {
+      const filePath = path.join(tmpDir, 'partial-utf8-tail.jsonl');
+      const entryLine = Buffer.from(`${JSON.stringify(buildLinkedEntries(1)[0])}\n`, 'utf8');
+      fs.writeFileSync(filePath, Buffer.concat([entryLine, Buffer.from([0xe2, 0x82])]));
+
+      const result = inspectSession(filePath, {
+        sessionRoot: tmpDir,
+        allowLegacyUnverified: true,
+      });
+
+      expect(result.canResume).toBe(true);
+      expect(result.disposition).toBe('LEGACY_UNVERIFIED');
+      expect(result.metadata.entryCount).toBe(1);
+      expect(result.diagnostics).toContain('discarded an incomplete final record');
     });
 
     it.each([

--- a/tests/mcp/services/session-resume.test.ts
+++ b/tests/mcp/services/session-resume.test.ts
@@ -5,13 +5,28 @@
  * - bounded full-file validation with a capped recent-entry projection
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { randomUUID } from 'crypto';
 import { resumeSession as inspectSession } from '../../../src/mcp/services/session-resume';
 import type { SessionEntry } from '../../../src/mcp/services/session-store';
+
+const fsOpenControl = vi.hoisted(() => ({ beforeOpen: undefined as (() => void) | undefined }));
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    openSync: (...args: unknown[]) => {
+      const beforeOpen = fsOpenControl.beforeOpen;
+      fsOpenControl.beforeOpen = undefined;
+      beforeOpen?.();
+      return Reflect.apply(actual.openSync, actual, args);
+    },
+  };
+});
 
 // ============================================================================
 // Helpers
@@ -77,6 +92,7 @@ describe('resumeSession', () => {
   });
 
   afterEach(() => {
+    fsOpenControl.beforeOpen = undefined;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -227,6 +243,32 @@ describe('resumeSession', () => {
       }
     });
 
+    it('should reject an intermediate-directory substitution at open time', () => {
+      const trustedParent = path.join(tmpDir, 'slot');
+      const displacedParent = path.join(tmpDir, 'slot-original');
+      const outsideParent = fs.mkdtempSync(path.join(os.tmpdir(), 'session-resume-outside-'));
+      const fileName = 'substituted.jsonl';
+      fs.mkdirSync(trustedParent);
+      writeJsonlFile(path.join(trustedParent, fileName), buildLinkedEntries(1));
+      writeJsonlFile(path.join(outsideParent, fileName), buildLinkedEntries(1));
+
+      fsOpenControl.beforeOpen = () => {
+        fs.renameSync(trustedParent, displacedParent);
+        fs.symlinkSync(outsideParent, trustedParent, 'dir');
+      };
+
+      try {
+        const result = inspectSession(path.join(trustedParent, fileName), {
+          sessionRoot: tmpDir,
+          allowLegacyUnverified: true,
+        });
+
+        expect(result.disposition).toBe('UNTRUSTED');
+      } finally {
+        fs.rmSync(outsideParent, { recursive: true, force: true });
+      }
+    });
+
     it('should reject a broken parent lineage instead of reconstructing a suffix', () => {
       const filePath = path.join(tmpDir, 'broken-chain.jsonl');
       const entries = buildLinkedEntries(3);
@@ -250,6 +292,42 @@ describe('resumeSession', () => {
 
       expect(result.canResume).toBe(false);
       expect(result.disposition).toBe('RESOURCE_LIMIT');
+    });
+
+    it.each([
+      ['infinite file size', { maxFileBytes: Number.POSITIVE_INFINITY }],
+      ['NaN record size', { maxRecordBytes: Number.NaN }],
+      ['zero record count', { maxRecords: 0 }],
+      ['file size above the hard ceiling', { maxFileBytes: 16 * 1024 * 1024 + 1 }],
+    ])('should reject the %s limit override', (_label, limits) => {
+      const filePath = path.join(tmpDir, 'invalid-limit.jsonl');
+      writeJsonlFile(filePath, buildLinkedEntries(1));
+
+      const result = inspectSession(filePath, {
+        sessionRoot: tmpDir,
+        allowLegacyUnverified: true,
+        ...limits,
+      });
+
+      expect(result.disposition).toBe('RESOURCE_LIMIT');
+    });
+
+    it.each([
+      ['malformed UUID', { uuid: 'not-a-uuid' }],
+      ['malformed parent UUID', { parentUuid: 'not-a-uuid' }],
+      ['negative timestamp', { timestamp: -1 }],
+      ['empty tool name', { toolName: '' }],
+      ['array params', { params: [] }],
+      ['negative token estimate', { tokenEstimate: -1 }],
+      ['unknown schema field', { schemaVersion: 99 }],
+    ])('should reject an entry with %s', (_label, mutation) => {
+      const filePath = path.join(tmpDir, 'malformed-entry.jsonl');
+      const entry = { ...buildLinkedEntries(1)[0], ...mutation };
+      fs.writeFileSync(filePath, `${JSON.stringify(entry)}\n`, 'utf8');
+
+      const result = resumeSession(filePath);
+
+      expect(result.disposition).toBe('INVALID');
     });
 
     it('should reject invalid UTF-8 before JSON parsing', () => {

--- a/tests/mcp/services/session-resume.test.ts
+++ b/tests/mcp/services/session-resume.test.ts
@@ -2,7 +2,7 @@
  * IMP-04: Session Resume Tests
  * Verifies session resumption from JSONL files including:
  * - well-formed files, corrupt lines, missing files
- * - head+tail reading behavior for large files
+ * - bounded full-file validation with a capped recent-entry projection
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -10,7 +10,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { randomUUID } from 'crypto';
-import { resumeSession } from '../../../src/mcp/services/session-resume';
+import { resumeSession as inspectSession } from '../../../src/mcp/services/session-resume';
 import type { SessionEntry } from '../../../src/mcp/services/session-store';
 
 // ============================================================================
@@ -18,6 +18,11 @@ import type { SessionEntry } from '../../../src/mcp/services/session-store';
 // ============================================================================
 
 let tmpDir: string;
+
+const resumeSession = (filePath: string) => inspectSession(filePath, {
+  sessionRoot: tmpDir,
+  allowLegacyUnverified: true,
+});
 
 function createTmpDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'session-resume-test-'));
@@ -123,7 +128,7 @@ describe('resumeSession', () => {
   });
 
   describe('corrupt lines', () => {
-    it('should skip corrupt lines and parse valid ones', () => {
+    it('should reject corrupt lines in the recoverable prefix', () => {
       const sessionId = randomUUID();
       const filePath = path.join(tmpDir, `${sessionId}.jsonl`);
 
@@ -138,9 +143,9 @@ describe('resumeSession', () => {
 
       const result = resumeSession(filePath);
 
-      // Should have parsed the 5 valid entries, skipping 2 corrupt ones
-      expect(result.canResume).toBe(true);
-      expect(result.metadata.entryCount).toBe(5);
+      expect(result.canResume).toBe(false);
+      expect(result.disposition).toBe('INVALID');
+      expect(result.metadata.entryCount).toBe(0);
     });
 
     it('should handle a file that is entirely corrupt', () => {
@@ -185,19 +190,91 @@ describe('resumeSession', () => {
     });
   });
 
-  describe('head+tail reading for large files', () => {
-    it('should not read the entire middle of a large file', () => {
+  describe('trust and integrity boundary', () => {
+    it('should require explicit opt-in before resuming an uncommitted legacy transcript', () => {
+      const filePath = path.join(tmpDir, 'legacy.jsonl');
+      writeJsonlFile(filePath, buildLinkedEntries(2));
+
+      const result = inspectSession(filePath, { sessionRoot: tmpDir });
+
+      expect(result.canResume).toBe(false);
+      expect(result.disposition).toBe('LEGACY_UNVERIFIED');
+      expect(result.diagnostics).toContain('legacy JSONL has no durable commit marker');
+    });
+
+    it('should reject a symlink without reading its target', () => {
+      const target = path.join(tmpDir, 'target.jsonl');
+      const link = path.join(tmpDir, 'link.jsonl');
+      writeJsonlFile(target, buildLinkedEntries(2));
+      fs.symlinkSync(target, link);
+
+      const result = inspectSession(link, { sessionRoot: tmpDir, allowLegacyUnverified: true });
+
+      expect(result.canResume).toBe(false);
+      expect(result.disposition).toBe('UNTRUSTED');
+      expect(result.metadata.entryCount).toBe(0);
+    });
+
+    it('should reject a path outside the configured session root', () => {
+      const outside = path.join(os.tmpdir(), `outside-${randomUUID()}.jsonl`);
+      writeJsonlFile(outside, buildLinkedEntries(1));
+      try {
+        const result = inspectSession(outside, { sessionRoot: tmpDir, allowLegacyUnverified: true });
+        expect(result.canResume).toBe(false);
+        expect(result.disposition).toBe('UNTRUSTED');
+      } finally {
+        fs.unlinkSync(outside);
+      }
+    });
+
+    it('should reject a broken parent lineage instead of reconstructing a suffix', () => {
+      const filePath = path.join(tmpDir, 'broken-chain.jsonl');
+      const entries = buildLinkedEntries(3);
+      entries[1].parentUuid = randomUUID();
+      writeJsonlFile(filePath, entries);
+
+      const result = resumeSession(filePath);
+
+      expect(result.canResume).toBe(false);
+      expect(result.disposition).toBe('INVALID');
+      expect(result.diagnostics).toContain('broken parentUuid lineage');
+    });
+
+    it('should enforce the file-size bound before parsing', () => {
+      const filePath = path.join(tmpDir, 'oversized.jsonl');
+      writeJsonlFile(filePath, buildLinkedEntries(2));
+
+      const result = inspectSession(filePath, {
+        sessionRoot: tmpDir, allowLegacyUnverified: true, maxFileBytes: 8,
+      });
+
+      expect(result.canResume).toBe(false);
+      expect(result.disposition).toBe('RESOURCE_LIMIT');
+    });
+
+    it('should reject invalid UTF-8 before JSON parsing', () => {
+      const filePath = path.join(tmpDir, 'invalid-utf8.jsonl');
+      fs.writeFileSync(filePath, Buffer.from([0xc3, 0x28, 0x0a]));
+
+      const result = resumeSession(filePath);
+
+      expect(result.canResume).toBe(false);
+      expect(result.disposition).toBe('INVALID');
+      expect(result.diagnostics).toContain('transcript is not valid UTF-8');
+    });
+  });
+
+  describe('bounded validation for larger files', () => {
+    it('should validate the full bounded transcript and cap returned recent entries', () => {
       const sessionId = randomUUID();
       const filePath = path.join(tmpDir, `${sessionId}.jsonl`);
 
-      // Create a file large enough that head (4KB) + tail (64KB) < total size
-      // Each entry is roughly 200 bytes. We need > 68KB = ~350 entries
+      // Create enough entries to exceed the recent-entry projection.
       const entries = buildLinkedEntries(500, 10000);
       writeJsonlFile(filePath, entries);
 
       const stat = fs.statSync(filePath);
-      // Verify file is larger than head + tail combined
-      expect(stat.size).toBeGreaterThan(4 * 1024 + 64 * 1024);
+      expect(stat.size).toBeGreaterThan(64 * 1024);
 
       const result = resumeSession(filePath);
 
@@ -206,8 +283,7 @@ describe('resumeSession', () => {
       expect(result.metadata.createdAt).toBe(10000);
       expect(result.metadata.lastActivityAt).toBe(10499);
 
-      // Recent entries should come from the tail and NOT include all 500
-      // (head parses ~20 entries from 4KB, tail parses ~300 from 64KB)
+      // Full validation counts every entry while the returned projection stays bounded.
       expect(result.recentEntries.length).toBeGreaterThan(0);
       expect(result.recentEntries.length).toBeLessThan(500);
 

--- a/tests/mcp/services/session-resume.test.ts
+++ b/tests/mcp/services/session-resume.test.ts
@@ -294,6 +294,38 @@ describe('resumeSession', () => {
       expect(result.disposition).toBe('RESOURCE_LIMIT');
     });
 
+    it('should discard a torn tail exactly at the record-size limit', () => {
+      const filePath = path.join(tmpDir, 'bounded-torn-tail.jsonl');
+      const entryLine = JSON.stringify(buildLinkedEntries(1)[0]);
+      const maxRecordBytes = Buffer.byteLength(entryLine, 'utf8');
+      fs.writeFileSync(filePath, `${entryLine}\n${'x'.repeat(maxRecordBytes)}`, 'utf8');
+
+      const result = inspectSession(filePath, {
+        sessionRoot: tmpDir,
+        allowLegacyUnverified: true,
+        maxRecordBytes,
+      });
+
+      expect(result.disposition).toBe('LEGACY_UNVERIFIED');
+      expect(result.diagnostics).toContain('discarded an incomplete final record');
+    });
+
+    it('should reject a torn tail one byte above the record-size limit', () => {
+      const filePath = path.join(tmpDir, 'oversized-torn-tail.jsonl');
+      const entryLine = JSON.stringify(buildLinkedEntries(1)[0]);
+      const maxRecordBytes = Buffer.byteLength(entryLine, 'utf8');
+      fs.writeFileSync(filePath, `${entryLine}\n${'x'.repeat(maxRecordBytes + 1)}`, 'utf8');
+
+      const result = inspectSession(filePath, {
+        sessionRoot: tmpDir,
+        allowLegacyUnverified: true,
+        maxRecordBytes,
+      });
+
+      expect(result.disposition).toBe('RESOURCE_LIMIT');
+      expect(result.diagnostics).toContain(`record exceeds ${maxRecordBytes} bytes`);
+    });
+
     it.each([
       ['infinite file size', { maxFileBytes: Number.POSITIVE_INFINITY }],
       ['NaN record size', { maxRecordBytes: Number.NaN }],


### PR DESCRIPTION
## Summary

Implements the first fail-closed recovery slice from #659. Session inspection now requires a configured root, opens one non-following descriptor, accepts only an exclusive regular file, bounds file/record/count work, validates UTF-8 and every entry, and rejects corrupt, duplicate, reordered, or broken-parent lineages. Legacy JSONL is explicitly `LEGACY_UNVERIFIED` and cannot authorize resume unless the caller opts into compatibility mode.

This does not close #659. Durable writer commit records, fsync policy, crash-position testing, and retry-of-retry lineage remain tracked there.

## Verification

- `npm test -- --run tests/mcp/services/session-resume.test.ts`: 31 passed
- `npm run typecheck`: pass
- focused ESLint on `session-resume.ts`: pass
- `npm run build`: pass
- `git diff --check`: pass

## Failure modes

- Symlink, root-escape, and deterministic intermediate-directory and final-file substitution reads are exercised by filesystem adversary tests.
- Middle corruption, forged parent links, invalid UTF-8, invalid limit overrides, oversized files, exact/+1 torn-record byte boundaries, and partial multibyte torn tails are exercised by focused negative tests.
- Legacy transcripts lack commit evidence and therefore require explicit opt-in; committed writer format and crash consistency remain tracked by #659.

---

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.** "Unlikely" is not an acceptable substitute. If you wrote "I don't think this can happen but...", that sentence is a failure mode and needs a test or an issue link.

### Optional context

- Linked issues: #659
- Trust tier change (if any): legacy automatic resume → explicit unverified opt-in
- Affects published API or CLI surface: internal MCP service signature and result contract
- Touches the init flow / `npm-publish.yml` / `tests/fixtures/init-corpus/`: no


