### PR TITLE
fix(cli): keep quality daemon running in foreground

### DIFF
--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -15,6 +15,7 @@ import { QualityDaemon, type QualityDaemonConfig } from '../../workers/quality-d
 import { PersistentWorkerMemory } from '../../workers/quality-daemon/persistent-memory';
 import { isPrivateIp } from '../../hooks/security/ssrf-guard';
 import type { WorkerMemory } from '../../workers/interfaces';
+import { activateForegroundCommand } from '../foreground-command';
 
 // In-process daemon instance (non-detached mode)
 let activeDaemon: QualityDaemon | undefined;
@@ -101,12 +102,14 @@ Examples:
           clearInterval(keepAlive);
         }
       }, 5000);
+      const releaseForeground = activateForegroundCommand();
 
       // Graceful shutdown
       const shutdown = async () => {
         console.log(chalk.yellow('\nStopping QE Quality Daemon...'));
         await activeDaemon?.stop();
         clearInterval(keepAlive);
+        releaseForeground();
         console.log(chalk.green('Daemon stopped'));
         process.exit(0);
       };

--- a/src/cli/foreground-command.ts
+++ b/src/cli/foreground-command.ts
@@ -1,0 +1,23 @@
+/**
+ * Tracks CLI commands that intentionally own the foreground process lifetime.
+ *
+ * Most AQE commands must be force-cleaned after Commander dispatch completes
+ * because native handles can keep Node alive. A foreground command is the
+ * inverse: the CLI must not force-exit merely because dispatch has completed.
+ */
+let foregroundCommandActive = false;
+
+export function activateForegroundCommand(): () => void {
+  foregroundCommandActive = true;
+
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    foregroundCommandActive = false;
+  };
+}
+
+export function isForegroundCommandActive(): boolean {
+  return foregroundCommandActive;
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -272,6 +272,7 @@ program
 // ============================================================================
 
 import { registerLazyCommand, registerLazyHandler } from './lazy-registry.js';
+import { isForegroundCommandActive } from './foreground-command.js';
 
 registerLazyHandler(program, 'init', 'Initialize the AQE v3 system',
   () => import('./handlers/init-handler.js').then(m => m.createInitHandler(cleanupAndExit)),
@@ -503,6 +504,9 @@ async function main(): Promise<void> {
   });
 
   await program.parseAsync();
+
+  // Foreground commands own their process lifetime after command dispatch.
+  if (isForegroundCommandActive()) return;
 
   // If the command didn't explicitly exit, clean up and exit now.
   // This prevents process hangs from active handles (domain init, embeddings, etc.)

--- a/tests/integration/cli/daemon-command.test.ts
+++ b/tests/integration/cli/daemon-command.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Integration regression for #678: `aqe daemon start` must remain in the
+ * foreground after Commander finishes dispatching the start action.
+ *
+ * This drives the built CLI because the defect sits at the boundary between
+ * command dispatch and the top-level process cleanup path.
+ */
+import { spawn, type ChildProcess } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = join(__dirname, '..', '..', '..');
+const CLI_BUNDLE = join(ROOT, 'dist', 'cli', 'bundle.js');
+const BUILT = existsSync(CLI_BUNDLE);
+const SKIP = !BUILT && !process.env.CI;
+
+function waitForStartupOrExit(child: ChildProcess): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let output = '';
+    const timeout = setTimeout(() => {
+      reject(new Error(`Timed out waiting for daemon startup. Output:\n${output}`));
+    }, 15_000);
+
+    const finish = () => {
+      clearTimeout(timeout);
+      resolve();
+    };
+
+    child.stdout?.on('data', (chunk: Buffer) => {
+      output += chunk.toString();
+      if (output.includes('QE Quality Daemon started')) finish();
+    });
+    child.stderr?.on('data', (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+    child.once('exit', finish);
+    child.once('error', (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+  });
+}
+
+function stopChild(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve();
+
+  return new Promise((resolve) => {
+    const forceKill = setTimeout(() => child.kill('SIGKILL'), 5_000);
+    // `close` fires after the stdio streams flush; `exit` can precede the
+    // daemon's final shutdown message reaching this process.
+    child.once('close', () => {
+      clearTimeout(forceKill);
+      resolve();
+    });
+    child.kill('SIGTERM');
+  });
+}
+
+describe.skipIf(SKIP)('#678 — foreground quality daemon lifetime', () => {
+  it('should_remainAlive_when_startCommandReportsSuccess', async () => {
+    // Arrange
+    const projectRoot = mkdtempSync(join(tmpdir(), 'aqe-daemon-678-'));
+    const child = spawn(
+      process.execPath,
+      [CLI_BUNDLE, 'daemon', 'start', '--tick-interval', '100', '--ci-interval', '200'],
+      {
+        cwd: ROOT,
+        env: {
+          ...process.env,
+          AQE_PROJECT_ROOT: projectRoot,
+          AQE_MEMORY_PATH: join(projectRoot, '.agentic-qe'),
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
+
+    try {
+      // Act
+      await waitForStartupOrExit(child);
+      await new Promise((resolve) => setTimeout(resolve, 250));
+
+      // Assert
+      expect(child.exitCode).toBeNull();
+    } finally {
+      await stopChild(child);
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  }, 25_000);
+});


### PR DESCRIPTION
## Summary

Keep `aqe daemon start` alive after Commander dispatch completes by marking it as a foreground-lifetime command. Add a built-CLI regression test that verifies the daemon remains alive after reporting successful startup.

Fixes #678.

## Verification

- `npm run typecheck` — passed
- `npm run build:cli` — passed
- Focused daemon CLI tests — 18 passed
- `npm run test:unit:fast` — 364 files passed, 1 skipped; 8,647 tests passed, 6 skipped
- Built CLI smoke check under a two-second timeout — exited 124, confirming the daemon remained active

All daemon test databases used temporary paths; `.agentic-qe/memory.db` was not modified.

## Failure modes

- Mitigates immediate successful exit after daemon startup; covered by the new built-CLI regression.
- Preserves existing post-command cleanup for non-foreground commands; covered by the existing fast unit suite.
- Preserves graceful `SIGTERM` shutdown; exercised by regression-test cleanup.

---

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.** "Unlikely" is not an acceptable substitute.

### Optional context

- Linked issues: #678
- Trust tier change (if any): none
- Affects published API or CLI surface: yes, CLI lifecycle bug fix
- Touches the init flow / `npm-publish.yml` / `tests/fixtures/init-corpus/`: no