### PR TITLE
feat(learning): expose partial pattern mutation failures

### DIFF
--- a/src/learning/index.ts
+++ b/src/learning/index.ts
@@ -160,6 +160,9 @@ export {
   DEFAULT_PATTERN_STORE_CONFIG,
 } from './pattern-store.js';
 
+export { PatternMutationError } from './pattern-mutation-error.js';
+export type { PatternMutationDisposition } from './pattern-mutation-error.js';
+
 export type {
   IPatternStore,
   PatternStoreConfig,

--- a/src/learning/pattern-mutation-error.ts
+++ b/src/learning/pattern-mutation-error.ts
@@ -1,0 +1,16 @@
+export type PatternMutationDisposition = 'FAILED' | 'COMMITTED_PENDING_INDEX';
+
+/** Error evidence that distinguishes an uncommitted write from index lag. */
+export class PatternMutationError extends Error {
+  readonly patternId: string;
+  readonly disposition: PatternMutationDisposition;
+  override readonly cause: unknown;
+
+  constructor(patternId: string, disposition: PatternMutationDisposition, cause: unknown) {
+    super(`${disposition}: pattern ${patternId}: ${cause instanceof Error ? cause.message : String(cause)}`);
+    this.name = 'PatternMutationError';
+    this.patternId = patternId;
+    this.disposition = disposition;
+    this.cause = cause;
+  }
+}

--- a/src/learning/pattern-store.ts
+++ b/src/learning/pattern-store.ts
@@ -822,6 +822,14 @@ export class PatternStore implements IPatternStore {
         )
       );
     }
+    const persistentBackend = (process.env.AQE_MEMORY_BACKEND ?? 'memory') !== 'memory';
+    if (persistentBackend && !this.sqliteStore) {
+      return err(new PatternMutationError(
+        pattern.id,
+        'FAILED',
+        new Error('authoritative SQLite pattern store is unavailable'),
+      ));
+    }
     const activeSpaceId = getActiveEmbeddingSpaceIdentity()?.spaceId ?? this.config.embeddingSpaceId;
     if (pattern.embedding && !activeSpaceId) {
       return err(new Error('VECTOR_SPACE_UNVERIFIED: refusing to persist or index an embedding without runtime provenance'));
@@ -878,7 +886,7 @@ export class PatternStore implements IPatternStore {
           new Error('HNSW unavailable after authoritative pattern commit'),
         ));
       }
