### PR TITLE
chore(release): v3.14.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-qe",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "description": "Agentic Quality Engineering — AI-powered QE platform with 60 specialized agents, 75+ skills, sublinear coverage analysis, ReasoningBank pattern learning, and deep MCP integration for Claude Code and 11 coding agent platforms",
   "author": {
     "name": "Agentic QE Team",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -48,7 +48,7 @@
   ],
   "engines": {
     "claudeCode": ">=2.0.0",
-    "node": ">=20.0.0"
+    "node": ">=22.13.0"
   },
   "mcpServers": {
     "agentic-qe": {

--- a/.claude/helpers/validate-v3-config.sh
+++ b/.claude/helpers/validate-v3-config.sh
@@ -144,12 +144,13 @@ if command -v node >/dev/null 2>&1; then
   node_version=$(node --version)
   log_success "Node.js installed: $node_version"
 
-  # Check if Node.js version is 20+
+  # Check if Node.js version is 22.13+
   node_major=$(echo "$node_version" | cut -d'.' -f1 | sed 's/v//')
-  if [ "$node_major" -ge 20 ]; then
-    log_success "Node.js version meets requirements (≥20.0.0)"
+  node_minor=$(echo "$node_version" | cut -d'.' -f2)
+  if [ "$node_major" -gt 22 ] || { [ "$node_major" -eq 22 ] && [ "$node_minor" -ge 13 ]; }; then
+    log_success "Node.js version meets requirements (≥22.13.0)"
   else
-    log_error "Node.js version too old. Required: ≥20.0.0, Found: $node_version"
+    log_error "Node.js version too old. Required: ≥22.13.0, Found: $node_version"
   fi
 else
   log_error "Node.js not installed"

--- a/.claude/hooks/aqe-hook.cjs
+++ b/.claude/hooks/aqe-hook.cjs
@@ -3,7 +3,7 @@
  * Resilient AQE hook shim (#510 item 5 — ports ruflo's hook-shim contract).
  *
  * Written in Node (CommonJS) so ONE file is cross-platform — Node is already a
- * hard dependency of AQE (the CLI is Node >= 20), so this runs identically on
+ * hard dependency of AQE (the CLI is Node >= 22.13), so this runs identically on
  * Windows / macOS / Linux with no POSIX `.sh` + `.cjs` twin. (It replaced an
  * earlier `aqe-hook.sh`, which forced a Windows twin and a `node_modules/.bin`
  * shell-wrapper spawn — see PR #512 discussion.)

--- a/.claude/skills/skills-manifest.json
+++ b/.claude/skills/skills-manifest.json
@@ -940,7 +940,7 @@
   },
   "metadata": {
     "generatedBy": "Agentic QE Fleet",
-    "fleetVersion": "3.14.0",
+    "fleetVersion": "3.14.1",
     "manifestVersion": "1.4.0",
     "lastUpdated": "2026-04-13T00:00:00.000Z",
     "contributors": [

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -77,11 +77,31 @@ jobs:
           test -s dist/mcp/bundle.js && echo "dist/mcp/bundle.js: OK"
         timeout-minutes: 2
 
+      - name: Verify publish assets are synchronized
+        run: |
+          npm run prepublishOnly
+          git diff --exit-code
+
+      - name: Seal npm package
+        run: |
+          mkdir -p release-artifact
+          npm pack --ignore-scripts --pack-destination release-artifact
+          TARBALL=$(find release-artifact -maxdepth 1 -name '*.tgz' -print -quit)
+          test -n "${TARBALL}"
+          sha256sum "${TARBALL}" | tee release-artifact/SHA256SUMS
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
+          retention-days: 1
+
+      - name: Upload sealed npm package
+        uses: actions/upload-artifact@v7
+        with:
+          name: npm-package
+          path: release-artifact/
           retention-days: 1
 
   # ============================================================================
@@ -130,25 +150,24 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Download build artifacts
+      - name: Download sealed npm package
         uses: actions/download-artifact@v8
         with:
-          name: dist
-          path: dist/
+          name: npm-package
+          path: release-artifact/
 
-      - name: Pack agentic-qe tarball
+      - name: Locate sealed agentic-qe tarball
         id: pack
         run: |
-          PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          npm pack --pack-destination /tmp
-          TARBALL=/tmp/agentic-qe-${PACKAGE_VERSION}.tgz
+          TARBALL=$(find release-artifact -maxdepth 1 -name '*.tgz' -print -quit)
           if [ ! -f "${TARBALL}" ]; then
-            echo "Error: expected tarball ${TARBALL} not produced by npm pack" >&2
-            ls -la /tmp/*.tgz 2>/dev/null || true
+            echo "Error: sealed npm tarball was not downloaded" >&2
             exit 1
           fi
+          sha256sum --check release-artifact/SHA256SUMS
+          TARBALL=$(realpath "${TARBALL}")
           echo "tarball=${TARBALL}" >> "$GITHUB_OUTPUT"
-          echo "Packed: ${TARBALL} ($(du -h ${TARBALL} | cut -f1))"
+          echo "Using sealed artifact: ${TARBALL} ($(du -h ${TARBALL} | cut -f1))"
 
       - name: Cache corpus tarballs
         uses: actions/cache@v6
@@ -319,15 +338,21 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build
-        run: npm run build
+      - name: Download sealed npm package
+        uses: actions/download-artifact@v8
+        with:
+          name: npm-package
+          path: release-artifact/
 
-      - name: Pack tarball
+      - name: Locate sealed tarball
         id: pack
         run: |
-          TARBALL=$(npm pack --json | jq -r '.[0].filename')
+          TARBALL=$(find release-artifact -maxdepth 1 -name '*.tgz' -print -quit)
+          test -f "${TARBALL}"
+          sha256sum --check release-artifact/SHA256SUMS
+          TARBALL=$(realpath "${TARBALL}")
           echo "tarball=${TARBALL}" >> "$GITHUB_OUTPUT"
-          echo "Packed: ${TARBALL}"
+          echo "Using sealed artifact: ${TARBALL}"
 
       - name: Audit against clean consumer install
         run: |
@@ -371,14 +396,23 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Download build artifacts
+      - name: Download sealed npm package
         uses: actions/download-artifact@v8
         with:
-          name: dist
-          path: dist/
+          name: npm-package
+          path: release-artifact/
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Verify sealed npm package
+        id: pack
+        run: |
+          TARBALL=$(find release-artifact -maxdepth 1 -name '*.tgz' -print -quit)
+          test -f "${TARBALL}"
+          sha256sum --check release-artifact/SHA256SUMS
+          TARBALL=$(realpath "${TARBALL}")
+          echo "tarball=${TARBALL}" >> "$GITHUB_OUTPUT"
 
       - name: Verify package version matches tag
         if: github.event_name == 'release'
@@ -396,13 +430,13 @@ jobs:
 
       - name: Publish to npm (dry run)
         if: github.event.inputs.dry_run == 'true'
-        run: npm publish --access public --dry-run
+        run: npm publish "${{ steps.pack.outputs.tarball }}" --access public --dry-run
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish to npm
         if: github.event.inputs.dry_run != 'true'
-        run: npm publish --access public --provenance
+        run: npm publish "${{ steps.pack.outputs.tarball }}" --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,12 +4,6 @@ on:
   release:
     types: [published]
   workflow_dispatch:
-    inputs:
-      dry_run:
-        description: 'Perform a dry run (no actual publish)'
-        required: false
-        default: 'false'
-        type: boolean
 
 # Required for npm trusted publishers (OIDC)
 permissions:
@@ -360,7 +354,7 @@ jobs:
           pushd "${CONSUMER_DIR}" >/dev/null
           echo '{"name":"audit-consumer","version":"0.0.0","private":true}' > package.json
           # Install our tarball as a real consumer would.
-          npm install --no-audit --no-fund "${GITHUB_WORKSPACE}/${{ steps.pack.outputs.tarball }}"
+          npm install --no-audit --no-fund "${{ steps.pack.outputs.tarball }}"
           # Now the moment of truth: audit from the consumer's POV, where
           # our root-only overrides do NOT apply.
           npm audit --audit-level=high
@@ -428,14 +422,23 @@ jobs:
           fi
           echo "Version verification passed: $PACKAGE_VERSION"
 
+          git fetch origin main --no-tags --depth=1
+          TAG_SHA=$(git rev-parse HEAD)
+          MAIN_SHA=$(git rev-parse origin/main)
+          if [ "$TAG_SHA" != "$MAIN_SHA" ]; then
+            echo "Error: release tag SHA ($TAG_SHA) is not current merged main ($MAIN_SHA)"
+            exit 1
+          fi
+          echo "Release lineage verification passed: $TAG_SHA"
+
       - name: Publish to npm (dry run)
-        if: github.event.inputs.dry_run == 'true'
+        if: github.event_name == 'workflow_dispatch'
         run: npm publish "${{ steps.pack.outputs.tarball }}" --access public --dry-run
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish to npm
-        if: github.event.inputs.dry_run != 'true'
+        if: github.event_name == 'release'
         run: npm publish "${{ steps.pack.outputs.tarball }}" --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -451,7 +454,7 @@ jobs:
           echo "- **Version**: $PACKAGE_VERSION" >> $GITHUB_STEP_SUMMARY
           echo "- **Registry**: https://www.npmjs.com/package/$PACKAGE_NAME" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ github.event.inputs.dry_run }}" == "true" ]; then
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             echo "> **Note**: This was a dry run. No package was actually published." >> $GITHUB_STEP_SUMMARY
           else
             echo "Install with: \`npm install $PACKAGE_NAME@$PACKAGE_VERSION\`" >> $GITHUB_STEP_SUMMARY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Agentic QE project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.14.1] - 2026-09-06
+## [3.14.1] - 2026-09-07
 
 This release moves AQE to maintained Node.js runtimes and strengthens the
 evidence boundaries around runtime diagnosis, verification, session recovery,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ and learned-pattern storage.
 - Kept Rust coverage analysis on the Rust instrumentation path so an available
   JavaScript test runner cannot replace the documented static-estimation
   fallback with an empty coverage report ([#569]).
+- Published the verdict JSON schemas and exposed pattern mutation outcomes at
+  the package root so downstream consumers can validate and classify writes.
+- Sealed one npm tarball after asset synchronization and reused those exact
+  bytes for initialization, consumer-audit, and publication gates.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ and learned-pattern storage.
   fixtures and accepted current Vibium screenshot output paths ([#561], [#667]).
 - Refreshed embedded graph, Ruvocal, and Goal UI dependency locks with clean
   Node 22+ installs and current vulnerability fixes ([#669]).
+- Kept Rust coverage analysis on the Rust instrumentation path so an available
+  JavaScript test runner cannot replace the documented static-estimation
+  fallback with an empty coverage report ([#569]).
 
 ### Changed
 
@@ -52,6 +55,7 @@ and learned-pattern storage.
   [#666]).
 
 [#561]: https://github.com/proffesor-for-testing/agentic-qe/issues/561
+[#569]: https://github.com/proffesor-for-testing/agentic-qe/issues/569
 [#649]: https://github.com/proffesor-for-testing/agentic-qe/issues/649
 [#651]: https://github.com/proffesor-for-testing/agentic-qe/issues/651
 [#653]: https://github.com/proffesor-for-testing/agentic-qe/issues/653

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,75 @@ All notable changes to the Agentic QE project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.14.1] - 2026-09-06
+
+This release moves AQE to maintained Node.js runtimes and strengthens the
+evidence boundaries around runtime diagnosis, verification, session recovery,
+and learned-pattern storage.
+
+### Added
+
+- Added a reproducible runtime-fault diagnosis benchmark covering clean/fault
+  pairs, classification, localization, abstention, and uncertainty reporting
+  ([#649], [#662]).
+- Added revision-bound verification-reach manifests so quality gates expose
+  direct, partial, uncovered, stale, and legacy-unknown evidence instead of
+  passing without observable failure-mode coverage ([#651], [#664]).
+- Added a 100-query structural-transfer retrieval corpus with deterministic
+  ranking metrics and immutable receipts ([#653], [#665]).
+- Added sanitized judge-measurement receipts with schema-enforced trust,
+  identity, retry, decoding, and timestamp boundaries ([#658], [#670]).
+
+### Fixed
+
+- Hardened legacy session recovery against root escape, symlink and inode
+  substitution, malformed lineage, invalid UTF-8, oversized records, torn
+  tails, and unbounded caller overrides; legacy resume remains explicit and
+  unverified ([#659], [#671]).
+- Made SQLite pattern-write failures and incomplete HNSW/RVF indexing return
+  typed `FAILED` or `COMMITTED_PENDING_INDEX` evidence while preserving
+  committed witness and dual-write side effects ([#660], [#672]).
+- Removed package-manager calls from generated Claude lifecycle hooks, added
+  bounded Codex guidance modes, and separated Vibium detection from readiness
+  installation in response to reports from @pacphi ([#654], [#655], [#656],
+  [#661]).
+- Replaced rate-limited qe-browser public fixtures with deterministic loopback
+  fixtures and accepted current Vibium screenshot output paths ([#561], [#667]).
+- Refreshed embedded graph, Ruvocal, and Goal UI dependency locks with clean
+  Node 22+ installs and current vulnerability fixes ([#669]).
+
+### Changed
+
+- Raised the published runtime floor to Node.js 22.13.0, recommends Node.js 24
+  for development and containers, and moved CI workflows off Node 18/20
+  runtimes ([#663]).
+- Early-exit presets now collect shadow-calibration evidence by default while
+  still executing every layer; enforced skipping remains explicit ([#657],
+  [#666]).
+
+[#561]: https://github.com/proffesor-for-testing/agentic-qe/issues/561
+[#649]: https://github.com/proffesor-for-testing/agentic-qe/issues/649
+[#651]: https://github.com/proffesor-for-testing/agentic-qe/issues/651
+[#653]: https://github.com/proffesor-for-testing/agentic-qe/issues/653
+[#654]: https://github.com/proffesor-for-testing/agentic-qe/issues/654
+[#655]: https://github.com/proffesor-for-testing/agentic-qe/issues/655
+[#656]: https://github.com/proffesor-for-testing/agentic-qe/issues/656
+[#657]: https://github.com/proffesor-for-testing/agentic-qe/issues/657
+[#658]: https://github.com/proffesor-for-testing/agentic-qe/issues/658
+[#659]: https://github.com/proffesor-for-testing/agentic-qe/issues/659
+[#660]: https://github.com/proffesor-for-testing/agentic-qe/issues/660
+[#661]: https://github.com/proffesor-for-testing/agentic-qe/pull/661
+[#662]: https://github.com/proffesor-for-testing/agentic-qe/pull/662
+[#663]: https://github.com/proffesor-for-testing/agentic-qe/pull/663
+[#664]: https://github.com/proffesor-for-testing/agentic-qe/pull/664
+[#665]: https://github.com/proffesor-for-testing/agentic-qe/pull/665
+[#666]: https://github.com/proffesor-for-testing/agentic-qe/pull/666
+[#667]: https://github.com/proffesor-for-testing/agentic-qe/pull/667
+[#669]: https://github.com/proffesor-for-testing/agentic-qe/pull/669
+[#670]: https://github.com/proffesor-for-testing/agentic-qe/pull/670
+[#671]: https://github.com/proffesor-for-testing/agentic-qe/pull/671
+[#672]: https://github.com/proffesor-for-testing/agentic-qe/pull/672
+
 ## [3.14.0] - 2026-08-30
 
 This release makes learned evidence, semantic vectors, recovery mirrors, and

--- a/assets/skills/pair-programming/SKILL.md
+++ b/assets/skills/pair-programming/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: "pair-programming"
-description: "Provides AI navigator for pair programming sessions with real-time code review, TDD guidance, and quality monitoring. Use when pair programming with AI assistance, practicing TDD with a navigator, debugging collaboratively, or refactoring with real-time verification."
+name: Pair Programming
+description: AI-assisted pair programming with multiple modes (driver/navigator/switch), real-time verification, quality monitoring, and comprehensive testing. Supports TDD, debugging, refactoring, and learning sessions. Features automatic role switching, continuous code review, security scanning, and performance optimization with truth-score verification.
 ---
 
 # Pair Programming

--- a/assets/skills/qe-browser/scripts/smoke-test.sh
+++ b/assets/skills/qe-browser/scripts/smoke-test.sh
@@ -1,10 +1,22 @@
 #!/usr/bin/env bash
-# qe-browser smoke test
+# qe-browser smoke test (bash mirror of evals/qe-browser.yaml)
 #
 # Runs each helper script against deterministic local fixtures and
-# verifies the output structure. This is the script that gates PR-reopen
-# per ADR-091 Phase 3 — it MUST be run on a machine with vibium installed
-# before the qe-browser PR is considered safe to reopen.
+# verifies the output structure. Gates PR-reopen per ADR-091 Phase 3.
+#
+# RELATIONSHIP TO evals/qe-browser.yaml
+# -------------------------------------
+# The canonical spec is `.claude/skills/qe-browser/evals/qe-browser.yaml`.
+# It is executed by `aqe eval run --skill qe-browser` via CommandEvalRunner
+# (src/validation/command-eval-runner.ts). The CI workflow runs it in the
+# "eval" job once the dist is built.
+#
+# This bash script mirrors the same test cases (tc001–tc011) so you can
+# run them without building the AQE CLI — useful during local skill
+# development and the initial smoke gate in CI (before the build finishes).
+# It also covers one case the yaml can't express naturally:
+#   - tc011 F1 contract: vibium-missing -> skipped envelope + exit 2
+#     (uses `env -i PATH=<fake-bin>` isolation, which is clumsy in yaml)
 #
 # Exit codes:
 #   0 — all smoke tests passed

--- a/assets/skills/skills-manifest.json
+++ b/assets/skills/skills-manifest.json
@@ -940,7 +940,7 @@
   },
   "metadata": {
     "generatedBy": "Agentic QE Fleet",
-    "fleetVersion": "3.14.0",
+    "fleetVersion": "3.14.1",
     "manifestVersion": "1.4.0",
     "lastUpdated": "2026-04-13T00:00:00.000Z",
     "contributors": [

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -4,7 +4,7 @@ All Agentic QE release notes organized by version.
 
 | Version | Date | Highlights |
 |---------|------|------------|
-| [v3.14.1](v3.14.1.md) | 2026-09-06 | Node 22+ support and stronger verification, recovery, and learning evidence. |
+| [v3.14.1](v3.14.1.md) | 2026-09-07 | Node 22+ support and stronger verification, recovery, and learning evidence. |
 | [v3.14.0](v3.14.0.md) | 2026-08-30 | Qualified learning evidence, embedding provenance, fail-closed RVF recovery, and packaged QE Court. |
 | [v3.13.12](v3.13.12.md) | 2026-08-21 | External LLM provider registration for downstream hosts. |
 | [v3.13.11](v3.13.11.md) | 2026-08-14 | Reliable diagnostics, native ESM exports, and learned pattern visibility. |

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -4,6 +4,7 @@ All Agentic QE release notes organized by version.
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| [v3.14.1](v3.14.1.md) | 2026-09-06 | Node 22+ support and stronger verification, recovery, and learning evidence. |
 | [v3.14.0](v3.14.0.md) | 2026-08-30 | Qualified learning evidence, embedding provenance, fail-closed RVF recovery, and packaged QE Court. |
 | [v3.13.12](v3.13.12.md) | 2026-08-21 | External LLM provider registration for downstream hosts. |
 | [v3.13.11](v3.13.11.md) | 2026-08-14 | Reliable diagnostics, native ESM exports, and learned pattern visibility. |

--- a/docs/releases/v3.14.1.md
+++ b/docs/releases/v3.14.1.md
@@ -42,6 +42,8 @@ ambiguous success.
 - Pattern writes distinguish `FAILED` from `COMMITTED_PENDING_INDEX`. A
   committed SQLite row remains observable when HNSW or RVF indexing is delayed,
   while uncommitted and orphan-vector paths fail before reporting success.
+  `PatternMutationError` is available from the package root for runtime
+  classification, and its disposition is part of the public TypeScript API.
 - The first structural-transfer qualification corpus adds 100 frozen queries,
   hard distractors, deterministic bootstrap metrics, and immutable retrieval
   receipts.
@@ -61,4 +63,5 @@ Upgrade the runtime before installing this release if the host still uses Node
 18 or Node 20. Node.js 22.13.0 is the minimum; Node.js 24 is recommended.
 
 Production packages are published only from merged `main` through the GitHub
-release workflow.
+release workflow. That workflow now validates and publishes one checksum-bound
+tarball containing the documented verdict schemas.

--- a/docs/releases/v3.14.1.md
+++ b/docs/releases/v3.14.1.md
@@ -1,6 +1,6 @@
 # v3.14.1 Release Notes
 
-**Release Date:** 2026-09-06
+**Release Date:** 2026-09-07
 
 ## Highlights
 

--- a/docs/releases/v3.14.1.md
+++ b/docs/releases/v3.14.1.md
@@ -1,0 +1,61 @@
+# v3.14.1 Release Notes
+
+**Release Date:** 2026-09-06
+
+## Highlights
+
+Agentic QE 3.14.1 moves the supported runtime floor to Node.js 22.13 and makes
+Node.js 24 the recommended default. It also makes verification, recovery, and
+learning failures visible through bounded, typed evidence instead of silent or
+ambiguous success.
+
+## Runtime support
+
+- AQE now requires Node.js 22.13.0 or newer. Development containers and primary
+  CI use Node.js 24, while a dedicated lane verifies the exact Node 22 floor.
+- GitHub workflows no longer rely on Node 18 or Node 20 action runtimes.
+- Embedded graph, Ruvocal, and Goal UI dependency locks were refreshed for
+  clean installation on the supported runtimes.
+
+## Verification and reliability
+
+- A versioned runtime-fault benchmark measures clean-run recognition, fault
+  classification, localization, abstention, and uncertainty without exposing
+  held-out truth in detector inputs.
+- Quality gates can consume revision-bound verification manifests and report
+  which failure modes have direct, partial, stale, or missing evidence.
+- Judge measurements carry sanitized receipts. Credential-shaped identifiers,
+  malformed hashes, impossible timestamps, invalid decoding settings, and
+  unsupported trust claims are rejected or demoted to `UNKNOWN`.
+- Early-exit presets run in shadow mode by default, recording predictions and
+  full-run outcomes before enforced skipping is enabled explicitly.
+
+## Recovery and learning integrity
+
+- Legacy JSONL session recovery is bounded and fail-closed across path escape,
+  symlink and inode substitution, malformed records, invalid UTF-8, broken
+  lineage, oversized data, and torn tails. Legacy recovery still requires an
+  explicit opt-in and is labeled unverified.
+- Pattern writes distinguish `FAILED` from `COMMITTED_PENDING_INDEX`. A
+  committed SQLite row remains observable when HNSW or RVF indexing is delayed,
+  while uncommitted and orphan-vector paths fail before reporting success.
+- The first structural-transfer qualification corpus adds 100 frozen queries,
+  hard distractors, deterministic bootstrap metrics, and immutable retrieval
+  receipts.
+
+## Initialization and browser checks
+
+- Fixes reported by @pacphi remove package-manager execution from generated
+  lifecycle-hook hot paths, add compact and disabled Codex guidance modes, and
+  prevent Vibium detection from triggering duplicate installation.
+- qe-browser CI uses deterministic loopback fixtures and recognizes both legacy
+  and current Vibium screenshot paths. The remaining Vibium library migration
+  continues under issue #561.
+
+## Upgrade notes
+
+Upgrade the runtime before installing this release if the host still uses Node
+18 or Node 20. Node.js 22.13.0 is the minimum; Node.js 24 is recommended.
+
+Production packages are published only from merged `main` through the GitHub
+release workflow.

--- a/docs/releases/v3.14.1.md
+++ b/docs/releases/v3.14.1.md
@@ -29,6 +29,9 @@ ambiguous success.
   unsupported trust claims are rejected or demoted to `UNKNOWN`.
 - Early-exit presets run in shadow mode by default, recording predictions and
   full-run outcomes before enforced skipping is enabled explicitly.
+- Rust projects no longer fall through to a JavaScript coverage runner when
+  `cargo-llvm-cov` is unavailable; AQE returns the documented, clearly labeled
+  static estimate instead.
 
 ## Recovery and learning integrity
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentic-qe",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentic-qe",
-      "version": "3.14.0",
+      "version": "3.14.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-qe",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "description": "Agentic Quality Engineering V3 - Domain-Driven Design Architecture with 13 Bounded Contexts, O(log n) coverage analysis, ReasoningBank learning, 60 specialized QE agents, mathematical Coherence verification, deep Claude Flow integration",
   "type": "module",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -294,6 +294,7 @@
     "dist/**/*.json",
     "dist/**/*.node",
     "assets/**",
+    "schemas/**",
     "scripts/postinstall.cjs",
     "scripts/preinstall.cjs",
     "scripts/fetch-content.cjs",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -12,6 +12,7 @@
  */
 
 import { toErrorMessage } from '../shared/error-utils.js';
+import { createRequire } from 'node:module';
 import { Command } from 'commander';
 import chalk from 'chalk';
 import type { QEKernel } from '../kernel/interfaces.js';
@@ -257,7 +258,9 @@ async function cleanupAndExit(code: number = 0): Promise<never> {
 
 const program = new Command();
 
-const VERSION = typeof __CLI_VERSION__ !== 'undefined' ? __CLI_VERSION__ : '0.0.0-dev';
+const require = createRequire(import.meta.url);
+const packageVersion = (require('../../package.json') as { version: string }).version;
+const VERSION = typeof __CLI_VERSION__ !== 'undefined' ? __CLI_VERSION__ : packageVersion;
 
 program
   .name('aqe')

--- a/src/coordination/handlers/coverage-handlers.ts
+++ b/src/coordination/handlers/coverage-handlers.ts
@@ -140,9 +140,17 @@ async function collectCoverage(
   }
 
   // #569 work item 1: delegate to real instrumentation where available.
-  if (isRustProject(targetPath)) {
+  const rustProject = isRustProject(targetPath);
+  if (rustProject) {
     const rust = await collectRustCoverage(targetPath);
     if (rust) return { collected: rust, ranTests: true };
+
+    // This target is a Rust crate. Do not continue into the JS/TS runner:
+    // `npx vitest --coverage` can still be available through the parent
+    // process PATH and will write an empty report even though the crate has no
+    // JavaScript tests. Treating that artifact as coverage hides the intended
+    // Rust static-estimation fallback and mislabels the result.
+    return { collected: buildEstimatedCoverage(targetPath), ranTests: false };
   }
 
   const ranTests = await tryRunJsCoverage(targetPath);

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,7 @@ export {
   diagnoseRetrieval,
   createRetrievalReceipt,
   STRUCTURAL_RETRIEVAL_TRANSFORMATIONS,
+  PatternMutationError,
 } from './learning';
 export type {
   QEPattern,
@@ -111,6 +112,7 @@ export type {
   StructuralRetrievalReport,
   RetrievalReceipt,
   CreateRetrievalReceiptInput,
+  PatternMutationDisposition,
 } from './learning';
 
 // Feedback Module - Quality Feedback Loop (ADR-023)

--- a/tests/integration/package-exports-esm.integration.test.ts
+++ b/tests/integration/package-exports-esm.integration.test.ts
@@ -48,6 +48,32 @@ describe('packed package native ESM contracts', () => {
     expectNativeImport('./dist/integrations/ruvector/index.js', 'RuVector barrel');
   });
 
+  it('exposes pattern mutation outcomes from the package root', () => {
+    const packageEntry = packageJson.exports['.']?.import;
+    expect(packageEntry).toBeDefined();
+    const url = pathToFileURL(path.resolve(installedRoot, packageEntry!)).href;
+    const result = spawnSync(
+      process.execPath,
+      [
+        '--input-type=module',
+        '--eval',
+        `const m = await import(${JSON.stringify(url)}); if (typeof m.PatternMutationError !== 'function') process.exit(1);`,
+      ],
+      { cwd: installedRoot, encoding: 'utf8', timeout: 30_000 },
+    );
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+  });
+
+  it('includes the published verdict schemas', () => {
+    for (const schema of [
+      'coverage-gap.schema.json',
+      'finding-verdict.schema.json',
+      'risk-decision.schema.json',
+    ]) {
+      expect(fs.existsSync(path.join(installedRoot, 'schemas', schema)), schema).toBe(true);
+    }
+  });
+
   it('should_importCoordinatorGNN_when_loadedByNativeNodeESM', () => {
     expectNativeImport(
       './dist/domains/code-intelligence/coordinator-gnn.js',

--- a/tests/integration/package-exports-esm.integration.test.ts
+++ b/tests/integration/package-exports-esm.integration.test.ts
@@ -9,6 +9,7 @@ describe('packed package native ESM contracts', () => {
   const tempRoot = path.join(packageRoot, 'node_modules', '.cache', `aqe-pack-esm-${process.pid}`);
   const installedRoot = path.join(tempRoot, 'node_modules', 'agentic-qe');
   let packageJson: {
+    version: string;
     exports: Record<string, { import?: string }>;
     bin?: Record<string, string>;
   };
@@ -46,6 +47,19 @@ describe('packed package native ESM contracts', () => {
 
   it('should_importRuVectorBarrel_when_loadedByNativeNodeESM', () => {
     expectNativeImport('./dist/integrations/ruvector/index.js', 'RuVector barrel');
+  });
+
+  it('reports the package version from the public CLI export', () => {
+    const cliEntry = packageJson.exports['./cli']?.import;
+    expect(cliEntry).toBeDefined();
+    const url = pathToFileURL(path.resolve(installedRoot, cliEntry!)).href;
+    const result = spawnSync(
+      process.execPath,
+      ['--input-type=module', '--eval', `await import(${JSON.stringify(url)});`, '--', '--version'],
+      { cwd: installedRoot, encoding: 'utf8', timeout: 30_000 },
+    );
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+    expect(result.stdout.trim()).toBe(packageJson.version);
   });
 
   it('exposes pattern mutation outcomes from the package root', () => {

--- a/tests/unit/coordination/handlers/coverage-collection.test.ts
+++ b/tests/unit/coordination/handlers/coverage-collection.test.ts
@@ -388,6 +388,29 @@ describe('#569 — analyze-coverage handler output', () => {
     expect(String(data.warning)).toMatch(/cargo-llvm-cov/);
   }, 120000);
 
+  it('does not run a JavaScript coverage tool for a Rust crate', async () => {
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aqe-569-js-bin-'));
+    const marker = path.join(binDir, 'npx-was-invoked');
+    const originalPath = process.env.PATH;
+
+    try {
+      fs.writeFileSync(
+        path.join(binDir, 'npx'),
+        `#!/bin/sh\necho invoked >> ${JSON.stringify(marker)}\nexit 1\n`
+      );
+      fs.chmodSync(path.join(binDir, 'npx'), 0o755);
+      process.env.PATH = `${binDir}:${originalPath}`;
+
+      const data = await analyze();
+
+      expect(data.coverageMethod).toBe('static-estimation');
+      expect(fs.existsSync(marker), 'npx was invoked for a Rust target').toBe(false);
+    } finally {
+      process.env.PATH = originalPath;
+      fs.rmSync(binDir, { recursive: true, force: true });
+    }
+  }, 120000);
+
   it('marks every emitted gap as estimated with low confidence', async () => {
     const data = await analyze();
     const gaps = data.gaps as Array<Record<string, unknown>>;

--- a/tests/unit/scripts/node-support-policy.test.ts
+++ b/tests/unit/scripts/node-support-policy.test.ts
@@ -30,6 +30,26 @@ describe('Node support policy', () => {
     expect(lock.packages?.['']?.engines?.node).toBe('>=22.13.0');
   });
 
+  it('uses the same floor for the Claude Code plugin', () => {
+    const manifest = JSON.parse(read('.claude-plugin/plugin.json')) as {
+      engines?: { node?: string };
+    };
+
+    expect(manifest.engines?.node).toBe('>=22.13.0');
+  });
+
+  it('enforces the exact floor in the shipped environment validator', () => {
+    const validator = read('.claude/helpers/validate-v3-config.sh');
+
+    expect(validator).toContain('[ "$node_major" -gt 22 ]');
+    expect(validator).toContain('[ "$node_major" -eq 22 ] && [ "$node_minor" -ge 13 ]');
+    expect(validator).toContain('Required: ≥22.13.0');
+  });
+
+  it('documents the exact floor in the shipped lifecycle hook', () => {
+    expect(read('.claude/hooks/aqe-hook.cjs')).toContain('CLI is Node >= 22.13');
+  });
+
   it('uses Node 24 for the production container', () => {
     expect(read('Dockerfile').match(/^FROM node:([^\s]+)/gm)).toEqual([
       'FROM node:24-alpine',

--- a/tests/unit/scripts/npm-publish-policy.test.ts
+++ b/tests/unit/scripts/npm-publish-policy.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const workflow = readFileSync(
+  resolve(import.meta.dirname, '../../../.github/workflows/npm-publish.yml'),
+  'utf8',
+);
+
+describe('npm publish workflow policy', () => {
+  it('keeps manual workflow dispatch dry-run only', () => {
+    expect(workflow).toContain("if: github.event_name == 'workflow_dispatch'");
+    expect(workflow).toContain("if: github.event_name == 'release'");
+    expect(workflow).not.toContain('github.event.inputs.dry_run');
+  });
+
+  it('passes the absolute sealed artifact directly to consumer install', () => {
+    expect(workflow).toContain(
+      'npm install --no-audit --no-fund "${{ steps.pack.outputs.tarball }}"',
+    );
+    expect(workflow).not.toContain(
+      '"${GITHUB_WORKSPACE}/${{ steps.pack.outputs.tarball }}"',
+    );
+  });
+
+  it('binds release publication to current merged main', () => {
+    expect(workflow).toContain('git fetch origin main --no-tags --depth=1');
+    expect(workflow).toContain('if [ "$TAG_SHA" != "$MAIN_SHA" ]; then');
+  });
+});


### PR DESCRIPTION
## Summary

Release Agentic QE 3.14.1 with Node.js 22.13 as the minimum runtime and Node.js 24 as the recommended default. The release combines the merged runtime-diagnosis, verification-reach, structural-retrieval, early-exit calibration, dependency, session-recovery, pattern-mutation, and judge-receipt changes, plus the Rust coverage fallback fix.

The npm workflow now synchronizes publish assets before sealing one checksum-bound tarball. Initialization, consumer audit, and publication all consume those exact bytes; manual dispatch is dry-run only, while production publication requires a GitHub release whose tag equals current merged `main`.

Includes the completed #569 fix. Issues #658, #659, and #660 remain open because this release implements only their documented first slices.

## Verification

- `npm run test:ci`: 974 files passed, 6 skipped; 23,503 tests passed, 57 skipped.
- `npm run test:regression`: fast 8,647 passed; heavy 7,177 passed; MCP 1,371 passed, with documented skips only.
- `npm run typecheck`, `npm run build`, `npm run verify:invariants`, `npm run verify:skill-parity`, `npm run verify:conservation`, `npm run sync:agents:check`, `npm run verify:counts`, and `npm run skills:validate-tier3`: passed.
- `npm run test:integration:fast`: 30/30 passed.
- `npm run performance:gate`: 15/15 passed.
- `npm audit --audit-level=high --omit=dev`: 0 vulnerabilities.
- Packed-package export/policy tests: 23/23 passed across the focused suites.
- Sealed artifact SHA-256: `1066460058a312594e6d187a484b303162727a979b526f148ddb4050f05d121f`.
- Clean artifact installs on Node 22.13.0 and Node 24.15.0 passed package import, `PatternMutationError`, public CLI and installed CLI version 3.14.1, schema presence, production audit, and MCP startup/shutdown.
- Init corpus against the sealed artifact: 4 passed, 0 failed, 0 skipped; second-init and daemon-liveness checks passed.

Repository-wide `npm run lint` still reports the existing baseline of 379 errors and 63 warnings; every changed TypeScript file passes focused ESLint. The legacy filename-based `verify:agent-skills` heuristic still reports 49 unmatched agents; invariant, parity, count, sync, and Tier-3 checks all pass.

## Failure modes

- A publish-time asset mutation is blocked by `prepublishOnly` followed by `git diff --exit-code`, and the sealed artifact checksum is revalidated in every consuming job.
- Manual workflow dispatch cannot publish; only a release event can reach the provenance-enabled publish step.
- A tag that differs from current merged `main` is rejected before publication.
- Node 20 is rejected by package, plugin, helper, hook, CI, and policy-test surfaces; Node 22.13 and 24 are exercised directly.
- Browser and PostgreSQL service-backed suites were not run because this release does not change those integrations; their external-service coverage remains outside this release gate.

---

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.** "Unlikely" is not an acceptable substitute.

### Optional context

- Linked issues: #569, #649, #651, #653, #654, #655, #656, #657, #658, #659, #660
- Trust tier change (if any): none
- Affects published API or CLI surface: yes
- Touches the init flow / `npm-publish.yml` / `tests/fixtures/init-corpus/`: yes
  - If yes: did you run `./tests/fixtures/init-corpus/run-gate.sh` locally? yes, against the sealed tarball (4/4 passed)
