### PR TITLE
feat(mcp): publish conservative tool safety annotations

### DIFF
--- a/docs/MCP-TOOL-SAFETY.md
+++ b/docs/MCP-TOOL-SAFETY.md
@@ -1,0 +1,18 @@
+# MCP tool safety annotations
+
+AQE includes the MCP `ToolAnnotations` hints in both the QE tool registry and
+the protocol server's `tools/list` response. The supported hints are
+`readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint`.
+
+The built-in inventory only marks a tool read-only when that disposition is
+clear. Unclassified tools receive conservative defaults: potentially
+destructive, non-idempotent, and open-world. Explicit tool metadata can refine
+those values for names in the reviewed inventory when the implementation has
+stronger guarantees. Unknown, dynamic, and plugin-supplied names cannot
+self-assert optimistic hints; they retain the conservative disposition until
+added to the reviewed inventory.
+
+These annotations are advisory metadata for client UX and confirmation
+decisions. They never grant access or change execution behavior. Every call
+continues to require the existing authorization, sandbox, input-validation, and
+policy checks; clients must not use a hint to bypass any of those controls.

--- a/scripts/smoke-mcp-protocol.mjs
+++ b/scripts/smoke-mcp-protocol.mjs
@@ -264,10 +264,23 @@ async function main() {
       `tool "${tool && tool.name}" inputSchema must be an object`,
       tool && tool.inputSchema,
     );
+    assert(
+      tool.annotations && typeof tool.annotations === 'object' && !Array.isArray(tool.annotations),
+      `tool "${tool && tool.name}" annotations must be an object`,
+      tool && tool.annotations,
+    );
+    assert(
+      tool.annotations.readOnlyHint === false &&
+        tool.annotations.destructiveHint === true &&
+        tool.annotations.idempotentHint === false &&
+        tool.annotations.openWorldHint === true,
+      `tool "${tool && tool.name}" must retain the reviewed conservative annotation disposition`,
+      tool && tool.annotations,
+    );
   }
 
   const toolCount = listResult.tools.length;
-  console.error(`[smoke]    OK tools/list: ${toolCount} tools, each with name + object inputSchema`);
+  console.error(`[smoke]    OK tools/list: ${toolCount} tools with schemas + conservative safety annotations`);
 
   // -- Summary -----------------------------------------------------------------
   console.error('\n========================================');

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -5,6 +5,15 @@
 
 // Types
 export * from './types';
+export {
+  CONSERVATIVE_TOOL_ANNOTATIONS,
+  BUILT_IN_TOOL_NAMES,
+  BUILT_IN_TOOL_SAFETY_INVENTORY,
+  getBuiltInToolAnnotations,
+  getBuiltInToolSafetyInventory,
+  resolveToolAnnotations,
+  type ResolvedToolAnnotations,
+} from './tool-annotations';
 
 // Tool Registry (O(1) hash-indexed lookup via Map)
 export { ToolRegistry, createToolRegistry } from './tool-registry';

--- a/src/mcp/protocol-server.ts
+++ b/src/mcp/protocol-server.ts
@@ -16,6 +16,7 @@ import {
 } from './transport';
 import { ToolRegistry, createToolRegistry } from './tool-registry';
 import { ToolDefinition } from './types';
+import { resolveToolAnnotations } from './tool-annotations';
 import { MiddlewareChain, type ToolCallContext, type ToolMiddleware } from './middleware/middleware-chain';
 import { createMicrocompactMiddleware } from './middleware/microcompact';
 import { SessionStore } from './services/session-store';
@@ -554,10 +555,11 @@ export class MCPProtocolServer {
     return {};
   }
 