-      if (!hnsw && (process.env.AQE_MEMORY_BACKEND ?? 'memory') !== 'memory') {
+      if (!hnsw && persistentBackend) {
         rollbackUncommittedCache();
         return err(new PatternMutationError(
           pattern.id,

--- a/src/learning/pattern-store.ts
+++ b/src/learning/pattern-store.ts
@@ -878,7 +878,7 @@ export class PatternStore implements IPatternStore {
           new Error('HNSW unavailable after authoritative pattern commit'),
         ));
       }
-      if (!hnsw && process.env.AQE_MEMORY_BACKEND !== 'memory') {
+      if (!hnsw && (process.env.AQE_MEMORY_BACKEND ?? 'memory') !== 'memory') {
         rollbackUncommittedCache();
         return err(new PatternMutationError(
           pattern.id,

--- a/src/learning/pattern-store.ts
+++ b/src/learning/pattern-store.ts
@@ -865,6 +865,13 @@ export class PatternStore implements IPatternStore {
     // Add to HNSW if embedding is available (lazy-load HNSW only when needed)
     if (pattern.embedding) {
       const hnsw = await this.ensureHNSW();
+      if (!hnsw && this.sqliteStore) {
+        return err(new PatternMutationError(
+          pattern.id,
+          'COMMITTED_PENDING_INDEX',
+          new Error('HNSW unavailable after authoritative pattern commit'),
+        ));
+      }
       if (hnsw) {
         try {
           // Cast pattern metadata to CoverageVectorMetadata for HNSW storage

--- a/src/learning/pattern-store.ts
+++ b/src/learning/pattern-store.ts
@@ -68,6 +68,7 @@ import {
 } from './hyperbolic-pattern-index.js';
 import { PatternNullStore, type NullSummary } from './pattern-null-store.js';
 import { getActiveEmbeddingSpaceIdentity } from './real-embeddings.js';
+import { PatternMutationError } from './pattern-mutation-error.js';
 
 // ============================================================================
 // R1: HDC Fingerprint Singleton (lazy-initialized)
@@ -855,7 +856,9 @@ export class PatternStore implements IPatternStore {
           this.indexPattern(pattern);
         }
       } catch (error) {
-        console.warn(`[PatternStore] SQLite persist failed for ${pattern.id}:`, toErrorMessage(error));
+        this.unindexPattern(pattern);
+        if (existingPattern) this.indexPattern(existingPattern);
+        return err(new PatternMutationError(pattern.id, 'FAILED', error));
       }
     }
 
@@ -879,7 +882,7 @@ export class PatternStore implements IPatternStore {
             totalLines: 0,
           } as import('../domains/coverage-analysis/services/hnsw-index.js').CoverageVectorMetadata);
         } catch (error) {
-          console.warn(`[PatternStore] Failed to index embedding for ${pattern.id}:`, error);
+          return err(new PatternMutationError(pattern.id, 'COMMITTED_PENDING_INDEX', error));
         }
       }
     }

--- a/src/learning/pattern-store.ts
+++ b/src/learning/pattern-store.ts
@@ -836,6 +836,12 @@ export class PatternStore implements IPatternStore {
 
     // R3b: Capture pre-existing pattern for VectorDeltaTracker before overwrite
     const existingPattern = this.patternCache.get(pattern.id) ?? null;
+    let authoritativeCommitted = false;
+
+    const rollbackUncommittedCache = (): void => {
+      this.unindexPattern(pattern);
+      if (existingPattern) this.indexPattern(existingPattern);
+    };
 
     // Index in memory cache
     this.indexPattern(pattern);
@@ -855,9 +861,9 @@ export class PatternStore implements IPatternStore {
           (pattern as { id: string }).id = actualId;
           this.indexPattern(pattern);
         }
+        authoritativeCommitted = true;
       } catch (error) {
-        this.unindexPattern(pattern);
-        if (existingPattern) this.indexPattern(existingPattern);
+        rollbackUncommittedCache();
         return err(new PatternMutationError(pattern.id, 'FAILED', error));
       }
     }
@@ -865,11 +871,19 @@ export class PatternStore implements IPatternStore {
     // Add to HNSW if embedding is available (lazy-load HNSW only when needed)
     if (pattern.embedding) {
       const hnsw = await this.ensureHNSW();
-      if (!hnsw && this.sqliteStore) {
+      if (!hnsw && authoritativeCommitted) {
         return err(new PatternMutationError(
           pattern.id,
           'COMMITTED_PENDING_INDEX',
           new Error('HNSW unavailable after authoritative pattern commit'),
+        ));
+      }
+      if (!hnsw && process.env.AQE_MEMORY_BACKEND !== 'memory') {
+        rollbackUncommittedCache();
+        return err(new PatternMutationError(
+          pattern.id,
+          'FAILED',
+          new Error('HNSW unavailable before an authoritative pattern commit'),
         ));
       }
       if (hnsw) {
@@ -889,7 +903,12 @@ export class PatternStore implements IPatternStore {
             totalLines: 0,
           } as import('../domains/coverage-analysis/services/hnsw-index.js').CoverageVectorMetadata);
         } catch (error) {
-          return err(new PatternMutationError(pattern.id, 'COMMITTED_PENDING_INDEX', error));
+          if (!authoritativeCommitted) rollbackUncommittedCache();
+          return err(new PatternMutationError(
+            pattern.id,
+            authoritativeCommitted ? 'COMMITTED_PENDING_INDEX' : 'FAILED',
+            error,
+          ));
         }
       }
     }

--- a/src/learning/qe-reasoning-bank.ts
+++ b/src/learning/qe-reasoning-bank.ts
@@ -52,6 +52,7 @@ import {
 import { getWitnessChain } from '../audit/witness-chain.js';
 import type { RvfDualWriter } from '../integrations/ruvector/rvf-dual-writer.js';
 import { getActiveEmbeddingSpaceIdentity } from './real-embeddings.js';
+import { PatternMutationError } from './pattern-mutation-error.js';
 
 // Import extracted modules
 import { DEFAULT_QE_REASONING_BANK_CONFIG } from './qe-reasoning-bank-types.js';
@@ -350,16 +351,36 @@ export class QEReasoningBank implements IQEReasoningBank {
 
     const result = await this.patternStore.create(options);
 
+    // A pending-index error still proves the authoritative SQLite mutation
+    // committed. Resolve that committed row for witness and replication side
+    // effects, while returning the original typed partial disposition.
+    let committedPattern: QEPattern | null = result.success ? result.value : null;
+    if (
+      !result.success &&
+      result.error instanceof PatternMutationError &&
+      result.error.disposition === 'COMMITTED_PENDING_INDEX'
+    ) {
+      try {
+        committedPattern = await this.patternStore.get(result.error.patternId);
+      } catch (error) {
+        logger.warn('Committed pattern lookup failed', {
+          patternId: result.error.patternId,
+          error: toErrorMessage(error),
+        });
+      }
+    }
+
     // ADR-070: Record pattern creation in witness chain
-    if (result.success) {
-      getWitnessChain().then(wc => wc.append('PATTERN_CREATE', { patternId: result.value.id, domain: result.value.qeDomain, confidence: result.value.confidence, name: result.value.name }, 'reasoning-bank')).catch((e) => { logger.warn('Witness chain PATTERN_CREATE failed', { error: toErrorMessage(e) }); });
+    if (committedPattern) {
+      const sideEffectPattern = committedPattern;
+      getWitnessChain().then(wc => wc.append('PATTERN_CREATE', { patternId: sideEffectPattern.id, domain: sideEffectPattern.qeDomain, confidence: sideEffectPattern.confidence, name: sideEffectPattern.name }, 'reasoning-bank')).catch((e) => { logger.warn('Witness chain PATTERN_CREATE failed', { error: toErrorMessage(e) }); });
 
       // Phase 3: Best-effort RVF dual-write for vector replication
-      if (this.rvfDualWriter && result.value.embedding && result.value.embedding.length > 0) {
+      if (this.rvfDualWriter && sideEffectPattern.embedding && sideEffectPattern.embedding.length > 0) {
         try {
-          this.rvfDualWriter.writePattern(result.value.id, result.value.embedding);
+          this.rvfDualWriter.writePattern(sideEffectPattern.id, sideEffectPattern.embedding);
         } catch (rvfErr) {
-          logger.warn('RVF dual-write failed (non-fatal)', { patternId: result.value.id, error: toErrorMessage(rvfErr) });
+          logger.warn('RVF dual-write failed (non-fatal)', { patternId: sideEffectPattern.id, error: toErrorMessage(rvfErr) });
         }
       }
     }

--- a/src/learning/rvf-pattern-store.ts
+++ b/src/learning/rvf-pattern-store.ts
@@ -253,6 +253,7 @@ export class RvfPatternStore implements IPatternStore {
     if (pattern.embedding && !activeSpaceId) {
       return err(new Error('VECTOR_SPACE_UNVERIFIED: refusing to persist or index an embedding without runtime provenance'));
     }
+    let authoritativeCommitted = false;
 
     // Persist metadata to SQLite. #447: capture the returned id — ON CONFLICT
     // on (name, qe_domain, pattern_type) preserves the existing row's id, so
@@ -268,6 +269,7 @@ export class RvfPatternStore implements IPatternStore {
           // before HNSW ingest (otherwise the index keys diverge from SQLite).
           (pattern as { id: string }).id = actualId;
         }
+        authoritativeCommitted = true;
       } catch (error) {
         return err(new PatternMutationError(pattern.id, 'FAILED', error));
       }
@@ -276,8 +278,8 @@ export class RvfPatternStore implements IPatternStore {
     if (pattern.embedding && !this.adapter && this.rvfInitError) {
       return err(new PatternMutationError(
         pattern.id,
-        'COMMITTED_PENDING_INDEX',
-        new Error(`RVF unavailable after authoritative pattern commit: ${this.rvfInitError}`),
+        authoritativeCommitted ? 'COMMITTED_PENDING_INDEX' : 'FAILED',
+        new Error(`RVF unavailable ${authoritativeCommitted ? 'after' : 'before'} authoritative pattern commit: ${this.rvfInitError}`),
       ));
     }
 
@@ -292,7 +294,11 @@ export class RvfPatternStore implements IPatternStore {
           throw new Error(`RVF rejected pattern vector (accepted=${ingest.accepted}, rejected=${ingest.rejected})`);
         }
       } catch (error) {
-        return err(new PatternMutationError(pattern.id, 'COMMITTED_PENDING_INDEX', error));
+        return err(new PatternMutationError(
+          pattern.id,
+          authoritativeCommitted ? 'COMMITTED_PENDING_INDEX' : 'FAILED',
+          error,
+        ));
       }
     }
 

--- a/src/learning/rvf-pattern-store.ts
+++ b/src/learning/rvf-pattern-store.ts
@@ -40,6 +40,7 @@ import type {
 import { DEFAULT_PATTERN_STORE_CONFIG } from './pattern-store.js';
 import { getActiveEmbeddingSpaceIdentity } from './real-embeddings.js';
 import { verifyOrCreateEmbeddingSpaceManifest } from './embedding-space.js';
+import { PatternMutationError } from './pattern-mutation-error.js';
 
 // ============================================================================
 // RVF Pattern Store Configuration
@@ -266,10 +267,7 @@ export class RvfPatternStore implements IPatternStore {
           (pattern as { id: string }).id = actualId;
         }
       } catch (error) {
-        console.warn(
-          `[RvfPatternStore] SQLite persist failed for ${pattern.id}:`,
-          toErrorMessage(error),
-        );
+        return err(new PatternMutationError(pattern.id, 'FAILED', error));
       }
     }
 
@@ -279,12 +277,12 @@ export class RvfPatternStore implements IPatternStore {
         const vec = pattern.embedding instanceof Float32Array
           ? pattern.embedding
           : new Float32Array(pattern.embedding);
-        this.adapter.ingest([{ id: pattern.id, vector: vec }]);
+        const ingest = this.adapter.ingest([{ id: pattern.id, vector: vec }]);
+        if (ingest.accepted !== 1 || ingest.rejected !== 0) {
+          throw new Error(`RVF rejected pattern vector (accepted=${ingest.accepted}, rejected=${ingest.rejected})`);
+        }
       } catch (error) {
-        console.warn(
-          `[RvfPatternStore] RVF ingest failed for ${pattern.id}:`,
-          toErrorMessage(error),
-        );
+        return err(new PatternMutationError(pattern.id, 'COMMITTED_PENDING_INDEX', error));
       }
     }
 

--- a/src/learning/rvf-pattern-store.ts
+++ b/src/learning/rvf-pattern-store.ts
@@ -249,6 +249,15 @@ export class RvfPatternStore implements IPatternStore {
       );
     }
 
+    const persistentBackend = (process.env.AQE_MEMORY_BACKEND ?? 'memory') !== 'memory';
+    if (persistentBackend && !this.sqliteStore) {
+      return err(new PatternMutationError(
+        pattern.id,
+        'FAILED',
+        new Error('authoritative SQLite pattern store is unavailable'),
+      ));
+    }
+
     const activeSpaceId = getActiveEmbeddingSpaceIdentity()?.spaceId ?? this.embeddingSpaceId;
     if (pattern.embedding && !activeSpaceId) {
       return err(new Error('VECTOR_SPACE_UNVERIFIED: refusing to persist or index an embedding without runtime provenance'));

--- a/src/learning/rvf-pattern-store.ts
+++ b/src/learning/rvf-pattern-store.ts
@@ -109,6 +109,8 @@ export class RvfPatternStore implements IPatternStore {
   async initialize(): Promise<void> {
     if (this.initialized) return;
 
+    this.rvfInitError = null;
+
     // Database-free mode (#534): never create an on-disk patterns.rvf (+ .idmap/.lock).
     // Run adapter-less — the store degrades to metadata-only (the same graceful
     // path used when the RVF native binding is unavailable), writing nothing.
@@ -269,6 +271,14 @@ export class RvfPatternStore implements IPatternStore {
       } catch (error) {
         return err(new PatternMutationError(pattern.id, 'FAILED', error));
       }
+    }
+
+    if (pattern.embedding && !this.adapter && this.rvfInitError) {
+      return err(new PatternMutationError(
+        pattern.id,
+        'COMMITTED_PENDING_INDEX',
+        new Error(`RVF unavailable after authoritative pattern commit: ${this.rvfInitError}`),
+      ));
     }
 
     // Ingest vector into RVF

--- a/src/learning/rvf-pattern-store.ts
+++ b/src/learning/rvf-pattern-store.ts
@@ -112,8 +112,9 @@ export class RvfPatternStore implements IPatternStore {
     this.rvfInitError = null;
 
     // Database-free mode (#534): never create an on-disk patterns.rvf (+ .idmap/.lock).
-    // Run adapter-less — the store degrades to metadata-only (the same graceful
-    // path used when the RVF native binding is unavailable), writing nothing.
+    // Run adapter-less and write nothing. The factory normally selects the
+    // in-memory PatternStore in this mode; a directly constructed RVF store
+    // remains fail-closed unless an authoritative SQLite delegate is attached.
     if (process.env.AQE_MEMORY_BACKEND === 'memory') {
       this.adapter = null;
       this.initialized = true;
@@ -249,8 +250,11 @@ export class RvfPatternStore implements IPatternStore {
       );
     }
 
-    const persistentBackend = (process.env.AQE_MEMORY_BACKEND ?? 'memory') !== 'memory';
-    if (persistentBackend && !this.sqliteStore) {
+    // RVF is a derived persistent index. A write is observable only through its
+    // authoritative SQLite metadata row, regardless of the process-wide memory
+    // setting. The factory routes memory mode to PatternStore, so a directly
+    // constructed RVF store without SQLite must fail before vector ingestion.
+    if (!this.sqliteStore) {
       return err(new PatternMutationError(
         pattern.id,
         'FAILED',

--- a/tests/integration/rvf/rvf-production-wiring.test.ts
+++ b/tests/integration/rvf/rvf-production-wiring.test.ts
@@ -28,6 +28,7 @@ import {
 import {
   createQEReasoningBank,
 } from '../../../src/learning/qe-reasoning-bank.js';
+import { PatternMutationError } from '../../../src/learning/pattern-mutation-error.js';
 
 const TEST_SPACE_ID = 'rvf-production-test-space';
 
@@ -529,11 +530,16 @@ describe.runIf(nativeAvailable)('RVF Native Path (real binding)', () => {
         context: { tags: ['test'] },
       }), 10000, 'bank.storePattern');
 
-      expect(result.success, result.success ? '' : result.error.message).toBe(true);
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(PatternMutationError);
+        expect((result.error as PatternMutationError).disposition).toBe('COMMITTED_PENDING_INDEX');
+        expect(await bank.getPattern((result.error as PatternMutationError).patternId)).not.toBeNull();
+      }
 
-      // Check that the RVF store received the embedding.
+      // The committed row still triggers the independent RVF dual-writer.
       const status = writer.status();
       expect(status.rvf).not.toBeNull();
+      expect(status.rvf?.totalVectors).toBeGreaterThan(0);
 
       // Cleanup
       await bank.dispose().catch(() => {});

--- a/tests/learning/coherence-integration.test.ts
+++ b/tests/learning/coherence-integration.test.ts
@@ -20,8 +20,11 @@ import { WasmLoader } from '../../src/integrations/coherence/wasm-loader.js';
 import { InMemoryBackend } from '../../src/kernel/memory-backend.js';
 import { InMemoryEventBus } from '../../src/kernel/event-bus.js';
 import type { CreateQEPatternOptions } from '../../src/learning/qe-patterns.js';
+import type { QEPattern } from '../../src/learning/qe-patterns.js';
 import type { EventBus } from '../../src/kernel/interfaces.js';
 import type { CoherenceNode, CoherenceResult } from '../../src/integrations/coherence/types.js';
+import type { Result } from '../../src/shared/types/index.js';
+import { PatternMutationError } from '../../src/learning/pattern-mutation-error.js';
 
 // ============================================================================
 // Test Helpers
@@ -44,6 +47,20 @@ function createTestPattern(overrides: Partial<CreateQEPatternOptions> = {}): Cre
     context: { tags: ['test'], testType: 'unit' },
     ...overrides,
   };
+}
+
+async function expectCommittedPattern(
+  bank: QEReasoningBank,
+  result: Result<QEPattern>,
+): Promise<QEPattern> {
+  if (result.success) return result.value;
+
+  expect(result.error).toBeInstanceOf(PatternMutationError);
+  const mutationError = result.error as PatternMutationError;
+  expect(mutationError.disposition).toBe('COMMITTED_PENDING_INDEX');
+  const committed = await bank.getPattern(mutationError.patternId);
+  expect(committed).not.toBeNull();
+  return committed!;
 }
 
 /**
@@ -137,7 +154,7 @@ describe('Learning Module Coherence Integration', () => {
         description: 'Arrange-Act-Assert unit testing pattern',
         context: { tags: ['unit-test', 'aaa'], testType: 'unit' },
       }));
-      expect(pattern1.success).toBe(true);
+      await expectCommittedPattern(bank, pattern1);
 
       // Pattern 2: Integration testing pattern (coherent with unit tests)
       const pattern2 = await bank.storePattern(createTestPattern({
@@ -145,7 +162,7 @@ describe('Learning Module Coherence Integration', () => {
         description: 'End-to-end integration testing pattern',
         context: { tags: ['integration-test', 'e2e'], testType: 'integration' },
       }));
-      expect(pattern2.success).toBe(true);
+      await expectCommittedPattern(bank, pattern2);
 
       // Pattern 3: Contradictory pattern (suggests skipping tests)
       const pattern3 = await bank.storePattern(createTestPattern({
@@ -153,7 +170,7 @@ describe('Learning Module Coherence Integration', () => {
         description: 'Pattern that suggests skipping test execution',
         context: { tags: ['skip', 'no-test'], testType: 'unit' },
       }));
-      expect(pattern3.success).toBe(true);
+      await expectCommittedPattern(bank, pattern3);
 
       // Search for test patterns
       const searchResult = await bank.searchPatterns('unit testing best practices', {
@@ -412,49 +429,47 @@ describe('Learning Module Coherence Integration', () => {
       await bank.initialize();
 
       // Store a long-term pattern (existing knowledge)
-      const existingPattern = await bank.storePattern(createTestPattern({
+      const existingResult = await bank.storePattern(createTestPattern({
         name: 'Established Best Practice',
         description: 'Use dependency injection for testability',
         context: { tags: ['di', 'best-practice'] },
       }));
-      expect(existingPattern.success).toBe(true);
-      if (!existingPattern.success) return;
+      const existingPattern = await expectCommittedPattern(bank, existingResult);
 
       // Manually promote to long-term to simulate existing knowledge
       await bank.recordOutcome({
-        patternId: existingPattern.value.id,
+        patternId: existingPattern.id,
         success: true,
       });
       await bank.recordOutcome({
-        patternId: existingPattern.value.id,
+        patternId: existingPattern.id,
         success: true,
       });
       await bank.recordOutcome({
-        patternId: existingPattern.value.id,
+        patternId: existingPattern.id,
         success: true,
       });
 
       // Create conflicting short-term pattern with good metrics
-      const conflictingPattern = await bank.storePattern(createTestPattern({
+      const conflictingResult = await bank.storePattern(createTestPattern({
         name: 'Avoid Dependency Injection',
         description: 'Hardcode dependencies for simplicity',
         context: { tags: ['simple', 'no-di'] },
       }));
-      expect(conflictingPattern.success).toBe(true);
-      if (!conflictingPattern.success) return;
+      const conflictingPattern = await expectCommittedPattern(bank, conflictingResult);
 
       // Give it good metrics
       await bank.recordOutcome({
-        patternId: conflictingPattern.value.id,
+        patternId: conflictingPattern.id,
         success: true,
       });
       await bank.recordOutcome({
-        patternId: conflictingPattern.value.id,
+        patternId: conflictingPattern.id,
         success: true,
       });
 
       // Check coherence between patterns before promotion
-      const patterns = [existingPattern.value, conflictingPattern.value];
+      const patterns = [existingPattern, conflictingPattern];
       const nodes = patterns.map(p => ({
         id: p.id,
         embedding: p.embedding,
@@ -487,7 +502,7 @@ describe('Learning Module Coherence Integration', () => {
       const pattern = await bank.storePattern(createTestPattern({
         name: 'Contradictory Pattern',
       }));
-      expect(pattern.success).toBe(true);
+      await expectCommittedPattern(bank, pattern);
 
       // The event would be emitted during promotion attempt
       // Event structure: { event: 'promotion_blocked', reason: 'coherence_violation', patternId: ... }
@@ -500,25 +515,24 @@ describe('Learning Module Coherence Integration', () => {
       await bank.initialize();
 
       // Create non-conflicting pattern with good metrics
-      const coherentPattern = await bank.storePattern(createTestPattern({
+      const coherentResult = await bank.storePattern(createTestPattern({
         name: 'Well-Tested Component Pattern',
         description: 'Pattern for testing components thoroughly',
         context: { tags: ['testing', 'coverage'] },
       }));
-      expect(coherentPattern.success).toBe(true);
-      if (!coherentPattern.success) return;
+      const coherentPattern = await expectCommittedPattern(bank, coherentResult);
 
       // Record successful uses to qualify for promotion (need 4 to get 3 successfulUses)
       for (let i = 0; i < 4; i++) {
         await bank.recordOutcome({
-          patternId: coherentPattern.value.id,
+          patternId: coherentPattern.id,
           success: true,
           metrics: { testsPassed: 10, coverageImprovement: 0.15 },
         });
       }
 
       // Get updated pattern
-      const updatedPattern = await bank.getPattern(coherentPattern.value.id);
+      const updatedPattern = await bank.getPattern(coherentPattern.id);
       expect(updatedPattern).toBeDefined();
       if (!updatedPattern) return;
 
@@ -547,14 +561,13 @@ describe('Learning Module Coherence Integration', () => {
       await bank.initialize();
 
       // Create pattern
-      const pattern = await bank.storePattern(createTestPattern());
-      expect(pattern.success).toBe(true);
-      if (!pattern.success) return;
+      const patternResult = await bank.storePattern(createTestPattern());
+      const pattern = await expectCommittedPattern(bank, patternResult);
 
       // Record outcomes to qualify for promotion (need 4 to get 3 successfulUses)
       for (let i = 0; i < 4; i++) {
         await bank.recordOutcome({
-          patternId: pattern.value.id,
+          patternId: pattern.id,
           success: true,
         });
       }
@@ -563,7 +576,7 @@ describe('Learning Module Coherence Integration', () => {
       // based only on basic criteria (success rate, usage count)
       // This is graceful degradation behavior
 
-      const updatedPattern = await bank.getPattern(pattern.value.id);
+      const updatedPattern = await bank.getPattern(pattern.id);
       expect(updatedPattern).toBeDefined();
       if (!updatedPattern) return;
 

--- a/tests/unit/learning/pattern-store.test.ts
+++ b/tests/unit/learning/pattern-store.test.ts
@@ -239,13 +239,13 @@ describe('PatternStore', () => {
       expect(await store.get(pattern.id)).toEqual(pattern);
     });
 
-    it('should allow an in-memory-only write when HNSW is unavailable', async () => {
+    it('should allow the default in-memory write when HNSW is unavailable and the backend is unset', async () => {
       const pattern = createTestPattern({ embedding: [0.1, 0.2, 0.3] });
       (store as unknown as { config: { embeddingSpaceId?: string } }).config.embeddingSpaceId = 'test-space';
       vi.spyOn(store as unknown as { ensureHNSW: () => Promise<null> }, 'ensureHNSW')
         .mockResolvedValueOnce(null);
       const previousBackend = process.env.AQE_MEMORY_BACKEND;
-      process.env.AQE_MEMORY_BACKEND = 'memory';
+      delete process.env.AQE_MEMORY_BACKEND;
 
       try {
         const result = await store.store(pattern);
@@ -263,14 +263,21 @@ describe('PatternStore', () => {
       (store as unknown as { config: { embeddingSpaceId?: string } }).config.embeddingSpaceId = 'test-space';
       vi.spyOn(store as unknown as { ensureHNSW: () => Promise<null> }, 'ensureHNSW')
         .mockResolvedValueOnce(null);
+      const previousBackend = process.env.AQE_MEMORY_BACKEND;
+      process.env.AQE_MEMORY_BACKEND = 'sqlite';
 
-      const result = await store.store(pattern);
+      try {
+        const result = await store.store(pattern);
 
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect((result.error as PatternMutationError).disposition).toBe('FAILED');
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect((result.error as PatternMutationError).disposition).toBe('FAILED');
+        }
+        expect(await store.get(pattern.id)).toBeNull();
+      } finally {
+        if (previousBackend === undefined) delete process.env.AQE_MEMORY_BACKEND;
+        else process.env.AQE_MEMORY_BACKEND = previousBackend;
       }
-      expect(await store.get(pattern.id)).toBeNull();
     });
 
     it('should roll back the cache and report FAILED when HNSW insert fails without SQLite', async () => {
@@ -280,14 +287,21 @@ describe('PatternStore', () => {
         insert: vi.fn(async () => { throw new Error('index unavailable'); }),
       };
       (store as unknown as { hnswSpaceId: string }).hnswSpaceId = 'test-space';
+      const previousBackend = process.env.AQE_MEMORY_BACKEND;
+      process.env.AQE_MEMORY_BACKEND = 'sqlite';
 
-      const result = await store.store(pattern);
+      try {
+        const result = await store.store(pattern);
 
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect((result.error as PatternMutationError).disposition).toBe('FAILED');
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect((result.error as PatternMutationError).disposition).toBe('FAILED');
+        }
+        expect(await store.get(pattern.id)).toBeNull();
+      } finally {
+        if (previousBackend === undefined) delete process.env.AQE_MEMORY_BACKEND;
+        else process.env.AQE_MEMORY_BACKEND = previousBackend;
       }
-      expect(await store.get(pattern.id)).toBeNull();
     });
 
     it('should store a valid pattern', async () => {

--- a/tests/unit/learning/pattern-store.test.ts
+++ b/tests/unit/learning/pattern-store.test.ts
@@ -202,6 +202,55 @@ describe('PatternStore', () => {
       expect(await store.get(pattern.id)).toEqual(pattern);
     });
 
+    it('should report COMMITTED_PENDING_INDEX when HNSW is unavailable after SQLite commit', async () => {
+      const pattern = createTestPattern({ embedding: [0.1, 0.2, 0.3] });
+      (store as unknown as { config: { embeddingSpaceId?: string } }).config.embeddingSpaceId = 'test-space';
+      (store as unknown as { sqliteStore: unknown }).sqliteStore = {
+        storePattern: vi.fn(() => pattern.id),
+      };
+      vi.spyOn(store as unknown as { ensureHNSW: () => Promise<null> }, 'ensureHNSW')
+        .mockResolvedValueOnce(null);
+
+      const result = await store.store(pattern);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(PatternMutationError);
+        expect((result.error as PatternMutationError).disposition).toBe('COMMITTED_PENDING_INDEX');
+      }
+      expect(await store.get(pattern.id)).toEqual(pattern);
+    });
+
+    it('should report COMMITTED_PENDING_INDEX when the HNSW embedding space mismatches', async () => {
+      const pattern = createTestPattern({ embedding: [0.1, 0.2, 0.3] });
+      (store as unknown as { config: { embeddingSpaceId?: string } }).config.embeddingSpaceId = 'active-space';
+      (store as unknown as { sqliteStore: unknown }).sqliteStore = {
+        storePattern: vi.fn(() => pattern.id),
+      };
+      (store as unknown as { hnswIndex: unknown }).hnswIndex = { insert: vi.fn() };
+      (store as unknown as { hnswSpaceId: string }).hnswSpaceId = 'stale-space';
+
+      const result = await store.store(pattern);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect((result.error as PatternMutationError).disposition).toBe('COMMITTED_PENDING_INDEX');
+      }
+      expect(await store.get(pattern.id)).toEqual(pattern);
+    });
+
+    it('should allow an in-memory-only write when HNSW is unavailable', async () => {
+      const pattern = createTestPattern({ embedding: [0.1, 0.2, 0.3] });
+      (store as unknown as { config: { embeddingSpaceId?: string } }).config.embeddingSpaceId = 'test-space';
+      vi.spyOn(store as unknown as { ensureHNSW: () => Promise<null> }, 'ensureHNSW')
+        .mockResolvedValueOnce(null);
+
+      const result = await store.store(pattern);
+
+      expect(result.success).toBe(true);
+      expect(await store.get(pattern.id)).toEqual(pattern);
+    });
+
     it('should store a valid pattern', async () => {
       const pattern = createTestPattern();
 

--- a/tests/unit/learning/pattern-store.test.ts
+++ b/tests/unit/learning/pattern-store.test.ts
@@ -16,6 +16,7 @@ import {
 import type { QEPattern, QEPatternType, QEDomain } from '../../../src/learning/qe-patterns.js';
 import type { MemoryBackend } from '../../../src/kernel/interfaces.js';
 import { setRuVectorFeatureFlags, resetRuVectorFeatureFlags } from '../../../src/integrations/ruvector/feature-flags.js';
+import { PatternMutationError } from '../../../src/learning/pattern-mutation-error.js';
 
 // Ensure these tests exercise the in-memory PatternStore, not the RVF variant
 beforeEach(() => { setRuVectorFeatureFlags({ useRVFPatternStore: false }); });
@@ -165,6 +166,42 @@ describe('PatternStore', () => {
   });
 
   describe('Pattern Storage', () => {
+    it('should roll back the cache and report FAILED when SQLite persistence fails', async () => {
+      const pattern = createTestPattern({ embedding: undefined });
+      (store as unknown as { sqliteStore: unknown }).sqliteStore = {
+        storePattern: vi.fn(() => { throw new Error('disk full'); }),
+      };
+
+      const result = await store.store(pattern);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(PatternMutationError);
+        expect((result.error as PatternMutationError).disposition).toBe('FAILED');
+      }
+      expect(await store.get(pattern.id)).toBeNull();
+    });
+
+    it('should report COMMITTED_PENDING_INDEX when HNSW indexing fails after SQLite commit', async () => {
+      const pattern = createTestPattern({ embedding: [0.1, 0.2, 0.3] });
+      (store as unknown as { config: { embeddingSpaceId?: string } }).config.embeddingSpaceId = 'test-space';
+      (store as unknown as { sqliteStore: unknown }).sqliteStore = {
+        storePattern: vi.fn(() => pattern.id),
+      };
+      (store as unknown as { hnswIndex: unknown }).hnswIndex = {
+        insert: vi.fn(async () => { throw new Error('index unavailable'); }),
+      };
+      (store as unknown as { hnswSpaceId: string }).hnswSpaceId = 'test-space';
+
+      const result = await store.store(pattern);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect((result.error as PatternMutationError).disposition).toBe('COMMITTED_PENDING_INDEX');
+      }
+      expect(await store.get(pattern.id)).toEqual(pattern);
+    });
+
     it('should store a valid pattern', async () => {
       const pattern = createTestPattern();
 

--- a/tests/unit/learning/pattern-store.test.ts
+++ b/tests/unit/learning/pattern-store.test.ts
@@ -244,11 +244,50 @@ describe('PatternStore', () => {
       (store as unknown as { config: { embeddingSpaceId?: string } }).config.embeddingSpaceId = 'test-space';
       vi.spyOn(store as unknown as { ensureHNSW: () => Promise<null> }, 'ensureHNSW')
         .mockResolvedValueOnce(null);
+      const previousBackend = process.env.AQE_MEMORY_BACKEND;
+      process.env.AQE_MEMORY_BACKEND = 'memory';
+
+      try {
+        const result = await store.store(pattern);
+
+        expect(result.success).toBe(true);
+        expect(await store.get(pattern.id)).toEqual(pattern);
+      } finally {
+        if (previousBackend === undefined) delete process.env.AQE_MEMORY_BACKEND;
+        else process.env.AQE_MEMORY_BACKEND = previousBackend;
+      }
+    });
+
+    it('should roll back the cache and report FAILED when HNSW is unavailable without SQLite', async () => {
+      const pattern = createTestPattern({ embedding: [0.1, 0.2, 0.3] });
+      (store as unknown as { config: { embeddingSpaceId?: string } }).config.embeddingSpaceId = 'test-space';
+      vi.spyOn(store as unknown as { ensureHNSW: () => Promise<null> }, 'ensureHNSW')
+        .mockResolvedValueOnce(null);
 
       const result = await store.store(pattern);
 
-      expect(result.success).toBe(true);
-      expect(await store.get(pattern.id)).toEqual(pattern);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect((result.error as PatternMutationError).disposition).toBe('FAILED');
+      }
+      expect(await store.get(pattern.id)).toBeNull();
+    });
+
+    it('should roll back the cache and report FAILED when HNSW insert fails without SQLite', async () => {
+      const pattern = createTestPattern({ embedding: [0.1, 0.2, 0.3] });
+      (store as unknown as { config: { embeddingSpaceId?: string } }).config.embeddingSpaceId = 'test-space';
+      (store as unknown as { hnswIndex: unknown }).hnswIndex = {
+        insert: vi.fn(async () => { throw new Error('index unavailable'); }),
+      };
+      (store as unknown as { hnswSpaceId: string }).hnswSpaceId = 'test-space';
+
+      const result = await store.store(pattern);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect((result.error as PatternMutationError).disposition).toBe('FAILED');
+      }
+      expect(await store.get(pattern.id)).toBeNull();
     });
 
     it('should store a valid pattern', async () => {

--- a/tests/unit/learning/pattern-store.test.ts
+++ b/tests/unit/learning/pattern-store.test.ts
@@ -258,35 +258,38 @@ describe('PatternStore', () => {
       }
     });
 
-    it('should roll back the cache and report FAILED when HNSW is unavailable without SQLite', async () => {
-      const pattern = createTestPattern({ embedding: [0.1, 0.2, 0.3] });
+    it('should preserve the prior cache and skip a healthy HNSW when persistent SQLite is absent', async () => {
+      const existingPattern = createTestPattern({ embedding: undefined, name: 'Existing Pattern' });
+      expect((await store.store(existingPattern)).success).toBe(true);
+      const replacement = createTestPattern({
+        ...existingPattern,
+        name: 'Replacement Pattern',
+        embedding: [0.1, 0.2, 0.3],
+      });
       (store as unknown as { config: { embeddingSpaceId?: string } }).config.embeddingSpaceId = 'test-space';
-      vi.spyOn(store as unknown as { ensureHNSW: () => Promise<null> }, 'ensureHNSW')
-        .mockResolvedValueOnce(null);
+      const insert = vi.fn(async () => undefined);
+      (store as unknown as { hnswIndex: unknown }).hnswIndex = { insert };
+      (store as unknown as { hnswSpaceId: string }).hnswSpaceId = 'test-space';
       const previousBackend = process.env.AQE_MEMORY_BACKEND;
       process.env.AQE_MEMORY_BACKEND = 'sqlite';
 
       try {
-        const result = await store.store(pattern);
+        const result = await store.store(replacement);
 
         expect(result.success).toBe(false);
         if (!result.success) {
           expect((result.error as PatternMutationError).disposition).toBe('FAILED');
         }
-        expect(await store.get(pattern.id)).toBeNull();
+        expect(await store.get(existingPattern.id)).toEqual(existingPattern);
+        expect(insert).not.toHaveBeenCalled();
       } finally {
         if (previousBackend === undefined) delete process.env.AQE_MEMORY_BACKEND;
         else process.env.AQE_MEMORY_BACKEND = previousBackend;
       }
     });
 
-    it('should roll back the cache and report FAILED when HNSW insert fails without SQLite', async () => {
-      const pattern = createTestPattern({ embedding: [0.1, 0.2, 0.3] });
-      (store as unknown as { config: { embeddingSpaceId?: string } }).config.embeddingSpaceId = 'test-space';
-      (store as unknown as { hnswIndex: unknown }).hnswIndex = {
-        insert: vi.fn(async () => { throw new Error('index unavailable'); }),
-      };
-      (store as unknown as { hnswSpaceId: string }).hnswSpaceId = 'test-space';
+    it('should report FAILED for an embedding-less persistent write without SQLite', async () => {
+      const pattern = createTestPattern({ embedding: undefined });
       const previousBackend = process.env.AQE_MEMORY_BACKEND;
       process.env.AQE_MEMORY_BACKEND = 'sqlite';
 

--- a/tests/unit/learning/qe-reasoning-bank-partial-commit.test.ts
+++ b/tests/unit/learning/qe-reasoning-bank-partial-commit.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const witnessMocks = vi.hoisted(() => ({
+  append: vi.fn(),
+  getWitnessChain: vi.fn(),
+}));
+
+vi.mock('../../../src/audit/witness-chain.js', () => ({
+  getWitnessChain: witnessMocks.getWitnessChain,
+}));
+
+import { QEReasoningBank } from '../../../src/learning/qe-reasoning-bank.js';
+import { PatternMutationError } from '../../../src/learning/pattern-mutation-error.js';
+import type { QEPattern } from '../../../src/learning/qe-patterns.js';
+import { resetRuVectorFeatureFlags, setRuVectorFeatureFlags } from '../../../src/integrations/ruvector/feature-flags.js';
+
+describe('QEReasoningBank committed-pending pattern side effects', () => {
+  afterEach(() => {
+    resetRuVectorFeatureFlags();
+    vi.clearAllMocks();
+  });
+
+  it('runs witness and dual-writer side effects while preserving the partial result', async () => {
+    setRuVectorFeatureFlags({ useRVFPatternStore: false });
+    witnessMocks.getWitnessChain.mockResolvedValue({ append: witnessMocks.append });
+
+    const embedding = [0.1, 0.2, 0.3];
+    const committedPattern = {
+      id: 'committed-pattern',
+      patternType: 'test-template',
+      qeDomain: 'test-generation',
+      domain: 'test-generation',
+      name: 'Committed Pattern',
+      description: 'Committed before its derived index failed',
+      confidence: 0.8,
+      embedding,
+    } as QEPattern;
+    const partial = new PatternMutationError(
+      committedPattern.id,
+      'COMMITTED_PENDING_INDEX',
+      new Error('derived index unavailable'),
+    );
+    const create = vi.fn(async () => ({ success: false as const, error: partial }));
+    const get = vi.fn(async () => committedPattern);
+    const writePattern = vi.fn();
+    const bank = new QEReasoningBank({} as never);
+    Object.assign(bank as unknown as Record<string, unknown>, {
+      initialized: true,
+      patternStore: { create, get },
+    });
+    bank.setRvfDualWriter({ writePattern } as never);
+
+    const result = await bank.storePattern({
+      patternType: 'test-template',
+      name: committedPattern.name,
+      description: committedPattern.description,
+      template: { type: 'code', content: 'test()', variables: [] },
+      embedding,
+    });
+
+    expect(result).toEqual({ success: false, error: partial });
+    expect(get).toHaveBeenCalledWith(committedPattern.id);
+    expect(writePattern).toHaveBeenCalledWith(committedPattern.id, embedding);
+    await vi.waitFor(() => {
+      expect(witnessMocks.append).toHaveBeenCalledWith(
+        'PATTERN_CREATE',
+        {
+          patternId: committedPattern.id,
+          domain: committedPattern.qeDomain,
+          confidence: committedPattern.confidence,
+          name: committedPattern.name,
+        },
+        'reasoning-bank',
+      );
+    });
+  });
+});

--- a/tests/unit/learning/rvf-pattern-store.test.ts
+++ b/tests/unit/learning/rvf-pattern-store.test.ts
@@ -260,6 +260,36 @@ describe('RvfPatternStore', () => {
       }
     });
 
+    it('should report FAILED when RVF initialization fails without a SQLite commit', async () => {
+      await store.dispose();
+      const initFailure = new RvfPatternStore(
+        () => { throw new Error('native RVF unavailable'); },
+        { rvfPath: path.join(tmpDir, 'failed-init-no-sqlite.rvf'), base: undefined as any, embeddingSpaceId: TEST_SPACE_ID },
+      );
+      await initFailure.initialize();
+      (initFailure as unknown as { sqliteStore: unknown }).sqliteStore = null;
+      store = initFailure;
+
+      const result = await store.store(makePattern());
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect((result.error as PatternMutationError).disposition).toBe('FAILED');
+      }
+    });
+
+    it('should report FAILED when RVF ingest fails without a SQLite commit', async () => {
+      (store as unknown as { sqliteStore: unknown }).sqliteStore = null;
+      vi.mocked(adapter.ingest).mockImplementationOnce(() => { throw new Error('rvf unavailable'); });
+
+      const result = await store.store(makePattern());
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect((result.error as PatternMutationError).disposition).toBe('FAILED');
+      }
+    });
+
     it('should report COMMITTED_PENDING_INDEX when RVF rejects the vector without throwing', async () => {
       const pattern = makePattern();
       vi.mocked(adapter.ingest).mockReturnValueOnce({ accepted: 0, rejected: 1 });

--- a/tests/unit/learning/rvf-pattern-store.test.ts
+++ b/tests/unit/learning/rvf-pattern-store.test.ts
@@ -18,6 +18,7 @@ import {
   setRuVectorFeatureFlags,
   resetRuVectorFeatureFlags,
 } from '../../../src/integrations/ruvector/feature-flags.js';
+import { PatternMutationError } from '../../../src/learning/pattern-mutation-error.js';
 
 const TEST_SPACE_ID = 'test-runtime-embedding-space';
 
@@ -183,6 +184,48 @@ describe('RvfPatternStore', () => {
   });
 
   describe('Store', () => {
+    it('should report FAILED and skip RVF ingest when SQLite persistence fails', async () => {
+      const pattern = makePattern();
+      (store as unknown as { sqliteStore: unknown }).sqliteStore = {
+        storePattern: vi.fn(() => { throw new Error('sqlite unavailable'); }),
+      };
+
+      const result = await store.store(pattern);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(PatternMutationError);
+        expect((result.error as PatternMutationError).disposition).toBe('FAILED');
+      }
+      expect(adapter.ingest).not.toHaveBeenCalled();
+    });
+
+    it('should report COMMITTED_PENDING_INDEX when RVF ingest fails after SQLite commit', async () => {
+      const pattern = makePattern();
+      vi.mocked(adapter.ingest).mockImplementationOnce(() => { throw new Error('rvf unavailable'); });
+
+      const result = await store.store(pattern);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect((result.error as PatternMutationError).disposition).toBe('COMMITTED_PENDING_INDEX');
+      }
+      expect(await store.get(pattern.id)).toMatchObject({ id: pattern.id });
+    });
+
+    it('should report COMMITTED_PENDING_INDEX when RVF rejects the vector without throwing', async () => {
+      const pattern = makePattern();
+      vi.mocked(adapter.ingest).mockReturnValueOnce({ accepted: 0, rejected: 1 });
+
+      const result = await store.store(pattern);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect((result.error as PatternMutationError).disposition).toBe('COMMITTED_PENDING_INDEX');
+      }
+      expect(await store.get(pattern.id)).toMatchObject({ id: pattern.id });
+    });
+
     it('should store a pattern and ingest its vector', async () => {
       const pattern = makePattern();
       const result = await store.store(pattern);

--- a/tests/unit/learning/rvf-pattern-store.test.ts
+++ b/tests/unit/learning/rvf-pattern-store.test.ts
@@ -238,7 +238,7 @@ describe('RvfPatternStore', () => {
       expect(await store.get(pattern.id)).toMatchObject({ id: pattern.id });
     });
 
-    it('should allow an intentional memory-only write without an RVF adapter', async () => {
+    it('should reject an explicit memory-mode RVF write without retrievable metadata', async () => {
       await store.dispose();
       const createAdapter = vi.fn(() => adapter);
       const memoryOnly = new RvfPatternStore(
@@ -250,10 +250,17 @@ describe('RvfPatternStore', () => {
       process.env.AQE_MEMORY_BACKEND = 'memory';
 
       try {
-        const result = await store.store(makePattern());
+        const pattern = makePattern();
+        const result = await store.store(pattern);
 
-        expect(result.success).toBe(true);
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(result.error).toBeInstanceOf(PatternMutationError);
+          expect((result.error as PatternMutationError).disposition).toBe('FAILED');
+        }
         expect(createAdapter).not.toHaveBeenCalled();
+        expect(adapter.ingest).not.toHaveBeenCalled();
+        expect(await store.get(pattern.id)).toBeNull();
       } finally {
         if (previousBackend === undefined) delete process.env.AQE_MEMORY_BACKEND;
         else process.env.AQE_MEMORY_BACKEND = previousBackend;
@@ -278,15 +285,37 @@ describe('RvfPatternStore', () => {
       }
     });
 
-    it('should report FAILED when RVF ingest fails without a SQLite commit', async () => {
+    it('should fail before RVF ingest without a SQLite commit', async () => {
       (store as unknown as { sqliteStore: unknown }).sqliteStore = null;
-      vi.mocked(adapter.ingest).mockImplementationOnce(() => { throw new Error('rvf unavailable'); });
 
       const result = await store.store(makePattern());
 
       expect(result.success).toBe(false);
       if (!result.success) {
         expect((result.error as PatternMutationError).disposition).toBe('FAILED');
+      }
+      expect(adapter.ingest).not.toHaveBeenCalled();
+    });
+
+    it('should reject an unset-backend RVF write without SQLite authority', async () => {
+      (store as unknown as { sqliteStore: unknown }).sqliteStore = null;
+      const previousBackend = process.env.AQE_MEMORY_BACKEND;
+      delete process.env.AQE_MEMORY_BACKEND;
+
+      try {
+        const pattern = makePattern();
+        const result = await store.store(pattern);
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(result.error).toBeInstanceOf(PatternMutationError);
+          expect((result.error as PatternMutationError).disposition).toBe('FAILED');
+        }
+        expect(adapter.ingest).not.toHaveBeenCalled();
+        expect(await store.get(pattern.id)).toBeNull();
+      } finally {
+        if (previousBackend === undefined) delete process.env.AQE_MEMORY_BACKEND;
+        else process.env.AQE_MEMORY_BACKEND = previousBackend;
       }
     });
 
@@ -486,6 +515,31 @@ describe('createPatternStore factory routing', () => {
     // Should be the original PatternStore (not RvfPatternStore)
     expect(store.constructor.name).toBe('PatternStore');
     await store.dispose();
+  });
+
+  it('should return PatternStore in explicit memory mode even when RVF is enabled', async () => {
+    setRuVectorFeatureFlags({ useRVFPatternStore: true });
+    const previousBackend = process.env.AQE_MEMORY_BACKEND;
+    process.env.AQE_MEMORY_BACKEND = 'memory';
+
+    try {
+      const { createPatternStore } = await import('../../../src/learning/pattern-store.js');
+      const mockMemory = {
+        get: vi.fn(),
+        set: vi.fn(),
+        delete: vi.fn(),
+        list: vi.fn(() => []),
+        clear: vi.fn(),
+      };
+
+      const store = createPatternStore(mockMemory as any);
+
+      expect(store.constructor.name).toBe('PatternStore');
+      await store.dispose();
+    } finally {
+      if (previousBackend === undefined) delete process.env.AQE_MEMORY_BACKEND;
+      else process.env.AQE_MEMORY_BACKEND = previousBackend;
+    }
   });
 
   it('should return RvfPatternStore when useRVFPatternStore is true and native is available', async () => {

--- a/tests/unit/learning/rvf-pattern-store.test.ts
+++ b/tests/unit/learning/rvf-pattern-store.test.ts
@@ -213,6 +213,53 @@ describe('RvfPatternStore', () => {
       expect(await store.get(pattern.id)).toMatchObject({ id: pattern.id });
     });
 
+    it('should report COMMITTED_PENDING_INDEX when RVF initialization failed before SQLite commit', async () => {
+      await store.dispose();
+      const initFailure = new RvfPatternStore(
+        () => { throw new Error('native RVF unavailable'); },
+        { rvfPath: path.join(tmpDir, 'failed-init.rvf'), base: undefined as any, embeddingSpaceId: TEST_SPACE_ID },
+      );
+      const sqliteStore = createSQLitePatternStore({
+        useUnified: false,
+        dbPath: path.join(tmpDir, 'failed-init-patterns.db'),
+      });
+      await sqliteStore.initialize();
+      initFailure.setSqliteStore(sqliteStore);
+      store = initFailure;
+      const pattern = makePattern();
+
+      const result = await store.store(pattern);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(PatternMutationError);
+        expect((result.error as PatternMutationError).disposition).toBe('COMMITTED_PENDING_INDEX');
+      }
+      expect(await store.get(pattern.id)).toMatchObject({ id: pattern.id });
+    });
+
+    it('should allow an intentional memory-only write without an RVF adapter', async () => {
+      await store.dispose();
+      const createAdapter = vi.fn(() => adapter);
+      const memoryOnly = new RvfPatternStore(
+        createAdapter,
+        { rvfPath: path.join(tmpDir, 'memory-only.rvf'), base: undefined as any, embeddingSpaceId: TEST_SPACE_ID },
+      );
+      store = memoryOnly;
+      const previousBackend = process.env.AQE_MEMORY_BACKEND;
+      process.env.AQE_MEMORY_BACKEND = 'memory';
+
+      try {
+        const result = await store.store(makePattern());
+
+        expect(result.success).toBe(true);
+        expect(createAdapter).not.toHaveBeenCalled();
+      } finally {
+        if (previousBackend === undefined) delete process.env.AQE_MEMORY_BACKEND;
+        else process.env.AQE_MEMORY_BACKEND = previousBackend;
+      }
+    });
+
     it('should report COMMITTED_PENDING_INDEX when RVF rejects the vector without throwing', async () => {
       const pattern = makePattern();
       vi.mocked(adapter.ingest).mockReturnValueOnce({ accepted: 0, rejected: 1 });

--- a/tests/unit/learning/rvf-pattern-store.test.ts
+++ b/tests/unit/learning/rvf-pattern-store.test.ts
@@ -290,6 +290,44 @@ describe('RvfPatternStore', () => {
       }
     });
 
+    it('should report FAILED and skip a healthy RVF adapter when persistent SQLite is absent', async () => {
+      (store as unknown as { sqliteStore: unknown }).sqliteStore = null;
+      const previousBackend = process.env.AQE_MEMORY_BACKEND;
+      process.env.AQE_MEMORY_BACKEND = 'sqlite';
+
+      try {
+        const result = await store.store(makePattern());
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect((result.error as PatternMutationError).disposition).toBe('FAILED');
+        }
+        expect(adapter.ingest).not.toHaveBeenCalled();
+      } finally {
+        if (previousBackend === undefined) delete process.env.AQE_MEMORY_BACKEND;
+        else process.env.AQE_MEMORY_BACKEND = previousBackend;
+      }
+    });
+
+    it('should report FAILED for an embedding-less persistent write without SQLite', async () => {
+      (store as unknown as { sqliteStore: unknown }).sqliteStore = null;
+      const previousBackend = process.env.AQE_MEMORY_BACKEND;
+      process.env.AQE_MEMORY_BACKEND = 'sqlite';
+
+      try {
+        const result = await store.store(makePattern({ embedding: undefined }));
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect((result.error as PatternMutationError).disposition).toBe('FAILED');
+        }
+        expect(adapter.ingest).not.toHaveBeenCalled();
+      } finally {
+        if (previousBackend === undefined) delete process.env.AQE_MEMORY_BACKEND;
+        else process.env.AQE_MEMORY_BACKEND = previousBackend;
+      }
+    });
+
     it('should report COMMITTED_PENDING_INDEX when RVF rejects the vector without throwing', async () => {
       const pattern = makePattern();
       vi.mocked(adapter.ingest).mockReturnValueOnce({ accepted: 0, rejected: 1 });


### PR DESCRIPTION
## Summary

Implements the first mutation-evidence slice from #660. PatternStore and RvfPatternStore no longer return plain success when authoritative SQLite persistence is absent or fails, or when a required HNSW/RVF update fails after commit. They now return a typed `PatternMutationError` with `FAILED` or `COMMITTED_PENDING_INDEX`; the in-memory PatternStore also restores its previous cached value after an uncommitted SQLite failure. Non-throwing RVF vector rejection is treated as index failure. QEReasoningBank preserves the typed pending-index result while continuing witness and dual-writer side effects from the retrievable committed SQLite row.

This does not close #660. Generation manifests, watermarks/outbox replay, atomic reader activation, tombstones, and generation-bound retrieval receipts remain tracked there.

## Verification

- `npm test -- --run tests/unit/learning/pattern-store.test.ts tests/unit/learning/rvf-pattern-store.test.ts`: 83 passed
- `npm test -- --run tests/unit/learning/qe-reasoning-bank-partial-commit.test.ts`: 1 passed
- `npm test -- --run tests/learning/coherence-integration.test.ts tests/integration/rvf/rvf-production-wiring.test.ts`: 32 passed
- `npm run typecheck`: pass
- focused ESLint on changed learning modules: pass
- `npm run build`: pass
- `git diff --check`: pass

## Failure modes

- SQLite failure after memory indexing is injected and verifies rollback plus `FAILED`.
- Throwing HNSW/RVF failures after SQLite commit are injected and verify `COMMITTED_PENDING_INDEX`.
- Unavailable HNSW initialization, embedding-space mismatch, and failed RVF initialization after SQLite commit cannot return plain success.
- Factory-selected PatternStore preserves intentional in-memory operation without SQLite/HNSW, including the documented default when `AQE_MEMORY_BACKEND` is unset.
- Every RvfPatternStore write without an authoritative SQLite store reports `FAILED` before RVF ingest, including unset and explicit-memory backend modes; explicit memory mode remains routed to PatternStore by the factory. Persistent PatternStore writes fail without SQLite and preserve their prior cached value.
- RVF rejection without an exception is injected and cannot become plain success.
- A committed mutation with a pending derived index remains retrievable and still emits its witness and dual-writer side effects without losing the typed partial disposition.
- Full generation activation and repair remain tracked by #660.

---

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.** "Unlikely" is not an acceptable substitute. If you wrote "I don't think this can happen but...", that sentence is a failure mode and needs a test or an issue link.

### Optional context

- Linked issues: #660
- Trust tier change (if any): silent partial success → explicit failed/pending-index evidence
- Affects published API or CLI surface: additive exported error/disposition; existing Result shape retained
- Touches the init flow / `npm-publish.yml` / `tests/fixtures/init-corpus/`: no