-  private handleToolsList(): { tools: Array<{ name: string; description: string; inputSchema: unknown }> } {
+  private handleToolsList(): { tools: Array<{ name: string; description: string; annotations: ToolDefinition['annotations']; inputSchema: unknown }> } {
     const tools = Array.from(this.tools.values()).map((entry) => ({
       name: entry.definition.name,
       description: entry.definition.description,
+      annotations: entry.definition.annotations,
       inputSchema: this.buildInputSchema(entry.definition),
     }));
 
@@ -1715,8 +1717,15 @@ export class MCPProtocolServer {
   }
 
   private registerTool(entry: ToolEntry): void {
-    this.tools.set(entry.definition.name, entry);
-    this.registry.register(entry.definition, entry.handler as Parameters<typeof this.registry.register>[1]);
+    const normalizedEntry: ToolEntry = {
+      ...entry,
+      definition: {
+        ...entry.definition,
+        annotations: resolveToolAnnotations(entry.definition.name, entry.definition.annotations),
+      },
+    };
+    this.tools.set(normalizedEntry.definition.name, normalizedEntry);
+    this.registry.register(normalizedEntry.definition, normalizedEntry.handler as Parameters<typeof this.registry.register>[1]);
   }
 
   private buildInputSchema(definition: ToolDefinition): {

--- a/src/mcp/qe-tool-bridge.ts
+++ b/src/mcp/qe-tool-bridge.ts
@@ -97,6 +97,7 @@ export function registerMissingQETools(
         name: tool.name,
         description: tool.description,
         category: 'domain',
+        annotations: tool.annotations,
         parameters: schemaToParameters(tool),
       },
       handler: async (params) => {

--- a/src/mcp/tool-annotations.ts
+++ b/src/mcp/tool-annotations.ts
@@ -1,0 +1,103 @@
+/**
+ * MCP tool safety annotations and the built-in safety inventory.
+ *
+ * The inventory is deliberately conservative. A tool is marked read-only
+ * only when its registered operation is an observation/query with no write or
+ * execution path. Every other built-in receives the MCP-safe fallback: it may
+ * be destructive, is not assumed idempotent, and may interact with the world.
+ * These values guide clients but never replace authorization, sandbox, or
+ * policy enforcement.
+ */
+
+import type { ToolAnnotations } from './types';
+
+export type ResolvedToolAnnotations = Required<
+  Pick<ToolAnnotations, 'readOnlyHint' | 'destructiveHint' | 'idempotentHint' | 'openWorldHint'>
+> & Pick<ToolAnnotations, 'title'>;
+
+export interface BuiltInToolSafetyDisposition {
+  annotations: ResolvedToolAnnotations;
+  reason: string;
+}
+
+export const CONSERVATIVE_TOOL_ANNOTATIONS: ResolvedToolAnnotations = Object.freeze({
+  readOnlyHint: false,
+  destructiveHint: true,
+  idempotentHint: false,
+  openWorldHint: true,
+});
+
+const HARD_CODED_TOOL_NAMES = [
+  'accessibility_test', 'advisor_consult', 'agent_complete', 'agent_list',
+  'agent_metrics', 'agent_spawn', 'agent_status', 'aqe_health', 'chaos_test',
+  'code_index', 'contract_validate', 'coverage_analyze_sublinear',
+  'cross_phase_cleanup', 'cross_phase_query', 'cross_phase_stats',
+  'cross_phase_store', 'defect_predict', 'fleet_health', 'fleet_init',
+  'fleet_status', 'format_signals', 'infra_healing_feed_output',
+  'infra_healing_recover', 'infra_healing_status', 'memory_delete',
+  'memory_query', 'memory_retrieve', 'memory_share', 'memory_store',
+  'memory_usage', 'migration_check', 'migration_promote', 'migration_status',
+  'model_route', 'phase_end', 'phase_start', 'pipeline_list', 'pipeline_load',
+  'pipeline_run', 'pipeline_validate', 'quality_assess',
+  'requirements_validate', 'routing_economics', 'routing_metrics',
+  'security_scan_comprehensive', 'session_cache_stats', 'task_cancel',
+  'task_list', 'task_orchestrate', 'task_status', 'task_submit',
+  'team_broadcast', 'team_health', 'team_list', 'team_message', 'team_rebalance',
+  'team_scale', 'test_execute_parallel', 'test_generate_enhanced',
+  'validation_pipeline',
+] as const;
+
+// QE tools not duplicated by the hard-coded protocol registrations.
+const BRIDGED_TOOL_NAMES = [
+  'qe/analysis/token_usage', 'qe/code/c4',
+  'qe/coherence/audit', 'qe/coherence/check', 'qe/coherence/collapse',
+  'qe/coherence/consensus', 'qe/coverage/gaps',
+  'qe/embeddings/compare', 'qe/embeddings/generate', 'qe/embeddings/search',
+  'qe/embeddings/stats', 'qe/embeddings/store',
+  'qe/learning/dream', 'qe/learning/optimize',
+  'qe/mincut/health', 'qe/mincut/analyze', 'qe/mincut/strengthen',
+  'qe/planning/goap_execute', 'qe/planning/goap_plan', 'qe/planning/goap_status',
+  'qe/quality/gate', 'qe/qx/analyze', 'qe/requirements/quality-criteria',
+  'qe/security/url-validate', 'qe/tests/load', 'qe/tests/schedule',
+  'qe/visual/compare', 'qe/workflows/browser-load',
+] as const;
+
+/** Complete deterministic inventory of names advertised by both MCP paths. */
+export const BUILT_IN_TOOL_NAMES: readonly string[] = Object.freeze(
+  [...HARD_CODED_TOOL_NAMES, ...BRIDGED_TOOL_NAMES].sort()
+);
+
+function conservativeDisposition(): BuiltInToolSafetyDisposition {
+  return {
+    annotations: CONSERVATIVE_TOOL_ANNOTATIONS,
+    reason: 'No narrow side-effect-free guarantee is recorded for this built-in; retain conservative policy defaults.',
+  };
+}
+
+export const BUILT_IN_TOOL_SAFETY_INVENTORY: Readonly<Record<string, BuiltInToolSafetyDisposition>> = Object.freeze(
+  Object.fromEntries(BUILT_IN_TOOL_NAMES.map((name) => [name, conservativeDisposition()]))
+);
+
+/** Resolve explicit metadata over inventory metadata over conservative defaults. */
+export function resolveToolAnnotations(
+  name: string,
+  annotations?: ToolAnnotations
+): ResolvedToolAnnotations {
+  const reviewedDisposition = BUILT_IN_TOOL_SAFETY_INVENTORY[name];
+  return Object.freeze({
+    ...(reviewedDisposition?.annotations ?? CONSERVATIVE_TOOL_ANNOTATIONS),
+    // Dynamic and plugin-supplied names cannot self-assert optimistic hints.
+    // Add the name to the reviewed inventory before accepting overrides.
+    ...(reviewedDisposition ? annotations : undefined),
+  });
+}
+
+export function getBuiltInToolAnnotations(): Readonly<Record<string, ToolAnnotations>> {
+  return Object.fromEntries(
+    Object.entries(BUILT_IN_TOOL_SAFETY_INVENTORY).map(([name, disposition]) => [name, disposition.annotations])
+  );
+}
+
+export function getBuiltInToolSafetyInventory(): Readonly<Record<string, BuiltInToolSafetyDisposition>> {
+  return BUILT_IN_TOOL_SAFETY_INVENTORY;
+}

--- a/src/mcp/tool-registry.ts
+++ b/src/mcp/tool-registry.ts
@@ -15,6 +15,7 @@ import {
   ToolResultMetadata,
   ToolParameter,
 } from './types';
+import { resolveToolAnnotations } from './tool-annotations';
 import { sanitizeInput } from './security/cve-prevention';
 import { toErrorMessage } from '../shared/error-utils.js';
 import { BatchToolExecutor, type BatchToolCall } from './middleware/batch-executor';
@@ -292,37 +293,41 @@ export class ToolRegistry {
    * Register a tool
    */
   register(definition: ToolDefinition, handler: ToolHandler): void {
-    const existing = this.tools.get(definition.name);
+    const normalizedDefinition: ToolDefinition = {
+      ...definition,
+      annotations: resolveToolAnnotations(definition.name, definition.annotations),
+    };
+    const existing = this.tools.get(normalizedDefinition.name);
     if (existing) {
       // Update existing tool
-      existing.definition = definition;
+      existing.definition = normalizedDefinition;
       existing.handler = handler;
       return;
     }
 
     // Register new tool
     const tool: RegisteredTool = {
-      definition,
+      definition: normalizedDefinition,
       handler,
-      loaded: !definition.lazyLoad,
+      loaded: !normalizedDefinition.lazyLoad,
       loadCount: 0,
     };
 
-    this.tools.set(definition.name, tool);
+    this.tools.set(normalizedDefinition.name, tool);
     this.stats.totalTools++;
 
     // Track by category
-    this.categoryTools.get(definition.category)?.add(definition.name);
-    this.stats.byCategory[definition.category]++;
+    this.categoryTools.get(normalizedDefinition.category)?.add(normalizedDefinition.name);
+    this.stats.byCategory[normalizedDefinition.category]++;
 
     // Track by domain if specified
-    if (definition.domain) {
-      this.domainTools.get(definition.domain)?.add(definition.name);
-      this.stats.byDomain[definition.domain] =
-        (this.stats.byDomain[definition.domain] || 0) + 1;
+    if (normalizedDefinition.domain) {
+      this.domainTools.get(normalizedDefinition.domain)?.add(normalizedDefinition.name);
+      this.stats.byDomain[normalizedDefinition.domain] =
+        (this.stats.byDomain[normalizedDefinition.domain] || 0) + 1;
     }
 
-    if (!definition.lazyLoad) {
+    if (!normalizedDefinition.lazyLoad) {
       this.stats.loadedTools++;
     }
   }

--- a/src/mcp/tools/base.ts
+++ b/src/mcp/tools/base.ts
@@ -7,7 +7,8 @@
 
 import { v4 as uuidv4 } from 'uuid';
 import { DomainName } from '../../shared/types';
-import { ToolResult, ToolResultMetadata } from '../types';
+import { ToolAnnotations, ToolResult, ToolResultMetadata } from '../types';
+import { resolveToolAnnotations } from '../tool-annotations';
 import { MemoryBackend } from '../../kernel/interfaces';
 import { HybridMemoryBackend } from '../../kernel/hybrid-backend';
 import { InMemoryBackend } from '../../kernel/memory-backend.js';
@@ -304,6 +305,7 @@ export interface MCPToolConfig {
   schema: MCPToolSchema;
   streaming?: boolean;
   timeout?: number;
+  annotations?: ToolAnnotations;
 }
 
 /**
@@ -670,6 +672,14 @@ export abstract class MCPToolBase<
    */
   get description(): string {
     return this.config.description;
+  }
+
+  /**
+   * Return the complete, conservative safety metadata for this tool.
+   * Missing hints must never be interpreted as permission to skip policy.
+   */
+  get annotations(): ToolAnnotations {
+    return resolveToolAnnotations(this.name, this.config.annotations);
   }
 
   /**

--- a/src/mcp/tools/registry.ts
+++ b/src/mcp/tools/registry.ts
@@ -7,6 +7,7 @@
 
 import { MCPToolBase } from './base';
 import { ToolRegistry } from '../tool-registry';
+import type { ToolAnnotations } from '../types';
 
 // Import all tools
 import { TestGenerateTool } from './test-generation/generate';
@@ -277,12 +278,14 @@ export function getToolsByDomain(domain: string): MCPToolBase[] {
 export function getToolDefinition(tool: MCPToolBase): {
   name: string;
   description: string;
+  annotations: ToolAnnotations;
   inputSchema: Record<string, unknown>;
 } {
   const schema = tool.getSchema();
   return {
     name: tool.name,
     description: tool.description,
+    annotations: tool.annotations,
     inputSchema: {
       ...schema,
       type: schema.type || 'object',
@@ -296,6 +299,7 @@ export function getToolDefinition(tool: MCPToolBase): {
 export function getAllToolDefinitions(): Array<{
   name: string;
   description: string;
+  annotations: ToolAnnotations;
   inputSchema: Record<string, unknown>;
 }> {
   return QE_TOOLS.map(getToolDefinition);

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -23,6 +23,21 @@ export interface ToolParameter {
 }
 
 /**
+ * Optional safety metadata advertised by an MCP tool.
+ *
+ * These hints help clients make better presentation and confirmation
+ * decisions. They are advisory only: authorization, sandboxing, and policy
+ * checks remain authoritative for every invocation.
+ */
+export interface ToolAnnotations {
+  title?: string;
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
+}
+
+/**
  * MCP tool definition
  */
 export interface ToolDefinition {
@@ -33,6 +48,7 @@ export interface ToolDefinition {
   domain?: DomainName;
   lazyLoad?: boolean;
   isConcurrencySafe?: boolean;
+  annotations?: ToolAnnotations;
 }
 
 /**

--- a/tests/integration/opencode/mcp-opencode.test.ts
+++ b/tests/integration/opencode/mcp-opencode.test.ts
@@ -15,6 +15,7 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { MCPProtocolServer, createMCPProtocolServer } from '../../../src/mcp/protocol-server';
+import { getBuiltInToolSafetyInventory } from '../../../src/mcp/tool-annotations';
 
 describe('AQE MCP Server - OpenCode Compatibility', () => {
   let server: MCPProtocolServer;
@@ -29,16 +30,26 @@ describe('AQE MCP Server - OpenCode Compatibility', () => {
 
   it('should list all registered tools via tool registry', async () => {
     const tools = server.getToolDefinitions();
+    const inventoryNames = Object.keys(getBuiltInToolSafetyInventory()).sort();
+    const registeredNames = tools.map((tool) => tool.name).sort();
 
     // The AQE MCP server registers tools across multiple categories.
     // Total varies as features are added. Verify a reasonable minimum.
     expect(tools.length).toBeGreaterThanOrEqual(30);
+    expect(registeredNames).toEqual(inventoryNames);
 
     // Every tool must have a name
     for (const tool of tools) {
       expect(tool.name).toBeDefined();
       expect(typeof tool.name).toBe('string');
       expect(tool.name.length).toBeGreaterThan(0);
+      expect(tool.annotations).toEqual(expect.objectContaining({
+        readOnlyHint: expect.any(Boolean),
+        destructiveHint: expect.any(Boolean),
+        idempotentHint: expect.any(Boolean),
+        openWorldHint: expect.any(Boolean),
+      }));
+      expect(getBuiltInToolSafetyInventory()[tool.name]).toBeDefined();
     }
   });
 
@@ -67,6 +78,20 @@ describe('AQE MCP Server - OpenCode Compatibility', () => {
         expect(typeof param.description).toBe('string');
       }
     }
+  });
+
+  it('should preserve annotations on the protocol tools/list representation', () => {
+    const response = (server as unknown as {
+      handleToolsList: () => { tools: Array<{ name: string; annotations?: Record<string, boolean> }> };
+    }).handleToolsList();
+    const status = response.tools.find((tool) => tool.name === 'fleet_status');
+
+    expect(status?.annotations).toEqual({
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/tests/unit/mcp/mcp-server.test.ts
+++ b/tests/unit/mcp/mcp-server.test.ts
@@ -9,6 +9,10 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { ToolRegistry, createToolRegistry } from '../../../src/mcp/tool-registry';
+import {
+  CONSERVATIVE_TOOL_ANNOTATIONS,
+  getBuiltInToolSafetyInventory,
+} from '../../../src/mcp/tool-annotations';
 
 describe('Tool Registry', () => {
   let registry: ToolRegistry;
@@ -18,6 +22,19 @@ describe('Tool Registry', () => {
   });
 
   describe('registration', () => {
+    it('should provide a complete conservative inventory for advertised built-ins', () => {
+      const inventory = getBuiltInToolSafetyInventory();
+      const names = Object.keys(inventory);
+
+      expect(names).toHaveLength(88);
+      expect(new Set(names).size).toBe(names.length);
+      expect(names).toEqual([...names].sort());
+      for (const disposition of Object.values(inventory)) {
+        expect(disposition.reason.length).toBeGreaterThan(0);
+        expect(disposition.annotations).toEqual(CONSERVATIVE_TOOL_ANNOTATIONS);
+      }
+    });
+
     it('should register a tool', () => {
       registry.register(
         {
@@ -57,6 +74,52 @@ describe('Tool Registry', () => {
 
       const definitions = registry.getDefinitions();
       expect(definitions.length).toBe(2);
+    });
+
+    it('should preserve reviewed built-in annotations and fail unknown tools conservatively', () => {
+      registry.register(
+        {
+          name: 'fleet_status',
+          description: 'Annotated tool',
+          category: 'core',
+          parameters: [],
+          annotations: {
+            readOnlyHint: true,
+            destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
+          },
+        },
+        async () => ({ success: true })
+      );
+      registry.register(
+        {
+          name: 'unclassified_tool',
+          description: 'Unclassified tool',
+          category: 'core',
+          parameters: [],
+          annotations: {
+            readOnlyHint: true,
+            destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
+          },
+        },
+        async () => ({ success: true })
+      );
+
+      expect(registry.get('fleet_status')?.definition.annotations).toEqual({
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      });
+      expect(registry.get('unclassified_tool')?.definition.annotations).toEqual({
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: true,
+      });
     });
 
     it('should get tools by category', () => {

--- a/tests/unit/mcp/tools/registry.test.ts
+++ b/tests/unit/mcp/tools/registry.test.ts
@@ -204,6 +204,17 @@ describe('QE Tool Registry', () => {
 
       expect(def.inputSchema.required).toBeDefined();
     });
+
+    it('should expose the conservative safety disposition', () => {
+      const def = getToolDefinition(getQETool('qe/analysis/token_usage')!);
+
+      expect(def.annotations).toEqual({
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: true,
+      });
+    });
   });
 
   describe('getAllToolDefinitions', () => {
@@ -230,6 +241,17 @@ describe('QE Tool Registry', () => {
       const uniqueNames = new Set(names);
       // 33 original + 4 new (schedule, load-test, visual-security, browser-workflow) + 1 (qe/code/c4, ADR-112) + 1 (qe/quality/gate, ADR-119) = 39 tools
       expect(uniqueNames.size).toBe(39);
+    });
+
+    it('should annotate every built-in definition', () => {
+      for (const def of getAllToolDefinitions()) {
+        expect(def.annotations).toEqual(expect.objectContaining({
+          readOnlyHint: expect.any(Boolean),
+          destructiveHint: expect.any(Boolean),
+          idempotentHint: expect.any(Boolean),
+          openWorldHint: expect.any(Boolean),
+        }));
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

Add typed MCP safety annotations and preserve them through the QE registry, bridge, protocol registry, and live `tools/list` response. Introduce a deterministic 88-tool reviewed inventory; every current built-in starts with the conservative disposition, and unknown or plugin-supplied names cannot self-assert optimistic hints.

This is the safe first increment for #681. The issue remains open for side-effect and repeat-call evidence before individual tools receive read-only or idempotent classifications.

## Verification

- `npm run typecheck` — passed
- `npx vitest run tests/unit/mcp/mcp-server.test.ts tests/unit/mcp/tools/registry.test.ts tests/integration/opencode/mcp-opencode.test.ts` — 3 files, 59 tests passed
- `node scripts/smoke-mcp-protocol.mjs` — live stdio initialize and tools/list passed; 88 tools exposed schemas and conservative annotations
- Targeted ESLint over changed TypeScript source except the known existing `protocol-server.ts:364` finding — passed
- `git diff --check` — passed

The live smoke used an isolated temporary `AQE_PROJECT_ROOT`; production learning databases were not modified.

## Failure modes

- Unknown or dynamic tools could claim optimistic metadata; covered by conservative-fallback unit tests.
- One listing path could drop annotations; covered by registry, protocol-list, exact-inventory-parity, and live stdio tests.
- Inventory names could drift from advertised tools; covered by exact sorted-set parity.
- Evidence-backed optimistic per-tool classification remains deferred and tracked by #681.

---

### Required check (issue #401)

- [x] **Every failure mode mentioned in this PR description has either (a) a test that exercises it, or (b) a linked tracking issue.** "Unlikely" is not an acceptable substitute.

### Optional context

- Linked issues: #681
- Trust tier change (if any): none
- Affects published API or CLI surface: yes, additive optional MCP response metadata
- Touches the init flow / `npm-publish.yml` / `tests/fixtures/init-corpus/`: no